### PR TITLE
Align configuration with Kafka Operator

### DIFF
--- a/examples/consumer/README.md
+++ b/examples/consumer/README.md
@@ -54,7 +54,7 @@ To use Hydra as authorization server set url of Hydra's token endpoint:
 
 If using Hydra with opaque tokens, also set:
 
-    export OAUTH_TOKENS_NOT_JWT=true
+    export OAUTH_ACCESS_TOKEN_IS_JWT=false
 
 If using Hydra with JWT tokens, then set:
 

--- a/examples/consumer/src/main/java/io/strimzi/examples/consumer/ExampleConsumer.java
+++ b/examples/consumer/src/main/java/io/strimzi/examples/consumer/ExampleConsumer.java
@@ -55,7 +55,7 @@ public class ExampleConsumer {
         }
 
         // Use 'preferred_username' rather than 'sub' for principal name
-        if (!external.getValueAsBoolean(Config.OAUTH_TOKENS_NOT_JWT, false)) {
+        if (external.getValueAsBoolean(Config.OAUTH_ACCESS_TOKEN_IS_JWT, true)) {
             defaults.setProperty(Config.OAUTH_USERNAME_CLAIM, "preferred_username");
         }
 

--- a/examples/consumer/src/main/java/io/strimzi/examples/consumer/ExampleConsumer.java
+++ b/examples/consumer/src/main/java/io/strimzi/examples/consumer/ExampleConsumer.java
@@ -55,7 +55,7 @@ public class ExampleConsumer {
         }
 
         // Use 'preferred_username' rather than 'sub' for principal name
-        if (external.getValueAsBoolean(Config.OAUTH_ACCESS_TOKEN_IS_JWT, true)) {
+        if (isAccessTokenJwt(external)) {
             defaults.setProperty(Config.OAUTH_USERNAME_CLAIM, "preferred_username");
         }
 
@@ -73,6 +73,16 @@ public class ExampleConsumer {
                 System.out.println("Consumed message: " + record.value());
             }
         }
+    }
+
+    @SuppressWarnings("deprecation")
+    private static boolean isAccessTokenJwt(Config config) {
+        String legacy = config.getValue(Config.OAUTH_TOKENS_NOT_JWT);
+        if (legacy != null) {
+            System.out.println("[WARN] OAUTH_TOKENS_NOT_JWT is deprecated. Use OAUTH_ACCESS_TOKEN_IS_JWT (with reverse meaning) instead.");
+        }
+        return legacy != null ? !Config.isTrue(legacy) :
+                config.getValueAsBoolean(Config.OAUTH_ACCESS_TOKEN_IS_JWT, true);
     }
 
     /**

--- a/examples/docker/kafka-oauth-strimzi/compose-hydra-jwt.yml
+++ b/examples/docker/kafka-oauth-strimzi/compose-hydra-jwt.yml
@@ -60,7 +60,7 @@ services:
       OAUTH_JWKS_ENDPOINT_URI: "https://${HYDRA_HOST:-hydra}:4444/.well-known/jwks.json"
 
       # Hydra JWT tokens don't contain token type claim, therefore type check has to be skipped
-      OAUTH_VALIDATION_SKIP_TYPE_CHECK: "true"
+      OAUTH_CHECK_ACCESS_TOKEN_TYPE: "false"
 
       # Truststore config for connecting to secured authorization server
       OAUTH_SSL_TRUSTSTORE_LOCATION: /opt/kafka/config/ca-truststore.p12

--- a/examples/docker/kafka-oauth-strimzi/compose-hydra.yml
+++ b/examples/docker/kafka-oauth-strimzi/compose-hydra.yml
@@ -65,7 +65,7 @@ services:
       OAUTH_SSL_TRUSTSTORE_TYPE: pkcs12
 
       # Skip attempts to parse tokens as JWT to locally introspect
-      OAUTH_TOKENS_NOT_JWT: "true"
+      OAUTH_ACCESS_TOKEN_IS_JWT: "false"
 
       # For start_with_hydra.sh script to know where hydra is listening
       HYDRA_HOST: ${HYDRA_HOST:-hydra}

--- a/examples/producer/README.md
+++ b/examples/producer/README.md
@@ -54,7 +54,7 @@ To use Hydra as authorization server set url of Hydra's token endpoint:
 
 If using Hydra with opaque tokens, also set:
 
-    export OAUTH_TOKENS_NOT_JWT=true
+    export OAUTH_ACCESS_TOKEN_IS_JWT=false
 
 If using Hydra with JWT tokens, then set:
 

--- a/examples/producer/src/main/java/io/strimzi/examples/producer/ExampleProducer.java
+++ b/examples/producer/src/main/java/io/strimzi/examples/producer/ExampleProducer.java
@@ -53,7 +53,7 @@ public class ExampleProducer {
         }
 
         // Use 'preferred_username' rather than 'sub' for principal name
-        if (external.getValueAsBoolean(Config.OAUTH_ACCESS_TOKEN_IS_JWT, true)) {
+        if (isAccessTokenJwt(external)) {
             defaults.setProperty(Config.OAUTH_USERNAME_CLAIM, "preferred_username");
         }
 
@@ -84,6 +84,16 @@ public class ExampleProducer {
                 throw new RuntimeException("Interrupted while sleeping!");
             }
         }
+    }
+
+    @SuppressWarnings("deprecation")
+    private static boolean isAccessTokenJwt(Config config) {
+        String legacy = config.getValue(Config.OAUTH_TOKENS_NOT_JWT);
+        if (legacy != null) {
+            System.out.println("[WARN] OAUTH_TOKENS_NOT_JWT is deprecated. Use OAUTH_ACCESS_TOKEN_IS_JWT (with reverse meaning) instead.");
+        }
+        return legacy != null ? !Config.isTrue(legacy) :
+                config.getValueAsBoolean(Config.OAUTH_ACCESS_TOKEN_IS_JWT, true);
     }
 
     /**

--- a/examples/producer/src/main/java/io/strimzi/examples/producer/ExampleProducer.java
+++ b/examples/producer/src/main/java/io/strimzi/examples/producer/ExampleProducer.java
@@ -53,7 +53,7 @@ public class ExampleProducer {
         }
 
         // Use 'preferred_username' rather than 'sub' for principal name
-        if (!external.getValueAsBoolean(Config.OAUTH_TOKENS_NOT_JWT, false)) {
+        if (external.getValueAsBoolean(Config.OAUTH_ACCESS_TOKEN_IS_JWT, true)) {
             defaults.setProperty(Config.OAUTH_USERNAME_CLAIM, "preferred_username");
         }
 

--- a/oauth-client/src/main/java/io/strimzi/kafka/oauth/client/JaasClientOauthLoginCallbackHandler.java
+++ b/oauth-client/src/main/java/io/strimzi/kafka/oauth/client/JaasClientOauthLoginCallbackHandler.java
@@ -99,7 +99,7 @@ public class JaasClientOauthLoginCallbackHandler implements AuthenticateCallback
             usernameClaim = null;
         }
 
-        isJwt = config.getValueAsBoolean(Config.OAUTH_ACCESS_TOKEN_IS_JWT, true);
+        isJwt = isAccessTokenJwt(config);
         if (!isJwt && usernameClaim != null) {
             throw new RuntimeException("Custom username claim (OAUTH_USERNAME_CLAIM) not available, when tokens are configured as opaque (OAUTH_ACCESS_TOKEN_IS_JWT=false)");
         }
@@ -119,6 +119,16 @@ public class JaasClientOauthLoginCallbackHandler implements AuthenticateCallback
                     + "\n    maxTokenExpirySeconds: " + maxTokenExpirySeconds
                     + "\n    usernameClaim: " + usernameClaim);
         }
+    }
+
+    @SuppressWarnings("deprecation")
+    private static boolean isAccessTokenJwt(Config config) {
+        String legacy = config.getValue(Config.OAUTH_TOKENS_NOT_JWT);
+        if (legacy != null) {
+            log.warn("OAUTH_TOKENS_NOT_JWT is deprecated. Use OAUTH_ACCESS_TOKEN_IS_JWT (with reverse meaning) instead.");
+        }
+        return legacy != null ? !Config.isTrue(legacy) :
+                config.getValueAsBoolean(Config.OAUTH_ACCESS_TOKEN_IS_JWT, true);
     }
 
     @Override

--- a/oauth-client/src/main/java/io/strimzi/kafka/oauth/client/JaasClientOauthLoginCallbackHandler.java
+++ b/oauth-client/src/main/java/io/strimzi/kafka/oauth/client/JaasClientOauthLoginCallbackHandler.java
@@ -45,7 +45,7 @@ public class JaasClientOauthLoginCallbackHandler implements AuthenticateCallback
     private String clientSecret;
     private URI tokenEndpoint;
     private String usernameClaim;
-    private boolean isJWT;
+    private boolean isJwt;
     private int maxTokenExpirySeconds;
 
     private SSLSocketFactory socketFactory;
@@ -99,9 +99,9 @@ public class JaasClientOauthLoginCallbackHandler implements AuthenticateCallback
             usernameClaim = null;
         }
 
-        isJWT = !config.getValueAsBoolean(Config.OAUTH_TOKENS_NOT_JWT, false);
-        if (!isJWT && usernameClaim != null) {
-            throw new RuntimeException("Custom username claim (OAUTH_USERNAME_CLAIM) not available, when tokens are configured as opaque (OAUTH_TOKENS_NOT_JWT)");
+        isJwt = config.getValueAsBoolean(Config.OAUTH_ACCESS_TOKEN_IS_JWT, true);
+        if (!isJwt && usernameClaim != null) {
+            throw new RuntimeException("Custom username claim (OAUTH_USERNAME_CLAIM) not available, when tokens are configured as opaque (OAUTH_ACCESS_TOKEN_IS_JWT=false)");
         }
 
         maxTokenExpirySeconds = config.getValueAsInt(ClientConfig.OAUTH_MAX_TOKEN_EXPIRY_SECONDS, -1);
@@ -115,7 +115,7 @@ public class JaasClientOauthLoginCallbackHandler implements AuthenticateCallback
                     + "\n    tokenEndpointUri: " + tokenEndpoint
                     + "\n    clientId: " + clientId
                     + "\n    clientSecret: " + mask(clientSecret)
-                    + "\n    notJWT: " + !isJWT
+                    + "\n    isJwt: " + isJwt
                     + "\n    maxTokenExpirySeconds: " + maxTokenExpirySeconds
                     + "\n    usernameClaim: " + usernameClaim);
         }
@@ -146,11 +146,11 @@ public class JaasClientOauthLoginCallbackHandler implements AuthenticateCallback
 
         if (token != null) {
             // we could check if it's a JWT - in that case we could check if it's expired
-            result = loginWithAccessToken(token, isJWT);
+            result = loginWithAccessToken(token, isJwt);
         } else if (refreshToken != null) {
-            result = loginWithRefreshToken(tokenEndpoint, socketFactory, hostnameVerifier, refreshToken, clientId, clientSecret, isJWT);
+            result = loginWithRefreshToken(tokenEndpoint, socketFactory, hostnameVerifier, refreshToken, clientId, clientSecret, isJwt);
         } else if (clientSecret != null) {
-            result = loginWithClientSecret(tokenEndpoint, socketFactory, hostnameVerifier, clientId, clientSecret, isJWT);
+            result = loginWithClientSecret(tokenEndpoint, socketFactory, hostnameVerifier, clientId, clientSecret, isJwt);
         } else {
             throw new IllegalStateException("Invalid oauth client configuration - no credentials");
         }

--- a/oauth-client/src/main/java/io/strimzi/kafka/oauth/client/JaasClientOauthLoginCallbackHandler.java
+++ b/oauth-client/src/main/java/io/strimzi/kafka/oauth/client/JaasClientOauthLoginCallbackHandler.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 
+import static io.strimzi.kafka.oauth.common.DeprecationUtil.isAccessTokenJwt;
 import static io.strimzi.kafka.oauth.common.JSONUtil.getClaimFromJWT;
 import static io.strimzi.kafka.oauth.common.LogUtil.mask;
 import static io.strimzi.kafka.oauth.common.OAuthAuthenticator.loginWithAccessToken;
@@ -99,7 +100,7 @@ public class JaasClientOauthLoginCallbackHandler implements AuthenticateCallback
             usernameClaim = null;
         }
 
-        isJwt = isAccessTokenJwt(config);
+        isJwt = isAccessTokenJwt(config, log, null);
         if (!isJwt && usernameClaim != null) {
             throw new RuntimeException("Custom username claim (OAUTH_USERNAME_CLAIM) not available, when tokens are configured as opaque (OAUTH_ACCESS_TOKEN_IS_JWT=false)");
         }
@@ -119,16 +120,6 @@ public class JaasClientOauthLoginCallbackHandler implements AuthenticateCallback
                     + "\n    maxTokenExpirySeconds: " + maxTokenExpirySeconds
                     + "\n    usernameClaim: " + usernameClaim);
         }
-    }
-
-    @SuppressWarnings("deprecation")
-    private static boolean isAccessTokenJwt(Config config) {
-        String legacy = config.getValue(Config.OAUTH_TOKENS_NOT_JWT);
-        if (legacy != null) {
-            log.warn("OAUTH_TOKENS_NOT_JWT is deprecated. Use OAUTH_ACCESS_TOKEN_IS_JWT (with reverse meaning) instead.");
-        }
-        return legacy != null ? !Config.isTrue(legacy) :
-                config.getValueAsBoolean(Config.OAUTH_ACCESS_TOKEN_IS_JWT, true);
     }
 
     @Override

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/Config.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/Config.java
@@ -17,7 +17,7 @@ public class Config {
     public static final String OAUTH_SSL_TRUSTSTORE_TYPE = "oauth.ssl.truststore.type";
     public static final String OAUTH_SSL_SECURE_RANDOM_IMPLEMENTATION = "oauth.ssl.secure.random.implementation";
     public static final String OAUTH_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM = "oauth.ssl.endpoint.identification.algorithm";
-    public static final String OAUTH_TOKENS_NOT_JWT = "oauth.tokens.not.jwt";
+    public static final String OAUTH_ACCESS_TOKEN_IS_JWT = "oauth.access.token.is.jwt";
 
     private Properties defaults;
 

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/Config.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/Config.java
@@ -19,6 +19,9 @@ public class Config {
     public static final String OAUTH_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM = "oauth.ssl.endpoint.identification.algorithm";
     public static final String OAUTH_ACCESS_TOKEN_IS_JWT = "oauth.access.token.is.jwt";
 
+    @Deprecated
+    public static final String OAUTH_TOKENS_NOT_JWT = "oauth.tokens.not.jwt";
+
     private Properties defaults;
 
     /**
@@ -128,7 +131,7 @@ public class Config {
         }
     }
 
-    private boolean isTrue(String result) {
+    public static boolean isTrue(String result) {
         String val = result.toLowerCase(Locale.ENGLISH);
         if (val.equals("true") || val.equals("yes") || val.equals("y") || val.equals("1")) {
             return true;

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/DeprecationUtil.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/DeprecationUtil.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017-2020, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.kafka.oauth.common;
+
+import org.slf4j.Logger;
+
+public class DeprecationUtil {
+
+    @SuppressWarnings("deprecation")
+    public static boolean isAccessTokenJwt(Config config, Logger log, String errorPrefix) {
+        String legacy = config.getValue(Config.OAUTH_TOKENS_NOT_JWT);
+        if (legacy != null) {
+            log.warn("OAUTH_TOKENS_NOT_JWT is deprecated. Use OAUTH_ACCESS_TOKEN_IS_JWT (with reverse meaning) instead.");
+            if (config.getValue(Config.OAUTH_ACCESS_TOKEN_IS_JWT) != null) {
+                throw new RuntimeException((errorPrefix != null ? errorPrefix : "") + "Can't use both OAUTH_ACCESS_TOKEN_IS_JWT and OAUTH_TOKENS_NOT_JWT");
+            }
+        }
+
+        return legacy != null ? !Config.isTrue(legacy) :
+                config.getValueAsBoolean(Config.OAUTH_ACCESS_TOKEN_IS_JWT, true);
+    }
+}

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/OAuthAuthenticator.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/OAuthAuthenticator.java
@@ -28,12 +28,12 @@ public class OAuthAuthenticator {
         return loginWithAccessToken(token, true);
     }
 
-    public static TokenInfo loginWithAccessToken(String token, boolean isJWT) {
+    public static TokenInfo loginWithAccessToken(String token, boolean isJwt) {
         if (log.isDebugEnabled()) {
             log.debug("loginWithAccessToken() - pass-through access_token: {}", mask(token));
         }
 
-        if (isJWT) {
+        if (isJwt) {
             // try introspect token
             try {
                 return introspectAccessToken(token);
@@ -47,7 +47,7 @@ public class OAuthAuthenticator {
 
     public static TokenInfo loginWithClientSecret(URI tokenEndpointUrl, SSLSocketFactory socketFactory,
                                                   HostnameVerifier hostnameVerifier,
-                                                  String clientId, String clientSecret, boolean isJWT) throws IOException {
+                                                  String clientId, String clientSecret, boolean isJwt) throws IOException {
         if (log.isDebugEnabled()) {
             log.debug("loginWithClientSecret() - tokenEndpointUrl: {}, clientId: {}, clientSecret: {}",
                     tokenEndpointUrl, clientId, mask(clientSecret));
@@ -57,12 +57,12 @@ public class OAuthAuthenticator {
 
         StringBuilder body = new StringBuilder("grant_type=client_credentials");
 
-        return post(tokenEndpointUrl, socketFactory, hostnameVerifier, authorization, body.toString(), isJWT);
+        return post(tokenEndpointUrl, socketFactory, hostnameVerifier, authorization, body.toString(), isJwt);
     }
 
     public static TokenInfo loginWithRefreshToken(URI tokenEndpointUrl, SSLSocketFactory socketFactory,
                                                   HostnameVerifier hostnameVerifier, String refreshToken,
-                                                  String clientId, String clientSecret, boolean isJWT) throws IOException {
+                                                  String clientId, String clientSecret, boolean isJwt) throws IOException {
         if (log.isDebugEnabled()) {
             log.debug("loginWithRefreshToken() - tokenEndpointUrl: {}, refreshToken: {}, clientId: {}, clientSecret: {}",
                     tokenEndpointUrl, refreshToken, clientId, mask(clientSecret));
@@ -76,11 +76,11 @@ public class OAuthAuthenticator {
                 .append("&refresh_token=").append(urlencode(refreshToken))
                 .append("&client_id=").append(urlencode(clientId));
 
-        return post(tokenEndpointUrl, socketFactory, hostnameVerifier, authorization, body.toString(), isJWT);
+        return post(tokenEndpointUrl, socketFactory, hostnameVerifier, authorization, body.toString(), isJwt);
     }
 
     private static TokenInfo post(URI tokenEndpointUri, SSLSocketFactory socketFactory, HostnameVerifier hostnameVerifier,
-                                  String authorization, String body, boolean isJWT) throws IOException {
+                                  String authorization, String body, boolean isJwt) throws IOException {
 
         long now = System.currentTimeMillis();
 
@@ -106,7 +106,7 @@ public class OAuthAuthenticator {
         // therefore we don't need to make it mandatory
         JsonNode scope = result.get("scope");
 
-        if (isJWT) {
+        if (isJwt) {
             // try introspect token
             try {
                 return introspectAccessToken(token.asText());

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/validator/JWTSignatureValidator.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/validator/JWTSignatureValidator.java
@@ -52,7 +52,7 @@ public class JWTSignatureValidator implements TokenValidator {
     private final String issuerUri;
     private final int maxStaleSeconds;
     private final boolean defaultChecks;
-    private final boolean skipTypeCheck;
+    private final boolean checkAccessTokenType;
     private final String audience;
     private final SSLSocketFactory socketFactory;
     private final HostnameVerifier hostnameVerifier;
@@ -69,7 +69,7 @@ public class JWTSignatureValidator implements TokenValidator {
                                  int refreshSeconds,
                                  int expirySeconds,
                                  boolean defaultChecks,
-                                 boolean skipTypeCheck,
+                                 boolean checkAccessTokenType,
                                  String audience,
                                  boolean enableBouncyCastleProvider,
                                  int bouncyCastleProviderPosition) {
@@ -104,7 +104,7 @@ public class JWTSignatureValidator implements TokenValidator {
         this.maxStaleSeconds = expirySeconds;
 
         this.defaultChecks = defaultChecks;
-        this.skipTypeCheck = skipTypeCheck;
+        this.checkAccessTokenType = checkAccessTokenType;
         this.audience = audience;
 
         if (enableBouncyCastleProvider && !bouncyInstalled.getAndSet(true)) {
@@ -135,7 +135,7 @@ public class JWTSignatureValidator implements TokenValidator {
                     + "\n    validIssuerUri: " + validIssuerUri
                     + "\n    certsRefreshSeconds: " + refreshSeconds
                     + "\n    certsExpirySeconds: " + expirySeconds
-                    + "\n    skipTypeCheck: " + skipTypeCheck
+                    + "\n    checkAccessTokenType: " + checkAccessTokenType
                     + "\n    enableBouncyCastleProvider: " + enableBouncyCastleProvider
                     + "\n    bouncyCastleProviderPosition: " + bouncyCastleProviderPosition);
         }
@@ -175,7 +175,7 @@ public class JWTSignatureValidator implements TokenValidator {
         TokenVerifier<AccessToken> tokenVerifier = TokenVerifier.create(token, AccessToken.class);
 
         if (defaultChecks) {
-            if (skipTypeCheck) {
+            if (!checkAccessTokenType) {
                 tokenVerifier.withChecks(SUBJECT_EXISTS_CHECK, IS_ACTIVE);
             } else {
                 tokenVerifier.withDefaultChecks();

--- a/oauth-server/src/main/java/io/strimzi/kafka/oauth/server/JaasServerOauthValidatorCallbackHandler.java
+++ b/oauth-server/src/main/java/io/strimzi/kafka/oauth/server/JaasServerOauthValidatorCallbackHandler.java
@@ -89,7 +89,7 @@ public class JaasServerOauthValidatorCallbackHandler implements AuthenticateCall
                     config.getValueAsInt(ServerConfig.OAUTH_JWKS_REFRESH_SECONDS, 300),
                     config.getValueAsInt(ServerConfig.OAUTH_JWKS_EXPIRY_SECONDS, 360),
                     true,
-                    config.getValueAsBoolean(ServerConfig.OAUTH_VALIDATION_SKIP_TYPE_CHECK, false),
+                    config.getValueAsBoolean(ServerConfig.OAUTH_CHECK_ACCESS_TOKEN_TYPE, true),
                     null,
                     enableBouncy,
                     bouncyPosition

--- a/oauth-server/src/main/java/io/strimzi/kafka/oauth/server/JaasServerOauthValidatorCallbackHandler.java
+++ b/oauth-server/src/main/java/io/strimzi/kafka/oauth/server/JaasServerOauthValidatorCallbackHandler.java
@@ -49,7 +49,7 @@ public class JaasServerOauthValidatorCallbackHandler implements AuthenticateCall
 
     private String usernameClaim;
 
-    private boolean notJWT;
+    private boolean isJwt;
 
     @Override
     public void configure(Map<String, ?> configs, String saslMechanism, List<AppConfigurationEntry> jaasConfigEntries) {
@@ -67,7 +67,7 @@ public class JaasServerOauthValidatorCallbackHandler implements AuthenticateCall
         p.putAll(e.getOptions());
         config = new ServerConfig(p);
 
-        notJWT = config.getValueAsBoolean(Config.OAUTH_TOKENS_NOT_JWT, false);
+        isJwt = config.getValueAsBoolean(Config.OAUTH_ACCESS_TOKEN_IS_JWT, true);
 
         validateConfig();
 
@@ -123,8 +123,8 @@ public class JaasServerOauthValidatorCallbackHandler implements AuthenticateCall
             throw new RuntimeException("OAuth validator configuration error: only one of OAUTH_JWKS_ENDPOINT_URI (for fast local signature validation) and OAUTH_INTROSPECTION_ENDPOINT_URI (for using authorization server during validation) can be specified!");
         }
 
-        if (jwksUri != null && notJWT) {
-            throw new RuntimeException("OAuth validator configuration error - OAUTH_JWKS_ENDPOINT_URI (for fast local signature validation) is not compatible with OAUTH_TOKENS_NOT_JWT");
+        if (jwksUri != null && !isJwt) {
+            throw new RuntimeException("OAuth validator configuration error - OAUTH_JWKS_ENDPOINT_URI (for fast local signature validation) is not compatible with OAUTH_ACCESS_TOKENS_IS_JWT=false");
         }
     }
 
@@ -241,7 +241,7 @@ public class JaasServerOauthValidatorCallbackHandler implements AuthenticateCall
     }
 
     private void debugLogToken(String token) {
-        if (!log.isDebugEnabled() || notJWT) {
+        if (!log.isDebugEnabled() || !isJwt) {
             return;
         }
 

--- a/oauth-server/src/main/java/io/strimzi/kafka/oauth/server/ServerConfig.java
+++ b/oauth-server/src/main/java/io/strimzi/kafka/oauth/server/ServerConfig.java
@@ -19,6 +19,9 @@ public class ServerConfig extends Config {
     public static final String OAUTH_CRYPTO_PROVIDER_BOUNCYCASTLE = "oauth.crypto.provider.bouncycastle";
     public static final String OAUTH_CRYPTO_PROVIDER_BOUNCYCASTLE_POSITION = "oauth.crypto.provider.bouncycastle.position";
 
+    @Deprecated
+    public static final String OAUTH_VALIDATION_SKIP_TYPE_CHECK = "oauth.validation.skip.type.check";
+
     public ServerConfig() {
     }
 

--- a/oauth-server/src/main/java/io/strimzi/kafka/oauth/server/ServerConfig.java
+++ b/oauth-server/src/main/java/io/strimzi/kafka/oauth/server/ServerConfig.java
@@ -15,7 +15,7 @@ public class ServerConfig extends Config {
     public static final String OAUTH_JWKS_REFRESH_SECONDS = "oauth.jwks.refresh.seconds";
     public static final String OAUTH_VALID_ISSUER_URI = "oauth.valid.issuer.uri";
     public static final String OAUTH_INTROSPECTION_ENDPOINT_URI = "oauth.introspection.endpoint.uri";
-    public static final String OAUTH_VALIDATION_SKIP_TYPE_CHECK = "oauth.validation.skip.type.check";
+    public static final String OAUTH_CHECK_ACCESS_TOKEN_TYPE = "oauth.check.access.token.type";
     public static final String OAUTH_CRYPTO_PROVIDER_BOUNCYCASTLE = "oauth.crypto.provider.bouncycastle";
     public static final String OAUTH_CRYPTO_PROVIDER_BOUNCYCASTLE_POSITION = "oauth.crypto.provider.bouncycastle.position";
 

--- a/testsuite/access-token-introspection-hydra-test/docker-compose.yml
+++ b/testsuite/access-token-introspection-hydra-test/docker-compose.yml
@@ -79,7 +79,7 @@ services:
       - OAUTH_SSL_TRUSTSTORE_TYPE=pkcs12
 
       # Skip attempts to parse tokens as JWT to locally introspect
-      - OAUTH_TOKENS_NOT_JWT=true
+      - OAUTH_ACCESS_TOKEN_IS_JWT=false
 
       # For start_with_hydra.sh script to know where hydra is listening
       - HYDRA_HOST=${HYDRA_HOST:-hydra}

--- a/testsuite/access-token-introspection-hydra-test/src/test/java/io/strimzi/testsuite/oauth/HydraOpaqueAccessTokenWithIntrospectValidationTest.java
+++ b/testsuite/access-token-introspection-hydra-test/src/test/java/io/strimzi/testsuite/oauth/HydraOpaqueAccessTokenWithIntrospectValidationTest.java
@@ -47,7 +47,7 @@ public class HydraOpaqueAccessTokenWithIntrospectValidationTest {
 
         Properties defaults = new Properties();
         defaults.setProperty(ClientConfig.OAUTH_TOKEN_ENDPOINT_URI, tokenEndpointUri);
-        defaults.setProperty(ClientConfig.OAUTH_TOKENS_NOT_JWT, "true");
+        defaults.setProperty(ClientConfig.OAUTH_ACCESS_TOKEN_IS_JWT, "false");
 
         defaults.setProperty(ClientConfig.OAUTH_SSL_TRUSTSTORE_LOCATION, "../docker/target/kafka/certs/ca-truststore.p12");
         defaults.setProperty(ClientConfig.OAUTH_SSL_TRUSTSTORE_PASSWORD, "changeit");

--- a/testsuite/client-secret-jwt-hydra-test/arquillian.xml
+++ b/testsuite/client-secret-jwt-hydra-test/arquillian.xml
@@ -25,6 +25,11 @@
                 strategy: log
                 match: '[KafkaServer id=1] started'
                 timeout: 120
+              beforeStop:
+                - log:
+                    to: ${PWD}/../kafka.log
+                    stdout: true
+                    stderr: true
         </property>
     </extension>
 </arquillian>

--- a/testsuite/client-secret-jwt-hydra-test/docker-compose.yml
+++ b/testsuite/client-secret-jwt-hydra-test/docker-compose.yml
@@ -74,7 +74,7 @@ services:
       - OAUTH_JWKS_ENDPOINT_URI=https://${HYDRA_HOST:-hydra}:4444/.well-known/jwks.json
 
       # Hydra JWT tokens don't contain token type claim, therefore type check has to be skipped
-      - OAUTH_VALIDATION_SKIP_TYPE_CHECK=true
+      - OAUTH_CHECK_ACCESS_TOKEN_TYPE=false
 
       # Truststore config for connecting to secured authorization server
       - OAUTH_SSL_TRUSTSTORE_LOCATION=/opt/kafka/config/strimzi/certs/ca-truststore.p12

--- a/testsuite/client-secret-jwt-hydra-test/docker-compose.yml
+++ b/testsuite/client-secret-jwt-hydra-test/docker-compose.yml
@@ -74,7 +74,7 @@ services:
       - OAUTH_JWKS_ENDPOINT_URI=https://${HYDRA_HOST:-hydra}:4444/.well-known/jwks.json
 
       # Hydra JWT tokens don't contain token type claim, therefore type check has to be skipped
-      - OAUTH_CHECK_ACCESS_TOKEN_TYPE=false
+      - OAUTH_VALIDATION_SKIP_TYPE_CHECK=true
 
       # Truststore config for connecting to secured authorization server
       - OAUTH_SSL_TRUSTSTORE_LOCATION=/opt/kafka/config/strimzi/certs/ca-truststore.p12


### PR DESCRIPTION
This PR introduces changes with regards to configuration:
* `oauth.tokens.not.jwt` is now called `oauth.access.token.is.jwt` and has a reverse meaning
* `oauth.validation.skip.type.check` is now called `oauth.check.access.token.type` and has a reverse meaning

Having a reverse meaning for both these configuration parameters means that the default value is `true` whereas before it was `false`, and when setting them explicitly you usually want to set them to `false` rather than `true` as it was the case before.

The old configuration parameter names still work with the old semantics, but have been marked @<!-- -->Deprecated and will be removed in future versions. A Warning is logged if the old parameter names are used.