### PR TITLE
Make OAuth scope optional

### DIFF
--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/OAuthAuthenticator.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/OAuthAuthenticator.java
@@ -102,7 +102,8 @@ public class OAuthAuthenticator {
             throw new IllegalStateException("Invalid response from authorization server: no expires_in");
         }
 
-        // Some OAuth2 authorization servers don't provide scope in this level
+        // Some OAuth2 authorization servers don't provide scope in this level,
+        // therefore we don't need to make it mandatory
         JsonNode scope = result.get("scope");
 
         if (isJWT) {

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/OAuthAuthenticator.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/OAuthAuthenticator.java
@@ -103,9 +103,6 @@ public class OAuthAuthenticator {
         }
 
         JsonNode scope = result.get("scope");
-        if (scope == null) {
-            throw new IllegalStateException("Invalid response from authorization server: no scope");
-        }
 
         if (isJWT) {
             // try introspect token
@@ -116,7 +113,7 @@ public class OAuthAuthenticator {
             }
         }
 
-        return new TokenInfo(token.asText(), scope.asText(), "undefined", now, now + expiresIn.asLong() * 1000L);
+        return new TokenInfo(token.asText(), scope != null ? scope.asText() : null, "undefined", now, now + expiresIn.asLong() * 1000L);
     }
 
     public static String base64encode(String value) {

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/OAuthAuthenticator.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/OAuthAuthenticator.java
@@ -102,6 +102,7 @@ public class OAuthAuthenticator {
             throw new IllegalStateException("Invalid response from authorization server: no expires_in");
         }
 
+        // Some OAuth2 authorization servers don't provide scope in this level
         JsonNode scope = result.get("scope");
 
         if (isJWT) {


### PR DESCRIPTION
Some OAuth Authorization servers such as AWS Cognito don't provide the `scope` in the response.  For example:
```
{
    "access_token": "{JWT_TOKEN}",
    "expires_in": 3600,
    "token_type": "Bearer"
}
```

This PR  makes `scope` property optional which gives us possibility to integrate with AWS Cognito. (Authorization servers which are not providing `scope` in the response) 