### PR TITLE
Better support for different authorization servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,7 @@ You can fallback to a secondary attribute, which allows you to map multiple acco
 
 If `oauth.username.claim` is specified but value does not exist in the Introspection Endpoint response, then `oauth.fallback.username.claim` is used. If value for that doesn't exist either, the `sub` attribute is used.
 When `oauth.fallback.username.prefix` is specified and the attribute specified by `oauth.fallback.username.claim` contains a non-null value the resulting principal will be equal to concatenation of the prefix, and the value.
+If none of the `oauth.*.username.*` attributes is specified, `sub` claim will be used automatically.
 
 For example, if the following configuration is set:
 
@@ -315,7 +316,14 @@ For example, if the following configuration is set:
 It means that if the response contains `"username": "alice"` then the principal will be `User:alice`.
 Otherwise, if the response contains `"client_id": "my-producer"` then the principal will be `User:client-account-my-producer`. 
 
-If you have a DEBUG logging configured for the `io.strimzi` category you may need to specify the following to prevent warnings about access token not being JWT:
+Sometimes the Introspection Endpoint does not provide any useful identifying information that we can use for principal.
+In that case you can configure User Info Endpoint:
+ 
+- `oauth.userinfo.endpoint.uri` (e.g.: "https://localhost:8443/auth/realms/demo/protocol/openid-connect/userinfo")
+
+If the principal name could not be extracted from Introspection Endpoint response, then the same rules (`oauth.username.claim`, `oauth.fallback.username.claim`, `oauth.fallback.username.prefix`) will be used to try extract the principal name from User Info Endpoint response.
+
+When you have a DEBUG logging configured for the `io.strimzi` category you may need to specify the following to prevent warnings about access token not being JWT:
 - `oauth.access.token.is.jwt` (e.g.: "false")
 
 ##### Configuring the client side of inter-broker communication

--- a/README.md
+++ b/README.md
@@ -233,20 +233,20 @@ Specify the following `oauth.*` properties:
 - `oauth.jwks.endpoint.uri` (e.g.: "https://localhost:8443/auth/realms/demo/protocol/openid-connect/certs")
 - `oauth.valid.issuer.uri` (e.g.: "https://localhost:8443/auth/realms/demo" - only access tokens issued by this issuer will be accepted)
 
-Some authorization servers don't provide the `iss` claim. In that case you would not set `oauth.valid.issuer.uri`, and you would explicilty turn off issuer checking by setting the following option to `false`:
+Some authorization servers don't provide the `iss` claim. In that case you would not set `oauth.valid.issuer.uri`, and you would explicitly turn off issuer checking by setting the following option to `false`:
 - `oauth.check.issuer` (e.g. "false")
 
 JWT tokens contain unique user identification in `sub` claim. However, this is often a long number or a UUID, but we usually prefer to use human readable usernames, which may also be present in JWT token.
-Use `oauth.username.claim` to map the claim (attribute) where the value you want to use as used id is stored:
+Use `oauth.username.claim` to map the claim (attribute) where the value you want to use as user id is stored:
 - `oauth.username.claim` (e.g.: "preferred_username")
 
-If `oauth.username.claim` is specified the value of that claim is used instead, but if not set, the fallback is still the `sub` claim.
+If `oauth.username.claim` is specified the value of that claim is used instead, but if not set, the automatic fallback claim is the `sub` claim.
 
-You can fallback to a secondary claim, which allows you to map multiple account types into the same principal namespace: 
+You can specify the secondary claim to fallback to, which allows you to map multiple account types into the same principal namespace: 
 - `oauth.fallback.username.claim` (e.g.: "client_id")
 - `oauth.fallback.username.prefix` (e.g.: "client-account-")
 
-If `oauth.username.claim` is specified but value does not exist in the token, then `oauth.fallback.username.claim` is used. If value for that doesn't exist either, the `sub` claim is used.
+If `oauth.username.claim` is specified but value does not exist in the token, then `oauth.fallback.username.claim` is used. If value for that doesn't exist either, the exception is thrown.`
 When `oauth.fallback.username.prefix` is specified and the claim specified by `oauth.fallback.username.claim` contains a non-null value the resulting user id will be equal to concatenation of the prefix, and the value.
 
 For example, if the following configuration is set:
@@ -283,7 +283,7 @@ Specify the following `oauth.*` properties:
  
 Introspection endpoint should be protected. The `oauth.client.id` and `oauth.client.secret` specify Kafka Broker credentials for authenticating to access the introspection endpoint. 
 
-Some authorization servers don't provide the `iss` claim. In that case you would not set `oauth.valid.issuer.uri`, and you would explicilty turn off issuer checking by setting the following option to `false`:
+Some authorization servers don't provide the `iss` claim. In that case you would not set `oauth.valid.issuer.uri`, and you would explicitly turn off issuer checking by setting the following option to `false`:
 - `oauth.check.issuer` (e.g.: "false")
 
 By default, if the Introspection Endpoint response contains `token_type` claim, there is no checking performed on it.
@@ -374,7 +374,7 @@ You can integrate KeycloakRBACAuthorizer with SimpleAclAuthorizer:
 - `strimzi.authorization.delegate.to.kafka.acl` (e.g.: "true" - if enabled, then when action is not granted based on Keycloak Authorization Services grant it is delegated to SimpleACLAuthorizer which can still grant it.)
 
 If you turn on authorization support in Kafka brokers, you need to properly set `super.users` property. 
-By default, access token's 'sub' claim is used as user id.
+By default, access token's `sub` claim is used as user id.
 You may want to use another claim provided in access token as an alternative user id (username, email ...). 
 
 For example, to add the account representing Kafka Broker in Keycloak to `super.users` add the following to your `server.properties` file:
@@ -519,7 +519,7 @@ sasl.jaas.config=org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginMo
 sasl.login.callback.handler.class=io.strimzi.kafka.oauth.client.JaasClientOauthLoginCallbackHandler
 ```
 
-When you have a Kafka Client connecting to a single Kafka cluster it only need one set of credentials - in such a situation it is sometimes more convenient to just use ENV vars.
+When you have a Kafka Client connecting to a single Kafka cluster it only needs one set of credentials - in such a situation it is sometimes more convenient to just use ENV vars.
 In that case you could simplify `my.properties` file:
 
 ```

--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ You can specify the secondary claim to fallback to, which allows you to map mult
 - `oauth.fallback.username.claim` (e.g.: "client_id")
 - `oauth.fallback.username.prefix` (e.g.: "client-account-")
 
-If `oauth.username.claim` is specified but value does not exist in the token, then `oauth.fallback.username.claim` is used. If value for that doesn't exist either, the exception is thrown.`
+If `oauth.username.claim` is specified but value does not exist in the token, then `oauth.fallback.username.claim` is used. If value for that doesn't exist either, the exception is thrown.
 When `oauth.fallback.username.prefix` is specified and the claim specified by `oauth.fallback.username.claim` contains a non-null value the resulting user id will be equal to concatenation of the prefix, and the value.
 
 For example, if the following configuration is set:
@@ -303,8 +303,9 @@ You can fallback to a secondary attribute, which allows you to map multiple acco
 - `oauth.fallback.username.claim` (e.g.: "client_id")
 - `oauth.fallback.username.prefix` (e.g.: "client-account-")
 
-If `oauth.username.claim` is specified but value does not exist in the Introspection Endpoint response, then `oauth.fallback.username.claim` is used. If value for that doesn't exist either, the `sub` attribute is used.
+If `oauth.username.claim` is specified but value does not exist in the Introspection Endpoint response, then `oauth.fallback.username.claim` is used. If value for that doesn't exist either, the exception is thrown.
 When `oauth.fallback.username.prefix` is specified and the attribute specified by `oauth.fallback.username.claim` contains a non-null value the resulting user id will be equal to concatenation of the prefix, and the value.
+
 If none of the `oauth.*.username.*` attributes is specified, `sub` claim will be used automatically.
 
 For example, if the following configuration is set:

--- a/README.md
+++ b/README.md
@@ -233,9 +233,30 @@ Specify the following `oauth.*` properties:
 - `oauth.jwks.endpoint.uri` (e.g.: "https://localhost:8443/auth/realms/demo/protocol/openid-connect/certs")
 - `oauth.valid.issuer.uri` (e.g.: "https://localhost:8443/auth/realms/demo" - only access tokens issued by this issuer will be accepted)
 
+Some authorization servers don't provide the `iss` claim. In that case you would not set `oauth.valid.issuer.uri`, and you would explicilty turn off issuer checking by setting the following option to `false`:
+- `oauth.check.issuer` (e.g. "false")
+
 JWT tokens contain unique user identification in `sub` claim. However, this is often a long number or a UUID, but we usually prefer to use human readable usernames, which may also be present in JWT token.
 Use `oauth.username.claim` to map the claim (attribute) where the username is stored:
 - `oauth.username.claim` (e.g.: "preferred_username")
+
+If `oauth.username.claim` is specified the value of that claim is used instead, but if not set, the fallback is still the `sub` claim.
+
+You can fallback to a secondary claim, which allows you to map multiple account types into the same principal namespace: 
+- `oauth.fallback.username.claim` (e.g.: "client_id")
+- `oauth.fallback.username.prefix` (e.g.: "client-account-")
+
+If `oauth.username.claim` is specified but value does not exist in the token, then `oauth.fallback.username.claim` is used. If value for that doesn't exist either, the `sub` claim is used.
+When `oauth.fallback.username.prefix` is specified and the claim specified by `oauth.fallback.username.claim` contains a non-null value the resulting principal will be equal to concatenation of the prefix, and the value.
+
+For example, if the following configuration is set:
+
+    oauth.username.claim="username"
+    oauth.fallback.username.claim="client_id"
+    oauth.fallback.username.prefix="client-account-"
+
+Then, if the token contains `"username": "alice"` claim then the principal will be `User:alice`.
+Otherwise, if the token contains `"client_id": "my-producer"` claim then the principal will be `User:client-account-my-producer`. 
 
 If your authorization server uses ECDSA encryption then you need to enable the BouncyCastle JCE crypto provider:
 - `oauth.crypto.provider.bouncycastle` (e.g.: "true")
@@ -259,8 +280,40 @@ Specify the following `oauth.*` properties:
 - `oauth.valid.issuer.uri` (e.g.: "https://localhost:8443/auth/realms/demo" - only access tokens issued by this issuer will be accepted)
 - `oauth.client.id` (e.g.: "kafka" - this is the client configuration id for Kafka Broker)
 - `oauth.client.secret` (e.g.: "kafka-secret")
-
+ 
 Introspection endpoint should be protected. The `oauth.client.id` and `oauth.client.secret` specify Kafka Broker credentials for authenticating to access the introspection endpoint. 
+
+Some authorization servers don't provide the `iss` claim. In that case you would not set `oauth.valid.issuer.uri`, and you would explicilty turn off issuer checking by setting the following option to `false`:
+- `oauth.check.issuer` (e.g.: "false")
+
+By default, if the Introspection Endpoint response contains `token_type` claim, there is no checking performed on it.
+Some authorization servers use a non-standard `token_type` value. To give the most flexibility, you can specify the valid `token_type` for your authorization server:
+- `oauth.valid.token.type` (e.g.: "access_token")
+
+When this is specified the Introspection Endpoint response has to contain `token_type`, and its value has to be equal to the value specified by `oauth.valid.token.type`.
+
+Introspection Endpoint may or may not return identifying information which we could use to construct a principal for the user (the 'username').
+
+If the information is available we need to extract the username from attributes contained in Introspection Endpoint response.
+
+Use `oauth.username.claim` to map the attribute where the username is stored:
+- `oauth.username.claim` (e.g.: "preferred_username")
+
+You can fallback to a secondary attribute, which allows you to map multiple account types into the same principal namespace: 
+- `oauth.fallback.username.claim` (e.g.: "client_id")
+- `oauth.fallback.username.prefix` (e.g.: "client-account-")
+
+If `oauth.username.claim` is specified but value does not exist in the Introspection Endpoint response, then `oauth.fallback.username.claim` is used. If value for that doesn't exist either, the `sub` attribute is used.
+When `oauth.fallback.username.prefix` is specified and the attribute specified by `oauth.fallback.username.claim` contains a non-null value the resulting principal will be equal to concatenation of the prefix, and the value.
+
+For example, if the following configuration is set:
+
+    oauth.username.claim="username"
+    oauth.fallback.username.claim="client_id"
+    oauth.fallback.username.prefix="client-account-"
+
+It means that if the response contains `"username": "alice"` then the principal will be `User:alice`.
+Otherwise, if the response contains `"client_id": "my-producer"` then the principal will be `User:client-account-my-producer`. 
 
 If you have a DEBUG logging configured for the `io.strimzi` category you may need to specify the following to prevent warnings about access token not being JWT:
 - `oauth.access.token.is.jwt` (e.g.: "false")
