### PR TITLE
Fix the Travis build to do only 3 builds and not 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ language: java
 jobs:
   include:
   - os: linux
-  - os: linux
     arch: s390x
     exclude:
       jdk: openjdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,7 @@ jobs:
   include:
   - os: linux
     arch: s390x
-    exclude:
-      jdk: openjdk8
+    jdk: openjdk11
     addons:
       apt:
         packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,8 @@ jobs:
   - os: linux
   - os: linux
     arch: s390x
-    jdk: openjdk11
+    exclude:
+      jdk: openjdk8
     addons:
       apt:
         packages:


### PR DESCRIPTION
Following up on #21, this PR does slight change tot he Travis file to do only Java8 and Java 11 builds on amd64 and Java11 on s390x. The previous version for some reasons triggered two Java8 builds on amd64.