### PR TITLE
Set Spotbugs Annotations as scope=provided

### DIFF
--- a/oauth-common/pom.xml
+++ b/oauth-common/pom.xml
@@ -34,6 +34,7 @@
         <dependency>
             <groupId>com.github.spotbugs</groupId>
             <artifactId>spotbugs-annotations</artifactId>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
This PR sets the spotbugs-annotations dependency as provided so that it does not get coppied when the library is used.