### PR TITLE
Make error the message about OAUTH_JWKS_ENDPOINT_URI and OAUTH_INTROSPECTION_ENDPOINT_URI more clear

### DIFF
--- a/oauth-server/src/main/java/io/strimzi/kafka/oauth/server/JaasServerOauthValidatorCallbackHandler.java
+++ b/oauth-server/src/main/java/io/strimzi/kafka/oauth/server/JaasServerOauthValidatorCallbackHandler.java
@@ -109,8 +109,10 @@ public class JaasServerOauthValidatorCallbackHandler implements AuthenticateCall
         String introspectUri = config.getValue(ServerConfig.OAUTH_INTROSPECTION_ENDPOINT_URI);
 
         // if both set or none set
-        if ((jwksUri == null) == (introspectUri == null)) {
-            throw new RuntimeException("OAuth validator configuration error - one of the two should be specified: OAUTH_JWKS_ENDPOINT_URI (for fast local signature validation) or OAUTH_INTROSPECTION_ENDPOINT_URI (for using authorization server during validation)");
+        if ((jwksUri == null) && (introspectUri == null)) {
+            throw new RuntimeException("OAuth validator configuration error: either OAUTH_JWKS_ENDPOINT_URI (for fast local signature validation) or OAUTH_INTROSPECTION_ENDPOINT_URI (for using authorization server during validation) should be specified!");
+        } else if ((jwksUri != null) && (introspectUri != null)) {
+            throw new RuntimeException("OAuth validator configuration error: only one of OAUTH_JWKS_ENDPOINT_URI (for fast local signature validation) and OAUTH_INTROSPECTION_ENDPOINT_URI (for using authorization server during validation) can be specified!");
         }
 
         // check - if truststore set - that uri starts with https://


### PR DESCRIPTION
The error message when both `OAUTH_JWKS_ENDPOINT_URI` and `OAUTH_INTROSPECTION_ENDPOINT_URI` is a bit confusing as seen in strimzi/strimzi-kafka-operator#2111. Spliting it into two separate messages should make the error message more clear.