@@ -278,7 +331,7 @@ Specify the following `oauth.*` properties:
 Also specify the username corresponding to client account identified by `oauth.client.id` in `super.users` property in `server.properties` file:
 - `super.users` (e.g.: "User:service-account-kafka") 
 
-This is not a full set of available `oauth.*` properties. All the `oauth.*` properties described in the next chapter about configuring the Kafka clients also apply to configuring the client side of inter-broker communication. 
+This is not a full set of available `oauth.*` properties. All the `oauth.*` properties described in the next chapter about [configuring the Kafka clients](#configuring-the-kafka-client) also apply to configuring the client side of inter-broker communication. 
 
 ### Configuring the Kafka Broker authorization
 
@@ -403,12 +456,20 @@ The third way is to manually obtain and set an access token:
 Access tokens are supposed to be short-lived in order to prevent unauthorized access if the token leaks.
 It is up to you, your environment, and how you plan to run your Kafka client application to consider if using long-lived access tokens is appropriate.
 
+Some authorization servers require that scope is specified:
+
+- `oauth.scope`
+
+Scope is sent to the Token Endpoint when obtaining the access token.
+
 For debug purposes you may want to properly configure which JWT token attribute contains the username of the account used to obtain the access token:
 
 - `oauth.username.claim` (e.g.: "preferred_username")
 
 This does not affect how Kafka client is presented to the Kafka Broker.
-The broker performs username extraction from the token once again.
+The broker performs username extraction from the token once again or it uses the Introspection Endpoint or the User Info Endpoint to get the username.
+
+By default the username on the Kafka client is obtained from `sub` claim in the token - only if token is JWT. 
 
 You may want to explicitly specify the period the access token is considered valid.
 This may be necessary if using opaque tokens do not contain expiry info. 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,11 @@ Release Notes
 
 ### Improved compatibility with authorization servers
 
+Some claims are no longer required in token or Introspection Endpoint response (`iat`).
+Others can be configured to not be required:
+* `iss` claim is not required if `oauth.check.issuer` is set to `false`
+* `sub` claim is no longer required if `oauth.username.claim` is configured since then it is no longer used to extract principal. 
+
 Additional options were added to improve interoperability with authorization servers.
 
 The following options were added:
@@ -23,7 +28,7 @@ The following options were added:
   Sometimes the introspection endpoint doesn't provide any claim that could be used for the principal. In such a case User Info Endpoint is used, if configured, and configuration of `oauth.username.claim`, `oauth.fallback.username.claim`, and `oauth.fallback.username.prefix` is taken into account.
 * `oauth.valid.token.type`
   When using the Introspection Endpoint, some servers use custom values for `token_type`.
-  If this configuration parameter is set then the `token_type` attribute has to be present in Introspection Token response, and has to have the same value.
+  If this configuration parameter is set then the `token_type` attribute has to be present in Introspection Token response, and has to have the specified value.
 
 ### Fixed a non-standard `token_type` enforcement when using the Introspection Endpoint
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -25,16 +25,16 @@ The following options were added:
 * `oauth.fallback.username.claim`
 
   Principal can now be extracted from JWT token or Introspection endpoint response by using multiple claims.
-  First `oauth.username.claim` is attempted (if configured). If the value is not present, then the fallback claim is attempted.
+  First `oauth.username.claim` is attempted (if configured). If the value is not present, the fallback claim is attempted.
   If neither `oauth.username.claim` nor `oauth.fallback.username.claim` is specified or its value present, `sub` claim is used.
 
 * `oauth.fallback.username.prefix`
 
-  If principal is set by `oauth.fallback.username.claim` then its value will be prefixed by the value of `oauth.fallback.username.prefix` if specified.
+  If principal is set by `oauth.fallback.username.claim` then its value will be prefixed by the value of `oauth.fallback.username.prefix`, if specified.
 
 * `oauth.userinfo.endpoint.uri`
 
-  Sometimes the introspection endpoint doesn't provide any claim that could be used for the principal. In such a case User Info Endpoint is used, if configured, and configuration of `oauth.username.claim`, `oauth.fallback.username.claim`, and `oauth.fallback.username.prefix` is taken into account.
+  Sometimes the introspection endpoint doesn't provide any claim that could be used for the principal. In such a case User Info Endpoint can be used, and configuration of `oauth.username.claim`, `oauth.fallback.username.claim`, and `oauth.fallback.username.prefix` is taken into account.
 
 * `oauth.valid.token.type`
 
@@ -49,6 +49,7 @@ Token type check is now disabled unless the newly introduced `oauth.valid.token.
 ### Improved examples
 
 * Fixed an issue with `keycloak` and `hydra` containers not visible when starting services in separate shells.
+
   The instructions for running `keycloak` / `hydra` separately omitted the required `-f compose.yml` as a first compose file, resulting in a separate bridge network being used.
 
 * Added Spring Security Authorization Server
@@ -56,7 +57,7 @@ Token type check is now disabled unless the newly introduced `oauth.valid.token.
 ### Improved logging to facilitate troubleshooting
 
 There is now some TRACE logging support which should only ever be used in development / testing environment because it outputs secrets into the log.
-When integrating with your authorization server, enabling TRACE logging on 'io.strimzi.kafka.oauth' logger will output the authorization server responses which can point you to how to correctly configure 'oauth.*' parameters to make the integration work. 
+When integrating with your authorization server, enabling TRACE logging on `io.strimzi.kafka.oauth` logger will output the authorization server responses which can point you to how to correctly configure `oauth.*` parameters to make the integration work. 
 
 0.4.0
 -----

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,27 @@
 Release Notes
 =============
 
+0.5.0
+-----
+
+### Improved compatibility with authorization servers
+
+Additional options were added to improve interoperability with authorization servers.
+
+The following options were added:
+* `oauth.scope`
+  Scope can now be specified for the Token endpoint on the Kafka clients and on the Kafka broker for inter-broker communication.
+* `oauth.check.issuer`
+  Issuer check can now be disabled when configuring token validation on the Kafka broker - some authorization servers don't provide `iss` claim.  
+* `oauth.fallback.username.claim`
+  Principal can now be extracted from JWT token or Introspection endpoint response by using multiple claims.
+  First `oauth.username.claim` is attempted (if configured). If the value is not present, then the fallback claim is attempted.
+  If neither `oauth.username.claim` nor `oauth.fallback.username.claim` is specified or its value present, `sub` claim is used.
+* `oauth.fallback.username.prefix`
+  If principal is set by `oauth.fallback.username.claim` then its value will be prefixed by the value of `oauth.fallback.username.prefix` if specified.
+* `oauth.userinfo.endpoint.uri`
+  Sometimes the introspection endpoint doesn't provide any claim that could be used for the principal. In such a case User Info Endpoint is used, if configured, and configuration of `oauth.username.claim`, `oauth.fallback.username.claim`, and `oauth.fallback.username.prefix` is taken into account.
+
 0.4.0
 -----
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,6 +14,7 @@ Others can be configured to not be required:
 Additional options were added to improve interoperability with authorization servers.
 
 The following options were added:
+
 * `oauth.scope`
 
   Scope can now be specified for the Token endpoint on the Kafka clients and on the Kafka broker for inter-broker communication.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -15,18 +15,29 @@ Additional options were added to improve interoperability with authorization ser
 
 The following options were added:
 * `oauth.scope`
+
   Scope can now be specified for the Token endpoint on the Kafka clients and on the Kafka broker for inter-broker communication.
+
 * `oauth.check.issuer`
-  Issuer check can now be disabled when configuring token validation on the Kafka broker - some authorization servers don't provide `iss` claim.  
+
+  Issuer check can now be disabled when configuring token validation on the Kafka broker - some authorization servers don't provide `iss` claim.
+  
 * `oauth.fallback.username.claim`
+
   Principal can now be extracted from JWT token or Introspection endpoint response by using multiple claims.
   First `oauth.username.claim` is attempted (if configured). If the value is not present, then the fallback claim is attempted.
   If neither `oauth.username.claim` nor `oauth.fallback.username.claim` is specified or its value present, `sub` claim is used.
+
 * `oauth.fallback.username.prefix`
+
   If principal is set by `oauth.fallback.username.claim` then its value will be prefixed by the value of `oauth.fallback.username.prefix` if specified.
+
 * `oauth.userinfo.endpoint.uri`
+
   Sometimes the introspection endpoint doesn't provide any claim that could be used for the principal. In such a case User Info Endpoint is used, if configured, and configuration of `oauth.username.claim`, `oauth.fallback.username.claim`, and `oauth.fallback.username.prefix` is taken into account.
+
 * `oauth.valid.token.type`
+
   When using the Introspection Endpoint, some servers use custom values for `token_type`.
   If this configuration parameter is set then the `token_type` attribute has to be present in Introspection Token response, and has to have the specified value.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -21,6 +21,26 @@ The following options were added:
   If principal is set by `oauth.fallback.username.claim` then its value will be prefixed by the value of `oauth.fallback.username.prefix` if specified.
 * `oauth.userinfo.endpoint.uri`
   Sometimes the introspection endpoint doesn't provide any claim that could be used for the principal. In such a case User Info Endpoint is used, if configured, and configuration of `oauth.username.claim`, `oauth.fallback.username.claim`, and `oauth.fallback.username.prefix` is taken into account.
+* `oauth.valid.token.type`
+  When using the Introspection Endpoint, some servers use custom values for `token_type`.
+  If this configuration parameter is set then the `token_type` attribute has to be present in Introspection Token response, and has to have the same value.
+
+### Fixed a non-standard `token_type` enforcement when using the Introspection Endpoint
+
+If `token_type` was present it was expected to be equal to `access_token` which is not an OAuth 2.0 spec compliant value.
+Token type check is now disabled unless the newly introduced `oauth.valid.token.type` configuration option is set. 
+
+### Improved examples
+
+* Fixed an issue with `keycloak` and `hydra` containers not visible when starting services in separate shells.
+  The instructions for running `keycloak` / `hydra` separately omitted the required `-f compose.yml` as a first compose file, resulting in a separate bridge network being used.
+
+* Added Spring Security Authorization Server
+
+### Improved logging to facilitate troubleshooting
+
+There is now some TRACE logging support which should only ever be used in development / testing environment because it outputs secrets into the log.
+When integrating with your authorization server, enabling TRACE logging on 'io.strimzi.kafka.oauth' logger will output the authorization server responses which can point you to how to correctly configure 'oauth.*' parameters to make the integration work. 
 
 0.4.0
 -----

--- a/examples/README-authz.md
+++ b/examples/README-authz.md
@@ -217,7 +217,7 @@ Let's now try to consume the messages we have produced.
     bin/kafka-console-consumer.sh --bootstrap-server kafka:9092 --topic a_messages \
       --from-beginning --consumer.config ~/team-a-client.properties
 
-This gives us an error like: 'Not authorized to access group: console-consumer-55841'.
+This gives us an error like: `Not authorized to access group: console-consumer-55841`.
 
 The reason is that we have to override the default consumer group name - `Dev Team A` only has access to consumer groups that have names starting with 'a_'.
 Let's set custom consumer group name that starts with 'a_'
@@ -236,7 +236,7 @@ Let's now list the topics:
 
     bin/kafka-topics.sh --bootstrap-server kafka:9092 --command-config ~/team-a-client.properties --list
     
-We get one topic listed: 'a_messages'.
+We get one topic listed: `a_messages`.
 
 Let's try and list the consumer groups:
 
@@ -269,12 +269,12 @@ sasl.login.callback.handler.class=io.strimzi.kafka.oauth.client.JaasClientOauthL
 EOF
 ```
 
-If we look at `team-b-client` client configuration in Keycloak, under 'Service Account Roles' we can see that it has `Dev Team B` realm role assigned.
+If we look at `team-b-client` client configuration in Keycloak, under `Service Account Roles` we can see that it has `Dev Team B` realm role assigned.
 Looking in Keycloak Console at the `kafka` client's `Authorization` tab where `Permissions` are listed, we can see the permissions that start with 'Dev Team B ...'.
-These match the users and service accounts that have the 'Dev Team B' realm role assigned to them. 
+These match the users and service accounts that have the `Dev Team B` realm role assigned to them. 
 The `Dev Team B` users have full access to topics beginning with 'b_' on Kafka cluster `cluster2` (which is the designated cluster name of the demo cluster we brought up), and read access on topics that start with 'x_'.
 
-Let's try produce some messages to topic 'a_messages' as `team-b-client`:
+Let's try produce some messages to topic `a_messages` as `team-b-client`:
 
 ```
 bin/kafka-console-producer.sh --broker-list kafka:9092 --topic a_messages \
@@ -360,7 +360,8 @@ Let's now try to create the `x_messages` topic:
     bin/kafka-topics.sh --bootstrap-server kafka:9092 --command-config ~/bob.properties \
       --topic x_messages --create --replication-factor 1 --partitions 1
 
-The operation should succeed. We can list the topics:
+The operation should succeed (you can ignore the warning about periods and underscores).
+We can list the topics:
 
     bin/kafka-topics.sh --bootstrap-server kafka:9092 --command-config ~/bob.properties --list
 
@@ -391,6 +392,8 @@ bin/kafka-console-producer.sh --broker-list kafka:9092 --topic x_messages \
 Message 4
 Message 5
 ```
+
+We get an error - `Not authorized to access topics: [x_messages]`.
 
 But `team-b-client` should be able to consume messages from the `x_messages` topic:
 

--- a/examples/docker/README.md
+++ b/examples/docker/README.md
@@ -19,13 +19,14 @@ Building
 Preparing
 ---------
 
-Make sure that the following ports on your host machine are free: 9092, 2181 (Kafka), 8080, 8443 (Keycloak), 4444, 4445 (Hydra).
+Make sure that the following ports on your host machine are free: 9092, 2181 (Kafka), 8080 (Spring or Keycloak), 8443 (Keycloak), 4444, 4445 (Hydra).
 
 Then, you have to add some entries to your `/etc/hosts` file:
 
     127.0.0.1            keycloak
     127.0.0.1            hydra
     127.0.0.1            kafka
+    127.0.0.1            spring
 
 That's needed for host resolution, because Kafka brokers and Kafka clients connecting to Keycloak / Hydra have to use the 
 same hostname to ensure compatibility of generated access tokens.
@@ -40,7 +41,7 @@ All the following docker-compose commands should be run from this directory.
 
 You may want to remove any old containers to start clean:
 
-    docker rm -f kafka zookeeper keycloak
+    docker rm -f kafka zookeeper keycloak spring
 
 
 Running with Keycloak without SSL
@@ -105,6 +106,19 @@ Or, you can have multiple terminal windows and start individual component in eac
     docker-compose -f hydra/compose-with-jwt.yml up
 
     docker-compose -f compose.yml -f hydra-import/compose.yml up --build
+
+
+Running with Spring using opaque tokens
+---------------------------------------
+
+Start spring authorization server first:
+
+    docker-compose -f compose.yml -f spring/compose.yml up
+
+Then start the Kafka broker:
+    
+    docker-compose -f compose.yml -f kafka-oauth-strimzi/compose-spring.yml up --build
+
 
 
 Rebuilding certificates

--- a/examples/docker/README.md
+++ b/examples/docker/README.md
@@ -3,7 +3,7 @@ Demo services
 
 This module provides docker containers for the demo. It includes Keycloak, realm import service for Keycloak, and a preconfigured Kafka broker.
 
-Alternative option is to use included Hydra project as authorization server.
+Alternative option is to use included 'hydra' or 'spring' project as authorization server.
 
 
 Building
@@ -55,7 +55,7 @@ Or, you can have multiple terminal windows and start individual component in eac
 
     docker-compose -f compose.yml -f kafka-oauth-strimzi/compose.yml up --build 
 
-    docker-compose -f keycloak/compose.yml up
+    docker-compose -f compose.yml -f keycloak/compose.yml up
 
     docker-compose -f compose.yml -f keycloak-import/compose.yml up --build
 
@@ -71,7 +71,7 @@ Or, you can have multiple terminal windows and start individual component in eac
 
     docker-compose -f compose.yml -f kafka-oauth-strimzi/compose-ssl.yml up --build 
 
-    docker-compose -f keycloak/compose-ssl.yml up
+    docker-compose -f compose.yml -f keycloak/compose-ssl.yml up
 
     docker-compose -f compose.yml -f keycloak-import/compose-ssl.yml up --build
 
@@ -87,7 +87,7 @@ Or, you can have multiple terminal windows and start individual component in eac
 
     docker-compose -f compose.yml -f kafka-oauth-strimzi/compose-hydra.yml up --build 
 
-    docker-compose -f hydra/compose.yml up
+    docker-compose -f compose.yml -f hydra/compose.yml up
 
     docker-compose -f compose.yml -f hydra-import/compose.yml up --build
 
@@ -103,7 +103,7 @@ Or, you can have multiple terminal windows and start individual component in eac
 
     docker-compose -f compose.yml -f kafka-oauth-strimzi/compose-hydra.yml up --build 
 
-    docker-compose -f hydra/compose-with-jwt.yml up
+    docker-compose -f compose.yml -f hydra/compose-with-jwt.yml up
 
     docker-compose -f compose.yml -f hydra-import/compose.yml up --build
 
@@ -118,7 +118,6 @@ Start spring authorization server first:
 Then start the Kafka broker:
     
     docker-compose -f compose.yml -f kafka-oauth-strimzi/compose-spring.yml up --build
-
 
 
 Rebuilding certificates

--- a/examples/docker/kafka-oauth-strimzi/README.md
+++ b/examples/docker/kafka-oauth-strimzi/README.md
@@ -15,20 +15,22 @@ Copy resources to prepare the docker-compose project by running:
 Preparing
 ---------
 
-This demo comes with several configurations using two different OAuth2 authorization servers - Keycloak, and Hydra. 
+This demo comes with several configurations using three different OAuth2 authorization servers - Keycloak, Hydra, and Spring Authorization Server. 
 It is important that all clients access the OAuth2 endpoints using the same url schema, host and port.
  
-First, determine your machine's local network IP address, and add keycloak / hydra entry to your `/etc/host`.
+First, determine your machine's local network IP address, and add keycloak / hydra / spring entry to your `/etc/host`.
 
 You can use `ifconfig` utility. On macOS for example you can run:
 
     ifconfig en0 | grep 'inet ' | awk '{print $2}'
 
-Then, add keycloak / hydra entry to your `/etc/hosts` file 
+Then, add keycloak / hydra / spring entry to your `/etc/hosts` file 
 
     <YOUR_IP_ADDRESS>    keycloak
     <YOUR_IP_ADDRESS>    hydra
+    <YOUR_IP_ADDRESS>    spring
 
+Usually you can simply use `localhost` instead of <YOUR_IP_ADDRESS>.
 
 Before each run you may want to delete any previous instances by using:
 
@@ -74,3 +76,12 @@ From `docker` directory run:
      
 Kafka broker should be available on localhost:9092. It connects to Hydra using `https://hydra:4444`
 
+
+Running using Spring with opaque tokens
+---------------------------------------
+
+From `docker` directory run:
+
+    docker-compose -f compose.yml -f kafka-oauth-strimzi/compose-spring.yml up --build
+    
+Kafka broker should be avaliable on localhost:9092. It connects to Spring Authorization Server using `http://spring:8080`

--- a/examples/docker/kafka-oauth-strimzi/compose-authz.yml
+++ b/examples/docker/kafka-oauth-strimzi/compose-authz.yml
@@ -67,7 +67,7 @@ services:
       # Validation config
       OAUTH_VALID_ISSUER_URI: "http://${KEYCLOAK_HOST:-keycloak}:8080/auth/realms/${REALM:-kafka-authz}"
       OAUTH_JWKS_ENDPOINT_URI: "http://${KEYCLOAK_HOST:-keycloak}:8080/auth/realms/${REALM:-kafka-authz}/protocol/openid-connect/certs"
-      #OAUTH_INTROSPECTION_ENDPOINT_URI: "http://${KEYCLOAK_HOST}:8080/auth/realms/${REALM:-demo}/protocol/openid-connect/token/introspect"
+      #OAUTH_INTROSPECTION_ENDPOINT_URI: "http://${KEYCLOAK_HOST:-keycloak}:8080/auth/realms/${REALM:-demo}/protocol/openid-connect/token/introspect"
 
       # username extraction from JWT token claim
       OAUTH_USERNAME_CLAIM: preferred_username

--- a/examples/docker/kafka-oauth-strimzi/compose-hydra.yml
+++ b/examples/docker/kafka-oauth-strimzi/compose-hydra.yml
@@ -58,6 +58,7 @@ services:
       # Validation config
       OAUTH_VALID_ISSUER_URI: "https://${HYDRA_HOST:-hydra}:4444/"
       OAUTH_INTROSPECTION_ENDPOINT_URI: "https://${HYDRA_HOST:-hydra}:4445/oauth2/introspect"
+      OAUTH_VALID_TOKEN_TYPE: "access_token"
 
       # Truststore config for connecting to secured authorization server
       OAUTH_SSL_TRUSTSTORE_LOCATION: /opt/kafka/config/ca-truststore.p12

--- a/examples/docker/kafka-oauth-strimzi/compose-spring.yml
+++ b/examples/docker/kafka-oauth-strimzi/compose-spring.yml
@@ -1,0 +1,81 @@
+version: '3.5'
+
+services:
+
+  #################################### KAFKA BROKER ####################################
+  kafka:
+    image: strimzi/example-kafka
+    build: kafka-oauth-strimzi/kafka/target
+    container_name: kafka
+    command:
+      - /bin/bash
+      - /opt/kafka/start_with_spring.sh
+    ports:
+      - 9092:9092
+
+      # javaagent debug port
+      - 5005:5005
+
+    environment:
+
+      # Java Debug
+      KAFKA_DEBUG: y
+      DEBUG_SUSPEND_FLAG: y
+      JAVA_DEBUG_PORT: 5005
+
+      #
+      # KAFKA Configuration
+      #
+      LOG_DIR: /home/kafka/logs
+      #KAFKA_LOG_DIRS: /home/kafka/1
+
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_LISTENERS: CLIENT://kafka:9092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CLIENT:SASL_PLAINTEXT
+      KAFKA_SASL_ENABLED_MECHANISMS: OAUTHBEARER
+      KAFKA_INTER_BROKER_LISTENER_NAME: CLIENT
+      KAFKA_SASL_MECHANISM_INTER_BROKER_PROTOCOL: OAUTHBEARER
+
+      KAFKA_LISTENER_NAME_CLIENT_OAUTHBEARER_SASL_JAAS_CONFIG: "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required;"
+      KAFKA_LISTENER_NAME_CLIENT_OAUTHBEARER_SASL_LOGIN_CALLBACK_HANDLER_CLASS: io.strimzi.kafka.oauth.client.JaasClientOauthLoginCallbackHandler
+      KAFKA_LISTENER_NAME_CLIENT_OAUTHBEARER_SASL_SERVER_CALLBACK_HANDLER_CLASS: io.strimzi.kafka.oauth.server.JaasServerOauthValidatorCallbackHandler
+
+      KAFKA_SUPER_USERS: User:service-account-kafka-broker
+
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+
+
+
+      #
+      # Strimzi OAuth Configuration
+      #
+
+      # Authentication config
+      OAUTH_CLIENT_ID: "kafka"
+      OAUTH_CLIENT_SECRET: "kafkasecret"
+      OAUTH_TOKEN_ENDPOINT_URI: "http://${SPRING_HOST:-spring}:8080/oauth/token"
+      OAUTH_SCOPE: "any"
+
+      # Validation config
+      OAUTH_INTROSPECTION_ENDPOINT_URI: "http://${SPRING_HOST:-spring}:8080/oauth/check_token"
+      OAUTH_CHECK_ISSUER: "false"
+      OAUTH_ACCESS_TOKEN_IS_JWT: "false"
+      OAUTH_CHECK_ACCESS_TOKEN_TYPE: "false"
+
+      # username extraction from JWT token claim
+      OAUTH_USERNAME_CLAIM: user_name
+      OAUTH_FALLBACK_USERNAME_CLAIM: client_id
+      OAUTH_FALLBACK_USERNAME_PREFIX: client-account-
+
+      # For start.sh script to know where the keycloak is listening
+      SPRING_HOST: ${SPRING_HOST:-spring}
+
+  zookeeper:
+    image: strimzi/example-zookeeper
+    build: kafka-oauth-strimzi/zookeeper/target
+    container_name: zookeeper
+    ports:
+      - 2181:2181
+    environment:
+      LOG_DIR: /home/kafka/logs

--- a/examples/docker/kafka-oauth-strimzi/compose-spring.yml
+++ b/examples/docker/kafka-oauth-strimzi/compose-spring.yml
@@ -14,14 +14,14 @@ services:
       - 9092:9092
 
       # javaagent debug port
-      - 5005:5005
+      #- 5005:5005
 
     environment:
 
       # Java Debug
-      KAFKA_DEBUG: y
-      DEBUG_SUSPEND_FLAG: y
-      JAVA_DEBUG_PORT: 5005
+      #KAFKA_DEBUG: y
+      #DEBUG_SUSPEND_FLAG: y
+      #JAVA_DEBUG_PORT: 5005
 
       #
       # KAFKA Configuration

--- a/examples/docker/kafka-oauth-strimzi/compose.yml
+++ b/examples/docker/kafka-oauth-strimzi/compose.yml
@@ -56,7 +56,7 @@ services:
       # Validation config
       OAUTH_VALID_ISSUER_URI: "http://${KEYCLOAK_HOST:-keycloak}:8080/auth/realms/${REALM:-demo}"
       OAUTH_JWKS_ENDPOINT_URI: "http://${KEYCLOAK_HOST:-keycloak}:8080/auth/realms/${REALM:-demo}/protocol/openid-connect/certs"
-      #OAUTH_INTROSPECTION_ENDPOINT_URI: "http://${KEYCLOAK_HOST}:8080/auth/realms/${REALM:-demo}/protocol/openid-connect/token/introspect"
+      #OAUTH_INTROSPECTION_ENDPOINT_URI: "http://${KEYCLOAK_HOST:-keycloak}:8080/auth/realms/${REALM:-demo}/protocol/openid-connect/token/introspect"
 
 
       # username extraction from JWT token claim

--- a/examples/docker/kafka-oauth-strimzi/kafka/config/log4j.properties
+++ b/examples/docker/kafka-oauth-strimzi/kafka/config/log4j.properties
@@ -66,7 +66,7 @@ log4j.logger.kafka=INFO
 log4j.logger.org.apache.kafka=INFO
 
 # Control Strimzi OAuth logging
-log4j.logger.io.strimzi=DEBUG
+log4j.logger.io.strimzi=TRACE
 
 # Change to DEBUG or TRACE to enable request logging
 log4j.logger.kafka.request.logger=WARN, requestAppender

--- a/examples/docker/kafka-oauth-strimzi/kafka/pom.xml
+++ b/examples/docker/kafka-oauth-strimzi/kafka/pom.xml
@@ -33,6 +33,7 @@
                                         <include>functions.sh</include>
                                         <include>start.sh</include>
                                         <include>start_with_hydra.sh</include>
+                                        <include>start_with_spring.sh</include>
                                         <include>jwt.sh</include>
                                         <include>oauth.sh</include>
                                         <include>simple_kafka_config.sh</include>

--- a/examples/docker/kafka-oauth-strimzi/kafka/start_with_spring.sh
+++ b/examples/docker/kafka-oauth-strimzi/kafka/start_with_spring.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -e
+
+source functions.sh
+
+#URI=${SPRING_URI}
+#if [ "" == "${URI}" ]; then
+#    URI="http://${SPRING_HOST:-spring}:8080"
+#fi
+
+#wait_for_url $URI "Waiting for Spring Authorization Server to start"
+
+./simple_kafka_config.sh | tee /tmp/strimzi.properties
+
+# add Strimzi kafka-oauth-* jars and their dependencies to classpath
+export CLASSPATH="/opt/kafka/libs/strimzi/*:$CLASSPATH"
+
+exec /opt/kafka/bin/kafka-server-start.sh /tmp/strimzi.properties

--- a/examples/docker/keycloak/compose-ssl.yml
+++ b/examples/docker/keycloak/compose-ssl.yml
@@ -14,3 +14,4 @@ services:
       KEYCLOAK_PASSWORD: "admin"
       KEYCLOAK_HTTPS_PORT: 8443
       PROXY_ADDRESS_FORWARDING: "true"
+    command: "-Dkeycloak.profile.feature.upload_scripts=enabled"

--- a/examples/docker/pom.xml
+++ b/examples/docker/pom.xml
@@ -14,7 +14,7 @@
         <plugins.dependency.version>3.1.1</plugins.dependency.version>
         <plugins.resources.version>3.1.0</plugins.resources.version>
 
-        <keycloak.version>7.0.0</keycloak.version>
+        <keycloak.version>9.0.3</keycloak.version>
         <bouncycastle.version>1.60</bouncycastle.version>
         <strimzi-oauth.version>1.0.0-SNAPSHOT</strimzi-oauth.version>
     </properties>

--- a/examples/docker/pom.xml
+++ b/examples/docker/pom.xml
@@ -96,6 +96,7 @@
 
     <modules>
         <module>kafka-oauth-strimzi</module>
+        <module>spring</module>
     </modules>
 </project>
 

--- a/examples/docker/spring/Dockerfile
+++ b/examples/docker/spring/Dockerfile
@@ -1,0 +1,6 @@
+FROM openjdk:8-jre
+
+ENTRYPOINT ["java", "-jar", "/usr/share/oauth/server.jar"]
+
+ARG JAR_FILE
+ADD target/${JAR_FILE} /usr/share/oauth/server.jar

--- a/examples/docker/spring/README.md
+++ b/examples/docker/spring/README.md
@@ -68,4 +68,3 @@ Configure your Kafka client by obtaining the token as user `user`:
     oauth.scope=any
     oauth.access.token.is.jwt=false
 
-    

--- a/examples/docker/spring/README.md
+++ b/examples/docker/spring/README.md
@@ -13,24 +13,59 @@ Building
 Running
 -------
 
+You can run it by using docker:
+
     docker run --rm -ti --name spring strimzi/example-spring
+
+Or by using docker-compose in which case run it from parent directory (`examples/docker`):
+
+    docker-compose -f compose.yml -f spring/compose.yml up
 
 
 Using
 -----
 
-Configure your kafka-broker with the following settings:
+Make sure to add `spring` entry to your `/etc/hosts` as explained [here](../README.md#preparing).
 
-    oauth.introspection.endpoint.uri=http://localhost:8080/oauth/check-token
+Configure your Kafka broker with the following settings:
+
+    oauth.introspection.endpoint.uri=http://spring:8080/oauth/check_token
+    oauth.token.endpoint.uri=http://spring:8080/oauth/token
     oauth.client.id=kafka
     oauth.client.secret=kafkasecret
+    oauth.scope=any
+    oauth.access.token.is.jwt=false
     oauth.check.issuer=false
-    oauth.check.access.token.type=false
     oauth.username.claim=user_name
-    oauth.failover.username.claim=client_id
-    oauth.failover.username.prefix=client-account-
+    oauth.fallback.username.claim=client_id
+    oauth.fallback.username.prefix=client-account-
 
 
-Configure your Kafka client, by obtaining the token as user
+Spring authorization server by default uses opaque tokens (non-JWT) which means validation has to use the introspection endpoint.
+The example single-broker cluster uses OAuth2 for inter-broker communication as well as Kafka client communication which requires token endpoint to be configured.
+Authorization server's Token endpoint requires `scope` to be specified.
+The Introspection endpoint returns no information about issuer, so we have to disable that check.
+User information is sent depending on the type of authentication. 
+If Kafka client sends a token obtained by a user using `password` grant, then `user_name` attribute 
+of introspection endpoint response contains user's username. If Kafka client sends a token obtained in as the client by using `client_credentials` grant, then no `user_name` is set, but `client_id` is.
+By using username prefix we can quickly differentiate client accounts from user accounts - client_id with the same name as another username will become a different principal.
+We can then use Kafka Simple ACL Authorization to define ACL policies based on authenticated principal.
+
+
+You can run the prepared example from parent directory (`examples/docker`):
+
+    docker-compose -f compose.yml -f kafka-oauth-strimzi/compose-spring.yml
+    
+
+
+Configure your Kafka client by obtaining the token as user `user`:
+
+    curl spring:8080/oauth/token -d "grant_type=password&scope=read&username=user&password=$PASSWORD" -u kafka:kafkasecret
+
+
+    oauth.token.endpoint.uri=http://spring:8080/oauth/token
+    oauth.refresh.token=$REFRESH_TOKEN
+    oauth.scope=any
+    oauth.access.token.is.jwt=false
 
     

--- a/examples/docker/spring/README.md
+++ b/examples/docker/spring/README.md
@@ -1,0 +1,36 @@
+Spring Authorization Server
+===========================
+
+This project builds and runs Spring Authorization Server as a docker container.
+
+
+Building
+--------
+
+    mvn clean install
+
+
+Running
+-------
+
+    docker run --rm -ti --name spring strimzi/example-spring
+
+
+Using
+-----
+
+Configure your kafka-broker with the following settings:
+
+    oauth.introspection.endpoint.uri=http://localhost:8080/oauth/check-token
+    oauth.client.id=kafka
+    oauth.client.secret=kafkasecret
+    oauth.check.issuer=false
+    oauth.check.access.token.type=false
+    oauth.username.claim=user_name
+    oauth.failover.username.claim=client_id
+    oauth.failover.username.prefix=client-account-
+
+
+Configure your Kafka client, by obtaining the token as user
+
+    

--- a/examples/docker/spring/compose.yml
+++ b/examples/docker/spring/compose.yml
@@ -2,7 +2,7 @@ version: '3.5'
 
 services:
 
-  keycloak:
+  spring:
     image: strimzi/example-spring
     container_name: strimzi
     ports:

--- a/examples/docker/spring/compose.yml
+++ b/examples/docker/spring/compose.yml
@@ -1,0 +1,9 @@
+version: '3.5'
+
+services:
+
+  keycloak:
+    image: strimzi/example-spring
+    container_name: strimzi
+    ports:
+      -  8080:8080

--- a/examples/docker/spring/pom.xml
+++ b/examples/docker/spring/pom.xml
@@ -1,0 +1,144 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>2.2.6.RELEASE</version>
+        <relativePath/> <!-- lookup parent from repository -->
+    </parent>
+
+    <groupId>io.strimzi.oauth.docker</groupId>
+    <artifactId>kafka-oauth-docker-spring</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <plugins.dependency.version>3.1.1</plugins.dependency.version>
+        <plugins.resources.version>3.1.0</plugins.resources.version>
+        <plugins.spotify.version>1.4.13</plugins.spotify.version>
+    </properties>
+
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+        </license>
+    </licenses>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.security.oauth</groupId>
+                <artifactId>spring-security-oauth2</artifactId>
+                <version>2.4.0.RELEASE</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.security.oauth.boot</groupId>
+                <artifactId>spring-security-oauth2-autoconfigure</artifactId>
+                <version>2.2.6.RELEASE</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.security</groupId>
+                <artifactId>spring-security-jwt</artifactId>
+                <version>1.1.0.RELEASE</version>
+            </dependency>
+            <dependency>
+                <groupId>com.nimbusds</groupId>
+                <artifactId>nimbus-jose-jwt</artifactId>
+                <version>8.14.1</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.security.oauth</groupId>
+            <artifactId>spring-security-oauth2</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security.oauth.boot</groupId>
+            <artifactId>spring-security-oauth2-autoconfigure</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-jwt</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-resources-plugin</artifactId>
+                    <version>${plugins.resources.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>com.spotify</groupId>
+                    <artifactId>dockerfile-maven-plugin</artifactId>
+                    <version>${plugins.spotify.version}</version>
+                </plugin>
+
+            </plugins>
+        </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>${plugins.dependency.version}</version>
+                <executions>
+                    <execution>
+                        <id>analyze-deps</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>analyze-only</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>com.spotify</groupId>
+                <artifactId>dockerfile-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default</id>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <repository>strimzi/example-spring</repository>
+                    <tag>latest</tag>
+                    <buildArgs>
+                        <JAR_FILE>${project.build.finalName}.jar</JAR_FILE>
+                    </buildArgs>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>
+

--- a/examples/docker/spring/pom.xml
+++ b/examples/docker/spring/pom.xml
@@ -20,6 +20,8 @@
         <plugins.dependency.version>3.1.1</plugins.dependency.version>
         <plugins.resources.version>3.1.0</plugins.resources.version>
         <plugins.spotify.version>1.4.13</plugins.spotify.version>
+        <spring.boot.version>2.2.6.RELEASE</spring.boot.version>
+        <spring.oauth2.version>2.4.0.RELEASE</spring.oauth2.version>
     </properties>
 
     <licenses>
@@ -34,46 +36,33 @@
             <dependency>
                 <groupId>org.springframework.security.oauth</groupId>
                 <artifactId>spring-security-oauth2</artifactId>
-                <version>2.4.0.RELEASE</version>
+                <version>${spring.oauth2.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.springframework.security.oauth.boot</groupId>
-                <artifactId>spring-security-oauth2-autoconfigure</artifactId>
-                <version>2.2.6.RELEASE</version>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot</artifactId>
+                <version>${spring.boot.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.springframework.security</groupId>
-                <artifactId>spring-security-jwt</artifactId>
-                <version>1.1.0.RELEASE</version>
-            </dependency>
-            <dependency>
-                <groupId>com.nimbusds</groupId>
-                <artifactId>nimbus-jose-jwt</artifactId>
-                <version>8.14.1</version>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-autoconfigure</artifactId>
+                <version>${spring.boot.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
 
     <dependencies>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-autoconfigure</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.security.oauth</groupId>
             <artifactId>spring-security-oauth2</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.security.oauth.boot</groupId>
-            <artifactId>spring-security-oauth2-autoconfigure</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.security</groupId>
-            <artifactId>spring-security-jwt</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-security</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
     </dependencies>
 

--- a/examples/docker/spring/pom.xml
+++ b/examples/docker/spring/pom.xml
@@ -21,7 +21,6 @@
         <plugins.resources.version>3.1.0</plugins.resources.version>
         <plugins.spotify.version>1.4.13</plugins.spotify.version>
         <spring.boot.version>2.2.6.RELEASE</spring.boot.version>
-        <spring.oauth2.version>2.4.0.RELEASE</spring.oauth2.version>
     </properties>
 
     <licenses>
@@ -34,18 +33,8 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>org.springframework.security.oauth</groupId>
-                <artifactId>spring-security-oauth2</artifactId>
-                <version>${spring.oauth2.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot</artifactId>
-                <version>${spring.boot.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-autoconfigure</artifactId>
+                <groupId>org.springframework.security.oauth.boot</groupId>
+                <artifactId>spring-security-oauth2-autoconfigure</artifactId>
                 <version>${spring.boot.version}</version>
             </dependency>
         </dependencies>
@@ -53,16 +42,12 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot</artifactId>
+            <groupId>org.springframework.security.oauth.boot</groupId>
+            <artifactId>spring-security-oauth2-autoconfigure</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-autoconfigure</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.security.oauth</groupId>
-            <artifactId>spring-security-oauth2</artifactId>
+            <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
     </dependencies>
 

--- a/examples/docker/spring/src/main/java/io/strimzi/examples/spring/SimpleAuthorizationServerApplication.java
+++ b/examples/docker/spring/src/main/java/io/strimzi/examples/spring/SimpleAuthorizationServerApplication.java
@@ -1,0 +1,13 @@
+package io.strimzi.examples.spring;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.security.oauth2.config.annotation.web.configuration.EnableAuthorizationServer;
+
+@EnableAuthorizationServer
+@SpringBootApplication
+public class SimpleAuthorizationServerApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(SimpleAuthorizationServerApplication.class, args);
+    }
+}

--- a/examples/docker/spring/src/main/resources/application.yml
+++ b/examples/docker/spring/src/main/resources/application.yml
@@ -1,0 +1,7 @@
+security:
+  oauth2:
+    authorization:
+      check-token-access: isAuthenticated()
+    client:
+      client-id: kafka
+      client-secret: kafkasecret

--- a/examples/kubernetes/README.md
+++ b/examples/kubernetes/README.md
@@ -39,7 +39,7 @@ Deploy the Keycloak server:
 Wait for Keycloak to start up:
 
     kubectl get pod
-    kubectl logs $(kubectl get pod | grep keycloak | awk '{print $1}')
+    kubectl logs $(kubectl get pod | grep keycloak | awk '{print $1}') -f
 
 In order to connect to Keycloak Admin Console you need an ip address and a port where it is listening. From the point of view of the Keycloak pod it is listening on port 8080 on all the interfaces. The `NodePort` service also exposes a port on the Kubernetes Node's IP:
 

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/Config.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/Config.java
@@ -11,7 +11,10 @@ public class Config {
 
     public static final String OAUTH_CLIENT_ID = "oauth.client.id";
     public static final String OAUTH_CLIENT_SECRET = "oauth.client.secret";
+    public static final String OAUTH_SCOPE = "oauth.scope";
     public static final String OAUTH_USERNAME_CLAIM = "oauth.username.claim";
+    public static final String OAUTH_FALLBACK_USERNAME_CLAIM = "oauth.fallback.username.claim";
+    public static final String OAUTH_FALLBACK_USERNAME_PREFIX = "oauth.fallback.username.prefix";
     public static final String OAUTH_SSL_TRUSTSTORE_LOCATION = "oauth.ssl.truststore.location";
     public static final String OAUTH_SSL_TRUSTSTORE_PASSWORD = "oauth.ssl.truststore.password";
     public static final String OAUTH_SSL_TRUSTSTORE_TYPE = "oauth.ssl.truststore.type";

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/HttpUtil.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/HttpUtil.java
@@ -11,6 +11,7 @@ import org.slf4j.LoggerFactory;
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLSocketFactory;
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -153,7 +154,15 @@ public class HttpUtil {
                 response.close();
                 return null;
             }
-            return JSONUtil.readJSON(response, responseType);
+            InputStream is = response;
+            if (log.isTraceEnabled()) {
+                ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+                IOUtil.copy(response, buffer);
+                log.trace("Response body: " + buffer.toString("utf-8"));
+
+                is = new ByteArrayInputStream(buffer.toByteArray());
+            }
+            return JSONUtil.readJSON(is, responseType);
         }
 
         // Don't call con.disconnect() in order to allow connection reuse.

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/HttpUtil.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/HttpUtil.java
@@ -158,7 +158,7 @@ public class HttpUtil {
             if (log.isTraceEnabled()) {
                 ByteArrayOutputStream buffer = new ByteArrayOutputStream();
                 IOUtil.copy(response, buffer);
-                log.trace("Response body: " + buffer.toString("utf-8"));
+                log.trace("Response body for " + method + " " + uri + ": " + buffer.toString("utf-8"));
 
                 is = new ByteArrayInputStream(buffer.toByteArray());
             }

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/JSONUtil.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/JSONUtil.java
@@ -11,6 +11,7 @@ import org.keycloak.util.JsonSerialization;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 
@@ -72,19 +73,27 @@ public class JSONUtil {
     }
 
     public static List<String> asListOfString(JsonNode arrayNode) {
-        if (!arrayNode.isArray()) {
-            throw new IllegalArgumentException("JsonNode not an array node: " + arrayNode);
-        }
+
         ArrayList<String> result = new ArrayList<>();
-        Iterator<JsonNode> it = arrayNode.iterator();
-        while (it.hasNext()) {
-            JsonNode n = it.next();
-            if (n.isTextual()) {
-                result.add(n.asText());
-            } else {
-                result.add(n.toString());
+
+        if (arrayNode.isTextual()) {
+            result.addAll(Arrays.asList(arrayNode.asText().split(" ")));
+        } else {
+            if (!arrayNode.isArray()) {
+                throw new IllegalArgumentException("JsonNode not a text node, nor an array node: " + arrayNode);
+            }
+
+            Iterator<JsonNode> it = arrayNode.iterator();
+            while (it.hasNext()) {
+                JsonNode n = it.next();
+                if (n.isTextual()) {
+                    result.add(n.asText());
+                } else {
+                    result.add(n.toString());
+                }
             }
         }
+
         return result;
     }
 }

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/PrincipalExtractor.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/PrincipalExtractor.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2017-2020, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.kafka.oauth.common;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.keycloak.jose.jws.JWSInput;
+import org.keycloak.representations.AccessToken;
+
+import static io.strimzi.kafka.oauth.common.JSONUtil.getClaimFromJWT;
+
+public class PrincipalExtractor {
+
+    private String usernameClaim;
+    private String fallbackUsernameClaim;
+    private String fallbackUsernamePrefix;
+
+    public PrincipalExtractor() {}
+
+    public PrincipalExtractor(String usernameClaim, String fallbackUsernameClaim, String fallbackUsernamePrefix) {
+        this.usernameClaim = usernameClaim;
+        this.fallbackUsernameClaim = fallbackUsernameClaim;
+        this.fallbackUsernamePrefix = fallbackUsernamePrefix;
+    }
+
+    public String getPrincipal(AccessToken token, JWSInput jws) {
+        if (usernameClaim != null) {
+            try {
+                return getPrincipal(jws.readJsonContent(JsonNode.class));
+            } catch (Exception e) {
+                throw new RuntimeException("Failed to parse access token", e);
+            }
+        }
+        return token.getSubject();
+    }
+
+    public String getPrincipal(JsonNode json) {
+        String result;
+
+        if (usernameClaim != null) {
+            result = getClaimFromJWT(json, usernameClaim);
+            if (result != null) {
+                return result;
+            }
+
+            if (fallbackUsernameClaim != null) {
+                result = getClaimFromJWT(json, fallbackUsernameClaim);
+                if (result != null) {
+                    return fallbackUsernamePrefix == null ? result : fallbackUsernamePrefix + result;
+                }
+            }
+        }
+
+        return getClaimFromJWT(json, "sub");
+    }
+
+    @Override
+    public String toString() {
+        return "PrincipalExtractor {usernameClaim: " + usernameClaim  + ", fallbackUsernameClaim: " + fallbackUsernameClaim + ", fallbackUsernamePrefix: " + fallbackUsernamePrefix + "}";
+    }
+
+    public boolean isConfigured() {
+        return usernameClaim != null || fallbackUsernameClaim != null || fallbackUsernamePrefix != null;
+    }
+}

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/PrincipalExtractor.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/PrincipalExtractor.java
@@ -32,7 +32,7 @@ public class PrincipalExtractor {
                 throw new RuntimeException("Failed to parse access token", e);
             }
         }
-        return token.getSubject();
+        return null;
     }
 
     public String getPrincipal(JsonNode json) {
@@ -52,6 +52,14 @@ public class PrincipalExtractor {
             }
         }
 
+        return null;
+    }
+
+    public String getSub(AccessToken token) {
+        return token.getSubject();
+    }
+
+    public String getSub(JsonNode json) {
         return getClaimFromJWT(json, "sub");
     }
 

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/TokenInfo.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/TokenInfo.java
@@ -23,8 +23,8 @@ public class TokenInfo {
         this(token,
                 payload.getScope(),
                 payload.getSubject(),
-                payload.getIssuedAt() * 1000L,
-                payload.getExpiration() * 1000L);
+                payload.getIat() == null ? 0 : payload.getIat() * 1000L,
+                payload.getExp() == null ? 0 : payload.getExp() * 1000L);
         this.payload = payload;
     }
 

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/TokenInfo.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/TokenInfo.java
@@ -15,22 +15,22 @@ public class TokenInfo {
     private String token;
     private Set<String> scopes = new HashSet<>();
     private long expiresAt;
-    private String subject;
+    private String principal;
     private long issuedAt;
     private AccessToken payload;
 
-    public TokenInfo(AccessToken payload, String token) {
+    public TokenInfo(AccessToken payload, String token, String principal) {
         this(token,
                 payload.getScope(),
-                payload.getSubject(),
+                principal,
                 payload.getIat() == null ? 0 : payload.getIat() * 1000L,
                 payload.getExp() == null ? 0 : payload.getExp() * 1000L);
         this.payload = payload;
     }
 
-    public TokenInfo(String token, String scope, String subject, long issuedAtMs, long expiresAtMs) {
+    public TokenInfo(String token, String scope, String principal, long issuedAtMs, long expiresAtMs) {
         this.token = token;
-        this.subject = subject;
+        this.principal = principal;
         this.issuedAt = issuedAtMs;
         this.expiresAt = expiresAtMs;
 
@@ -53,8 +53,8 @@ public class TokenInfo {
         return expiresAt;
     }
 
-    public String subject() {
-        return subject;
+    public String principal() {
+        return principal;
     }
 
     public long issuedAtMs() {

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/TokenIntrospection.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/TokenIntrospection.java
@@ -25,7 +25,11 @@ public class TokenIntrospection {
                 principalExtractor = new PrincipalExtractor();
             }
 
-            return new TokenInfo(parsed, token, principalExtractor.getPrincipal(parsed, jws));
+            String principal = principalExtractor.getPrincipal(parsed, jws);
+            if (principal == null) {
+                principal = principalExtractor.getSub(parsed);
+            }
+            return new TokenInfo(parsed, token, principal);
 
         } catch (Exception e) {
             throw new RuntimeException("Failed to read payload from JWT access token", e);

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/TokenIntrospection.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/TokenIntrospection.java
@@ -10,7 +10,7 @@ import org.keycloak.representations.AccessToken;
 
 public class TokenIntrospection {
 
-    public static TokenInfo introspectAccessToken(String token) {
+    public static TokenInfo introspectAccessToken(String token, PrincipalExtractor principalExtractor) {
         JWSInput jws;
         try {
             jws = new JWSInput(token);
@@ -20,7 +20,12 @@ public class TokenIntrospection {
 
         try {
             AccessToken parsed = jws.readJsonContent(AccessToken.class);
-            return new TokenInfo(parsed, token);
+
+            if (principalExtractor == null) {
+                principalExtractor = new PrincipalExtractor();
+            }
+
+            return new TokenInfo(parsed, token, principalExtractor.getPrincipal(parsed, jws));
 
         } catch (Exception e) {
             throw new RuntimeException("Failed to read payload from JWT access token", e);

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/validator/JWTSignatureValidator.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/validator/JWTSignatureValidator.java
@@ -234,9 +234,15 @@ public class JWTSignatureValidator implements TokenValidator {
                     TimeUtil.formatIsoDateTimeUTC(expiresMillis) + ")");
         }
 
-        String principal = principalExtractor.getPrincipal(JSONUtil.asJson(t));
+        String principal = null;
+        if (principalExtractor.isConfigured()) {
+            principal = principalExtractor.getPrincipal(JSONUtil.asJson(t));
+        }
+        if (principal == null && !principalExtractor.isConfigured()) {
+            principal = principalExtractor.getSub(t);
+        }
         if (principal == null) {
-            throw new RuntimeException("Failed to extract principal: principal == null    (check usernameClaim, fallbackUsernameClaim configuration)");
+            throw new RuntimeException("Failed to extract principal - check usernameClaim, fallbackUsernameClaim configuration");
         }
         return new TokenInfo(t, token, principal);
     }

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/validator/JWTSignatureValidator.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/validator/JWTSignatureValidator.java
@@ -6,6 +6,8 @@ package io.strimzi.kafka.oauth.validator;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.strimzi.kafka.oauth.common.HttpUtil;
+import io.strimzi.kafka.oauth.common.JSONUtil;
+import io.strimzi.kafka.oauth.common.PrincipalExtractor;
 import io.strimzi.kafka.oauth.common.TimeUtil;
 import io.strimzi.kafka.oauth.common.TokenInfo;
 import org.apache.kafka.common.utils.Time;
@@ -18,6 +20,7 @@ import org.keycloak.jose.jwk.JSONWebKeySet;
 import org.keycloak.jose.jwk.JWK;
 import org.keycloak.representations.AccessToken;
 import org.keycloak.util.JWKSUtils;
+import org.keycloak.util.TokenUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,8 +40,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static io.strimzi.kafka.oauth.validator.TokenValidationException.Status;
-import static org.keycloak.TokenVerifier.IS_ACTIVE;
-import static org.keycloak.TokenVerifier.SUBJECT_EXISTS_CHECK;
 
 public class JWTSignatureValidator implements TokenValidator {
 
@@ -46,16 +47,18 @@ public class JWTSignatureValidator implements TokenValidator {
 
     private static AtomicBoolean bouncyInstalled =  new AtomicBoolean(false);
 
+    private static final TokenVerifier.TokenTypeCheck TOKEN_TYPE_CHECK = new TokenVerifier.TokenTypeCheck(TokenUtil.TOKEN_TYPE_BEARER);
+
     private final ScheduledExecutorService scheduler;
 
     private final URI keysUri;
     private final String issuerUri;
     private final int maxStaleSeconds;
-    private final boolean defaultChecks;
     private final boolean checkAccessTokenType;
     private final String audience;
     private final SSLSocketFactory socketFactory;
     private final HostnameVerifier hostnameVerifier;
+    private final PrincipalExtractor principalExtractor;
 
     private long lastFetchTime;
 
@@ -65,10 +68,10 @@ public class JWTSignatureValidator implements TokenValidator {
     public JWTSignatureValidator(String keysEndpointUri,
                                  SSLSocketFactory socketFactory,
                                  HostnameVerifier verifier,
+                                 PrincipalExtractor principalExtractor,
                                  String validIssuerUri,
                                  int refreshSeconds,
                                  int expirySeconds,
-                                 boolean defaultChecks,
                                  boolean checkAccessTokenType,
                                  String audience,
                                  boolean enableBouncyCastleProvider,
@@ -93,8 +96,14 @@ public class JWTSignatureValidator implements TokenValidator {
         }
         this.hostnameVerifier = verifier;
 
-        if (validIssuerUri == null) {
-            throw new IllegalArgumentException("validIssuerUri == null");
+        this.principalExtractor = principalExtractor;
+
+        if (validIssuerUri != null) {
+            try {
+                new URI(validIssuerUri);
+            } catch (URISyntaxException e) {
+                throw new IllegalArgumentException("Value of validIssuerUri not a valid URI: " + validIssuerUri, e);
+            }
         }
         this.issuerUri = validIssuerUri;
 
@@ -103,7 +112,6 @@ public class JWTSignatureValidator implements TokenValidator {
         }
         this.maxStaleSeconds = expirySeconds;
 
-        this.defaultChecks = defaultChecks;
         this.checkAccessTokenType = checkAccessTokenType;
         this.audience = audience;
 
@@ -132,6 +140,7 @@ public class JWTSignatureValidator implements TokenValidator {
             log.debug("Configured JWTSignatureValidator:\n    keysEndpointUri: " + keysEndpointUri
                     + "\n    sslSocketFactory: " + socketFactory
                     + "\n    hostnameVerifier: " + hostnameVerifier
+                    + "\n    principalExtractor: " + principalExtractor
                     + "\n    validIssuerUri: " + validIssuerUri
                     + "\n    certsRefreshSeconds: " + refreshSeconds
                     + "\n    certsExpirySeconds: " + expirySeconds
@@ -174,13 +183,14 @@ public class JWTSignatureValidator implements TokenValidator {
     public TokenInfo validate(String token) {
         TokenVerifier<AccessToken> tokenVerifier = TokenVerifier.create(token, AccessToken.class);
 
-        if (defaultChecks) {
-            if (!checkAccessTokenType) {
-                tokenVerifier.withChecks(SUBJECT_EXISTS_CHECK, IS_ACTIVE);
-            } else {
-                tokenVerifier.withDefaultChecks();
-            }
+        if (issuerUri != null) {
             tokenVerifier.realmUrl(issuerUri);
+        }
+        if (checkAccessTokenType) {
+            tokenVerifier.withChecks(TOKEN_TYPE_CHECK);
+        }
+        if (audience != null) {
+            tokenVerifier.audience(audience);
         }
 
         String kid = null;
@@ -189,10 +199,6 @@ public class JWTSignatureValidator implements TokenValidator {
         } catch (Exception e) {
             throw new TokenValidationException("Token signature validation failed: " + token, e)
                     .status(Status.INVALID_TOKEN);
-        }
-
-        if (audience != null) {
-            tokenVerifier.audience(audience);
         }
 
         AccessToken t;
@@ -222,14 +228,17 @@ public class JWTSignatureValidator implements TokenValidator {
             throw new TokenValidationException("Token validation failed:", e);
         }
 
-
         long expiresMillis = t.getExpiration() * 1000L;
         if (Time.SYSTEM.milliseconds() > expiresMillis) {
             throw new TokenExpiredException("Token expired at: " + expiresMillis + " (" +
                     TimeUtil.formatIsoDateTimeUTC(expiresMillis) + ")");
         }
 
-        return new TokenInfo(t, token);
+        String principal = principalExtractor.getPrincipal(JSONUtil.asJson(t));
+        if (principal == null) {
+            throw new RuntimeException("Failed to extract principal: principal == null    (check usernameClaim, fallbackUsernameClaim configuration)");
+        }
+        return new TokenInfo(t, token, principal);
     }
 
     private static boolean isAlgorithmEC(String algorithm) {

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/validator/OAuthIntrospectionValidator.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/validator/OAuthIntrospectionValidator.java
@@ -20,6 +20,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 
 import static io.strimzi.kafka.oauth.common.HttpUtil.post;
+import static io.strimzi.kafka.oauth.common.HttpUtil.get;
 import static io.strimzi.kafka.oauth.common.LogUtil.mask;
 import static io.strimzi.kafka.oauth.common.OAuthAuthenticator.base64encode;
 import static io.strimzi.kafka.oauth.validator.TokenValidationException.Status;
@@ -30,7 +31,7 @@ public class OAuthIntrospectionValidator implements TokenValidator {
 
     private final URI introspectionURI;
     private final String validIssuerURI;
-    private final String userInfoURI;
+    private final URI userInfoURI;
     private final String validTokenType;
     private final String clientId;
     private final String clientSecret;
@@ -70,7 +71,7 @@ public class OAuthIntrospectionValidator implements TokenValidator {
         }
         this.hostnameVerifier = verifier;
 
-        this.principalExtractor = principalExtractor;
+        this.principalExtractor = principalExtractor != null ? principalExtractor : new PrincipalExtractor();
 
         if (issuerUri != null) {
             try {
@@ -83,12 +84,13 @@ public class OAuthIntrospectionValidator implements TokenValidator {
 
         if (userInfoUri != null) {
             try {
-                new URI(userInfoUri);
+                this.userInfoURI = new URI(userInfoUri);
             } catch (URISyntaxException e) {
                 throw new IllegalArgumentException("Invalid userInfo uri: " + userInfoUri, e);
             }
+        } else {
+            this.userInfoURI = null;
         }
-        this.userInfoURI = userInfoUri;
 
         this.validTokenType = validTokenType;
         this.clientId = clientId;
@@ -154,18 +156,13 @@ public class OAuthIntrospectionValidator implements TokenValidator {
         String principal = principalExtractor.getPrincipal(response);
         if (principal == null) {
             if (userInfoURI != null) {
-                authorization = "Bearer " + token;
-                try {
-                    response = post(introspectionURI, socketFactory, hostnameVerifier, authorization,
-                            "application/x-www-form-urlencoded", body.toString(), JsonNode.class);
-                } catch (IOException e) {
-                    throw new RuntimeException("Failed to introspect token - send, fetch or parse failed: ", e);
-                }
-                // apply principalExtractor
-                principal = principalExtractor.getPrincipal(response);
+                principal = getPrincipalFromUserInfoEndpoint(token);
+            }
+            if (principal == null && !principalExtractor.isConfigured()) {
+                principal = principalExtractor.getSub(response);
             }
             if (principal == null) {
-                throw new RuntimeException("Failed to extract principal: principal == null    (check usernameClaim, fallbackUsernameClaim configuration)");
+                throw new RuntimeException("Failed to extract principal - check usernameClaim, fallbackUsernameClaim configuration");
             }
         }
         performOptionalChecks(response);
@@ -174,6 +171,23 @@ public class OAuthIntrospectionValidator implements TokenValidator {
         String scopes = value != null ? String.join(" ", JSONUtil.asListOfString(value)) : null;
 
         return new TokenInfo(token, scopes, principal, iat, expiresMillis);
+    }
+
+    String getPrincipalFromUserInfoEndpoint(String token) {
+        String authorization = "Bearer " + token;
+        JsonNode response;
+        try {
+            response = get(userInfoURI, socketFactory, hostnameVerifier, authorization, JsonNode.class);
+        } catch (IOException e) {
+            throw new RuntimeException("Request to User Info Endpoint failed: ", e);
+        }
+        // apply principalExtractor
+        String principal = principalExtractor.getPrincipal(response);
+
+        if (principal == null && !principalExtractor.isConfigured()) {
+            principal = principalExtractor.getSub(response);
+        }
+        return principal;
     }
 
     private void performOptionalChecks(JsonNode response) {

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/validator/OAuthIntrospectionValidator.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/validator/OAuthIntrospectionValidator.java
@@ -31,7 +31,7 @@ public class OAuthIntrospectionValidator implements TokenValidator {
     private final URI introspectionURI;
     private final String validIssuerURI;
     private final String userInfoURI;
-    private final boolean checkTokenType;
+    private final String validTokenType;
     private final String clientId;
     private final String clientSecret;
     private final String audience;
@@ -45,7 +45,7 @@ public class OAuthIntrospectionValidator implements TokenValidator {
                                        PrincipalExtractor principalExtractor,
                                        String issuerUri,
                                        String userInfoUri,
-                                       boolean checkTokenType,
+                                       String validTokenType,
                                        String clientId,
                                        String clientSecret,
                                        String audience) {
@@ -90,7 +90,7 @@ public class OAuthIntrospectionValidator implements TokenValidator {
         }
         this.userInfoURI = userInfoUri;
 
-        this.checkTokenType = checkTokenType;
+        this.validTokenType = validTokenType;
         this.clientId = clientId;
         this.clientSecret = clientSecret;
         this.audience = audience;
@@ -102,7 +102,7 @@ public class OAuthIntrospectionValidator implements TokenValidator {
                     + "\n    principalExtractor: " + principalExtractor
                     + "\n    validIssuerUri: " + validIssuerURI
                     + "\n    userInfoUri: " + userInfoURI
-                    + "\n    checkTokenType: " + checkTokenType
+                    + "\n    validTokenType: " + validTokenType
                     + "\n    clientId: " + clientId
                     + "\n    clientSecret: " + mask(clientSecret));
         }
@@ -186,10 +186,10 @@ public class OAuthIntrospectionValidator implements TokenValidator {
             }
         }
 
-        if (checkTokenType) {
+        if (validTokenType != null) {
             value = response.get("token_type");
-            if (value != null && !"Bearer".equalsIgnoreCase(value.asText())) {
-                throw new TokenValidationException("Token check failed - invalid token type: " + value + " (should be 'Bearer')" + (value == null ? ". Consider setting OAUTH_CHECK_ACCESS_TOKEN_TYPE to false." : ""))
+            if (value == null || !validTokenType.equals(value.asText())) {
+                throw new TokenValidationException("Token check failed - invalid token type: " + value + " (should be '" + validTokenType + "')" + (value == null ? ". Consider not setting OAUTH_VALID_TOKEN_TYPE." : ""))
                         .status(Status.UNSUPPORTED_TOKEN_TYPE);
             }
         }

--- a/oauth-keycloak-authorizer/src/main/java/io/strimzi/kafka/oauth/server/authorizer/KeycloakRBACAuthorizer.java
+++ b/oauth-keycloak-authorizer/src/main/java/io/strimzi/kafka/oauth/server/authorizer/KeycloakRBACAuthorizer.java
@@ -341,7 +341,7 @@ public class KeycloakRBACAuthorizer extends kafka.security.auth.SimpleAclAuthori
 
                     if (grantedScopes.isGranted(operation.name())) {
                         if (GRANT_LOG.isDebugEnabled()) {
-                            GRANT_LOG.debug("Authorization GRANTED - cluster: " + clusterName + ",user: " + session.principal() + ", operation: " + operation +
+                            GRANT_LOG.debug("Authorization GRANTED - cluster: " + clusterName + ", user: " + session.principal() + ", operation: " + operation +
                                     ", resource: " + resource + "\nGranted scopes for resource (" + resourceSpec + "): " + grantedScopes);
                         }
                         return true;
@@ -387,7 +387,7 @@ public class KeycloakRBACAuthorizer extends kafka.security.auth.SimpleAclAuthori
 
         if (DENY_LOG.isDebugEnabled()) {
             DENY_LOG.debug("Authorization DENIED -" + nonAuthMessageFragment + " user: " + session.principal() +
-                    " cluster: " + clusterName + ", operation: " + operation + ", resource: " + resource + "\n permissions: " + authz);
+                    ", cluster: " + clusterName + ", operation: " + operation + ", resource: " + resource + ",\n permissions: " + authz);
         }
         return false;
     }

--- a/oauth-server/src/main/java/io/strimzi/kafka/oauth/server/JaasServerOauthValidatorCallbackHandler.java
+++ b/oauth-server/src/main/java/io/strimzi/kafka/oauth/server/JaasServerOauthValidatorCallbackHandler.java
@@ -269,7 +269,7 @@ public class JaasServerOauthValidatorCallbackHandler implements AuthenticateCall
 
         try {
             AccessToken t = parser.readJsonContent(AccessToken.class);
-            log.debug("Access token expires at (UTC): " + LocalDateTime.ofEpochSecond(t.getExpiration(), 0, ZoneOffset.UTC).format(DateTimeFormatter.ISO_DATE_TIME));
+            log.debug("Access token expires at (UTC): " + LocalDateTime.ofEpochSecond(t.getExp() == null ? 0 : t.getExp(), 0, ZoneOffset.UTC).format(DateTimeFormatter.ISO_DATE_TIME));
         } catch (JWSInputException e) {
             // Try parse as refresh token:
             log.debug("[IGNORED] Failed to parse JWT token's payload", e);

--- a/oauth-server/src/main/java/io/strimzi/kafka/oauth/server/JaasServerOauthValidatorCallbackHandler.java
+++ b/oauth-server/src/main/java/io/strimzi/kafka/oauth/server/JaasServerOauthValidatorCallbackHandler.java
@@ -176,47 +176,7 @@ public class JaasServerOauthValidatorCallbackHandler implements AuthenticateCall
 
         try {
             TokenInfo ti = validateToken(token);
-
-            callback.token(new BearerTokenWithPayload() {
-
-                private Object payload;
-
-                @Override
-                public Object getPayload() {
-                    return payload;
-                }
-
-                @Override
-                public void setPayload(Object value) {
-                    payload = value;
-                }
-
-                @Override
-                public String value() {
-                    return ti.token();
-                }
-
-                @Override
-                public Set<String> scope() {
-                    return ti.scope();
-                }
-
-                @Override
-                public long lifetimeMs() {
-                    return ti.expiresAtMs();
-                }
-
-                @Override
-                public String principalName() {
-                    return ti.principal();
-                }
-
-                @Override
-                public Long startTimeMs() {
-                    return ti.issuedAtMs();
-                }
-
-            });
+            callback.token(new BearerTokenWithPayloadImpl(ti));
 
         } catch (TokenValidationException e) {
             if (log.isDebugEnabled()) {
@@ -278,6 +238,51 @@ public class JaasServerOauthValidatorCallbackHandler implements AuthenticateCall
         } catch (JWSInputException e) {
             // Try parse as refresh token:
             log.debug("[IGNORED] Failed to parse JWT token's payload", e);
+        }
+    }
+
+    static class BearerTokenWithPayloadImpl implements BearerTokenWithPayload {
+
+        private final TokenInfo ti;
+        private Object payload;
+
+        BearerTokenWithPayloadImpl(TokenInfo ti) {
+            this.ti = ti;
+        }
+
+        @Override
+        public Object getPayload() {
+            return payload;
+        }
+
+        @Override
+        public void setPayload(Object value) {
+            payload = value;
+        }
+
+        @Override
+        public String value() {
+            return ti.token();
+        }
+
+        @Override
+        public Set<String> scope() {
+            return ti.scope();
+        }
+
+        @Override
+        public long lifetimeMs() {
+            return ti.expiresAtMs();
+        }
+
+        @Override
+        public String principalName() {
+            return ti.principal();
+        }
+
+        @Override
+        public Long startTimeMs() {
+            return ti.issuedAtMs();
         }
     }
 }

--- a/oauth-server/src/main/java/io/strimzi/kafka/oauth/server/JaasServerOauthValidatorCallbackHandler.java
+++ b/oauth-server/src/main/java/io/strimzi/kafka/oauth/server/JaasServerOauthValidatorCallbackHandler.java
@@ -86,10 +86,22 @@ public class JaasServerOauthValidatorCallbackHandler implements AuthenticateCall
 
         boolean checkTokenType = isCheckAccessTokenType(config);
 
+        String usernameClaim = config.getValue(Config.OAUTH_USERNAME_CLAIM);
+        String fallbackUsernameClaim = config.getValue(Config.OAUTH_FALLBACK_USERNAME_CLAIM);
+        String fallbackUsernamePrefix = config.getValue(Config.OAUTH_FALLBACK_USERNAME_PREFIX);
+
+        if (fallbackUsernameClaim != null && usernameClaim == null) {
+            throw new RuntimeException("OAuth validator configuration error: OAUTH_USERNAME_CLAIM must be set when OAUTH_FALLBACK_USERNAME_CLAIM is set");
+        }
+
+        if (fallbackUsernamePrefix != null && fallbackUsernameClaim == null) {
+            throw new RuntimeException("OAuth validator configuration error: OAUTH_FALLBACK_USERNAME_CLAIM must be set when OAUTH_FALLBACK_USERNAME_PREFIX is set");
+        }
+
         PrincipalExtractor principalExtractor = new PrincipalExtractor(
-                config.getValue(Config.OAUTH_USERNAME_CLAIM),
-                config.getValue(Config.OAUTH_FALLBACK_USERNAME_CLAIM),
-                config.getValue(Config.OAUTH_FALLBACK_USERNAME_PREFIX));
+                usernameClaim,
+                fallbackUsernameClaim,
+                fallbackUsernamePrefix);
 
         if (jwksUri != null) {
             validator = new JWTSignatureValidator(

--- a/oauth-server/src/main/java/io/strimzi/kafka/oauth/server/JaasServerOauthValidatorCallbackHandler.java
+++ b/oauth-server/src/main/java/io/strimzi/kafka/oauth/server/JaasServerOauthValidatorCallbackHandler.java
@@ -113,7 +113,7 @@ public class JaasServerOauthValidatorCallbackHandler implements AuthenticateCall
                     principalExtractor,
                     validIssuerUri,
                     config.getValue(ServerConfig.OAUTH_USERINFO_ENDPOINT_URI),
-                    checkTokenType,
+                    config.getValue(ServerConfig.OAUTH_VALID_TOKEN_TYPE),
                     config.getValue(Config.OAUTH_CLIENT_ID),
                     config.getValue(Config.OAUTH_CLIENT_SECRET),
                     null

--- a/oauth-server/src/main/java/io/strimzi/kafka/oauth/server/JaasServerOauthValidatorCallbackHandler.java
+++ b/oauth-server/src/main/java/io/strimzi/kafka/oauth/server/JaasServerOauthValidatorCallbackHandler.java
@@ -220,17 +220,17 @@ public class JaasServerOauthValidatorCallbackHandler implements AuthenticateCall
 
         } catch (TokenValidationException e) {
             if (log.isDebugEnabled()) {
-                log.debug("Validation failed for token: " + mask(token), e);
+                log.debug("Token validation failed for token: " + mask(token), e);
             }
             callback.error(e.status(), null, null);
 
         } catch (RuntimeException e) {
             // Kafka ignores cause inside thrown exception, and doesn't log it
             if (log.isDebugEnabled()) {
-                log.debug("Validation failed due to runtime exception (network issue or misconfiguration): ", e);
+                log.debug("Token validation failed due to runtime exception (network issue or misconfiguration): ", e);
             }
             // Extract cause and include it in a message string in order for it to be in the server log
-            throw new AuthenticationException("Validation failed due to runtime exception: " + getCauseMessage(e), e);
+            throw new AuthenticationException("Token validation failed due to runtime exception: " + getCauseMessage(e), e);
 
         } catch (Exception e) {
             // Log cause, because Kafka doesn't

--- a/oauth-server/src/main/java/io/strimzi/kafka/oauth/server/ServerConfig.java
+++ b/oauth-server/src/main/java/io/strimzi/kafka/oauth/server/ServerConfig.java
@@ -15,7 +15,9 @@ public class ServerConfig extends Config {
     public static final String OAUTH_JWKS_REFRESH_SECONDS = "oauth.jwks.refresh.seconds";
     public static final String OAUTH_VALID_ISSUER_URI = "oauth.valid.issuer.uri";
     public static final String OAUTH_INTROSPECTION_ENDPOINT_URI = "oauth.introspection.endpoint.uri";
+    public static final String OAUTH_USERINFO_ENDPOINT_URI = "oauth.userinfo.endpoint.uri";
     public static final String OAUTH_CHECK_ACCESS_TOKEN_TYPE = "oauth.check.access.token.type";
+    public static final String OAUTH_CHECK_ISSUER = "oauth.check.issuer";
     public static final String OAUTH_CRYPTO_PROVIDER_BOUNCYCASTLE = "oauth.crypto.provider.bouncycastle";
     public static final String OAUTH_CRYPTO_PROVIDER_BOUNCYCASTLE_POSITION = "oauth.crypto.provider.bouncycastle.position";
 

--- a/oauth-server/src/main/java/io/strimzi/kafka/oauth/server/ServerConfig.java
+++ b/oauth-server/src/main/java/io/strimzi/kafka/oauth/server/ServerConfig.java
@@ -20,6 +20,7 @@ public class ServerConfig extends Config {
     public static final String OAUTH_CHECK_ISSUER = "oauth.check.issuer";
     public static final String OAUTH_CRYPTO_PROVIDER_BOUNCYCASTLE = "oauth.crypto.provider.bouncycastle";
     public static final String OAUTH_CRYPTO_PROVIDER_BOUNCYCASTLE_POSITION = "oauth.crypto.provider.bouncycastle.position";
+    public static final String OAUTH_VALID_TOKEN_TYPE = "oauth.valid.token.type";
 
     @Deprecated
     public static final String OAUTH_VALIDATION_SKIP_TYPE_CHECK = "oauth.validation.skip.type.check";

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
         <jackson.version>2.10.3</jackson.version>
         <junit.version>4.12</junit.version>
         <slf4j.version>1.7.26</slf4j.version>
-        <keycloak.version>7.0.0</keycloak.version>
+        <keycloak.version>9.0.3</keycloak.version>
         <bouncycastle.version>1.60</bouncycastle.version>
     </properties>
 

--- a/testsuite/access-token-introspection-hydra-test/arquillian.xml
+++ b/testsuite/access-token-introspection-hydra-test/arquillian.xml
@@ -25,6 +25,11 @@
                 strategy: log
                 match: '[KafkaServer id=1] started'
                 timeout: 120
+              beforeStop:
+                - log:
+                    to: ${PWD}/../kafka.log
+                    stdout: true
+                    stderr: true
         </property>
     </extension>
 </arquillian>

--- a/testsuite/access-token-introspection-hydra-test/docker-compose.yml
+++ b/testsuite/access-token-introspection-hydra-test/docker-compose.yml
@@ -72,6 +72,7 @@ services:
       # Validation config
       - OAUTH_VALID_ISSUER_URI=https://${HYDRA_HOST:-hydra}:4444/
       - OAUTH_INTROSPECTION_ENDPOINT_URI=https://${HYDRA_HOST:-hydra}:4445/oauth2/introspect
+      - OAUTH_CHECK_ACCESS_TOKEN_TYPE=false
 
       # Truststore config for connecting to secured authorization server
       - OAUTH_SSL_TRUSTSTORE_LOCATION=/opt/kafka/config/strimzi/certs/ca-truststore.p12

--- a/testsuite/access-token-introspection-hydra-test/src/test/java/io/strimzi/testsuite/oauth/HydraOpaqueAccessTokenWithIntrospectValidationTest.java
+++ b/testsuite/access-token-introspection-hydra-test/src/test/java/io/strimzi/testsuite/oauth/HydraOpaqueAccessTokenWithIntrospectValidationTest.java
@@ -58,7 +58,7 @@ public class HydraOpaqueAccessTokenWithIntrospectValidationTest {
         // Request access token using client id and secret, and trustore configuration
         TokenInfo info = OAuthAuthenticator.loginWithClientSecret(URI.create(tokenEndpointUri),
                 ConfigUtil.createSSLFactory(new ClientConfig()),
-                null, CLIENT_ID, CLIENT_SECRET, true);
+                null, CLIENT_ID, CLIENT_SECRET, true, null, null);
 
         // Configure received token for Kafka client auth
         defaults.setProperty(ClientConfig.OAUTH_ACCESS_TOKEN, info.token());

--- a/testsuite/access-token-introspection-keycloak-test/arquillian.xml
+++ b/testsuite/access-token-introspection-keycloak-test/arquillian.xml
@@ -16,6 +16,11 @@
                 strategy: log
                 match: '[KafkaServer id=1] started'
                 timeout: 120
+              beforeStop:
+                - log:
+                    to: ${PWD}/../kafka.log
+                    stdout: true
+                    stderr: true
             keycloak:
               await:
                 strategy: log

--- a/testsuite/access-token-introspection-keycloak-test/src/test/java/io/strimzi/testsuite/oauth/KeycloakAccessTokenWithIntrospectValidationTest.java
+++ b/testsuite/access-token-introspection-keycloak-test/src/test/java/io/strimzi/testsuite/oauth/KeycloakAccessTokenWithIntrospectValidationTest.java
@@ -46,7 +46,7 @@ public class KeycloakAccessTokenWithIntrospectValidationTest {
         final String tokenEndpointUri = "http://" + HOST + ":8080/auth/realms/" + REALM + "/protocol/openid-connect/token";
 
         // first, request access token using client id and secret
-        TokenInfo info = OAuthAuthenticator.loginWithClientSecret(URI.create(tokenEndpointUri), null, null, CLIENT_ID, CLIENT_SECRET, true);
+        TokenInfo info = OAuthAuthenticator.loginWithClientSecret(URI.create(tokenEndpointUri), null, null, CLIENT_ID, CLIENT_SECRET, true, null, null);
 
 
         Properties defaults = new Properties();

--- a/testsuite/client-secret-jwt-keycloak-authz-test/arquillian.xml
+++ b/testsuite/client-secret-jwt-keycloak-authz-test/arquillian.xml
@@ -16,6 +16,11 @@
                 strategy: log
                 match: '[KafkaServer id=1] started'
                 timeout: 120
+              beforeStop:
+                - log:
+                    to: ${PWD}/../kafka.log
+                    stdout: true
+                    stderr: true
             keycloak:
               await:
                 strategy: log

--- a/testsuite/client-secret-jwt-keycloak-authz-test/src/test/java/io/strimzi/testsuite/oauth/KeycloakClientCredentialsWithJwtValidationAuthzTest.java
+++ b/testsuite/client-secret-jwt-keycloak-authz-test/src/test/java/io/strimzi/testsuite/oauth/KeycloakClientCredentialsWithJwtValidationAuthzTest.java
@@ -408,9 +408,9 @@ public class KeycloakClientCredentialsWithJwtValidationAuthzTest {
 
         HashMap<String, String> tokens = new HashMap<>();
         tokens.put(TEAM_A_CLIENT, loginWithClientSecret(URI.create(TOKEN_ENDPOINT_URI), null, null,
-                TEAM_A_CLIENT, TEAM_A_CLIENT + "-secret", true).token());
+                TEAM_A_CLIENT, TEAM_A_CLIENT + "-secret", true, null, null).token());
         tokens.put(TEAM_B_CLIENT, loginWithClientSecret(URI.create(TOKEN_ENDPOINT_URI), null, null,
-                TEAM_B_CLIENT, TEAM_B_CLIENT + "-secret", true).token());
+                TEAM_B_CLIENT, TEAM_B_CLIENT + "-secret", true, null, null).token());
         tokens.put(BOB, loginWithUsernamePassword(URI.create(TOKEN_ENDPOINT_URI),
                 BOB, BOB + "-password", "kafka-cli"));
         return tokens;

--- a/testsuite/docker/kafka/config/log4j.properties
+++ b/testsuite/docker/kafka/config/log4j.properties
@@ -66,7 +66,7 @@ log4j.logger.kafka=INFO
 log4j.logger.org.apache.kafka=INFO
 
 # Control Strimzi OAuth logging
-log4j.logger.io.strimzi=DEBUG
+log4j.logger.io.strimzi=TRACE
 
 # Change to DEBUG or TRACE to enable request logging
 log4j.logger.kafka.request.logger=WARN, requestAppender

--- a/testsuite/refresh-token-jwt-keycloak-test/arquillian.xml
+++ b/testsuite/refresh-token-jwt-keycloak-test/arquillian.xml
@@ -21,6 +21,11 @@
                 strategy: log
                 match: 'regexp:.* Keycloak .* started in .*'
                 timeout: 120
+              beforeStop:
+                - log:
+                    to: ${PWD}/../kafka.log
+                    stdout: true
+                    stderr: true
         </property>
     </extension>
 </arquillian>


### PR DESCRIPTION
* Added Spring Authorization Server example
* Added support for TRACE logging of endpoint responses
* Additional options for better interoperability with different authorization servers:    
  * `oauth.check.issuer`
    Allows turning off the issuer check against the value set by `oauth.valid.issuer.uri`.
    Some authorization servers don't provide `iss` value.
  * `oauth.userinfo.endpoint.uri` 
    This can be set to the User Info Endpoint uri, as a fallback endpoint to obtain the username (principal) when it could not be extracted from the Introspection Endpoint response.
  * `oauth.fallback.username.claim`
    A secondary claim that can be used to extract the username (principal) if the claim specified by `oauth.username.claim` is not present. It is used for both JWT token extraction, and Introspection Endpoint or User Info Endpoint response extraction.
  * `oauth.fallback.username.prefix` 
    When `oauth.fallback.username.claim` is used to extract the username (principal) this value is prefixed to the extracted username. This allows mapping two sets of accounts - users, and clients for example - into the same user space.
  * `oauth.scope`
    Scope may be required by some authorization servers, and can now be passed to the Token Endpoint.
  * `oauth.valid.token.type`
    Some servers return non-standard values for `token_type` attribute in Introspection Endpoint response. When set, the `token_type` value has to be equal to the one specified here.

See [RELEASE_NOTES.md](), and [README.md]() for more information.

