### PR TITLE
Bump Jackson Databind dependency to 2.9.10 becausee of CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <sonatype.nexus.staging>1.6.3</sonatype.nexus.staging>
 
         <kafka.version>2.3.0</kafka.version>
-        <jackson.version>2.9.9.3</jackson.version>
+        <jackson.version>2.9.10</jackson.version>
         <junit.version>4.12</junit.version>
         <slf4j.version>1.7.26</slf4j.version>
         <keycloak.version>7.0.0</keycloak.version>


### PR DESCRIPTION
JAckoson Databind 2.9.9.3 has some new CVEs. We should bump it to 2.9.10.