### PR TITLE
Fix scope support when refreshing the token + enhance examples and tests

### DIFF
--- a/examples/docker/kafka-oauth-strimzi/kafka/Dockerfile
+++ b/examples/docker/kafka-oauth-strimzi/kafka/Dockerfile
@@ -1,4 +1,4 @@
-FROM strimzi/kafka:latest-kafka-2.4.0
+FROM strimzi/kafka:latest-kafka-2.5.0
 
 COPY libs/* /opt/kafka/libs/strimzi/
 COPY config/* /opt/kafka/config/

--- a/examples/docker/kafka-oauth-strimzi/zookeeper/Dockerfile
+++ b/examples/docker/kafka-oauth-strimzi/zookeeper/Dockerfile
@@ -1,4 +1,4 @@
-FROM strimzi/kafka:latest-kafka-2.4.0
+FROM strimzi/kafka:latest-kafka-2.5.0
 
 COPY start.sh /opt/kafka/
 COPY simple_zk_config.sh /opt/kafka/

--- a/examples/kubernetes/kafka-oauth-single-spring.yaml
+++ b/examples/kubernetes/kafka-oauth-single-spring.yaml
@@ -1,0 +1,49 @@
+apiVersion: kafka.strimzi.io/v1beta1
+kind: Kafka
+metadata:
+  name: my-cluster
+spec:
+  kafka:
+    version: 2.4.1
+    replicas: 1
+    listeners:
+      plain:
+        authentication:
+          type: oauth
+          introspectionEndpointUri: http://spring:8080/oauth/check_token
+          clientId: kafka
+          clientSecret:
+            secretName: my-cluster-kafka-client-secret
+            key: secret
+          checkIssuer: false
+          accessTokenIsJwt: false
+          userNameClaim: user_name
+          fallbackUserNameClaim: client_id
+          fallbackUserNamePrefix: client-account-
+      tls: {}
+    logging:
+      type: inline
+      loggers:
+        log4j.logger.io.strimzi: "DEBUG"
+    config:
+      offsets.topic.replication.factor: 1
+      transaction.state.log.replication.factor: 1
+      transaction.state.log.min.isr: 1
+      log.message.format.version: "2.4"
+    storage:
+      type: jbod
+      volumes:
+      - id: 0
+        type: persistent-claim
+        size: 100Gi
+        deleteClaim: false
+  zookeeper:
+    replicas: 1
+    storage:
+      type: persistent-claim
+      size: 100Gi
+      deleteClaim: false
+  entityOperator:
+    topicOperator: {}
+    userOperator: {}
+

--- a/examples/kubernetes/spring-authserver.yaml
+++ b/examples/kubernetes/spring-authserver.yaml
@@ -1,0 +1,41 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: spring
+  labels:
+    app: spring
+spec:
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+  selector:
+    app: spring
+  type: NodePort
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: spring
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: spring
+  template:
+    metadata:
+      labels:
+        app: spring
+    spec:
+      containers:
+        - name: spring
+          image: strimzi/example-spring
+          ports:
+            - name: http
+              containerPort: 8080
+          readinessProbe:
+            httpGet:
+              path: /oauth/error
+              port: 8080

--- a/oauth-client/src/main/java/io/strimzi/kafka/oauth/client/JaasClientOauthLoginCallbackHandler.java
+++ b/oauth-client/src/main/java/io/strimzi/kafka/oauth/client/JaasClientOauthLoginCallbackHandler.java
@@ -153,7 +153,7 @@ public class JaasClientOauthLoginCallbackHandler implements AuthenticateCallback
             // we could check if it's a JWT - in that case we could check if it's expired
             result = loginWithAccessToken(token, isJwt, principalExtractor);
         } else if (refreshToken != null) {
-            result = loginWithRefreshToken(tokenEndpoint, socketFactory, hostnameVerifier, refreshToken, clientId, clientSecret, isJwt, principalExtractor);
+            result = loginWithRefreshToken(tokenEndpoint, socketFactory, hostnameVerifier, refreshToken, clientId, clientSecret, isJwt, principalExtractor, scope);
         } else if (clientSecret != null) {
             result = loginWithClientSecret(tokenEndpoint, socketFactory, hostnameVerifier, clientId, clientSecret, isJwt, principalExtractor, scope);
         } else {

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/OAuthAuthenticator.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/OAuthAuthenticator.java
@@ -46,8 +46,8 @@ public class OAuthAuthenticator {
                                                   String clientId, String clientSecret, boolean isJwt,
                                                   PrincipalExtractor principalExtractor, String scope) throws IOException {
         if (log.isDebugEnabled()) {
-            log.debug("loginWithClientSecret() - tokenEndpointUrl: {}, clientId: {}, clientSecret: {}",
-                    tokenEndpointUrl, clientId, mask(clientSecret));
+            log.debug("loginWithClientSecret() - tokenEndpointUrl: {}, clientId: {}, clientSecret: {}, scope: {}",
+                    tokenEndpointUrl, clientId, mask(clientSecret), scope);
         }
 
         String authorization = "Basic " + base64encode(clientId + ':' + clientSecret);
@@ -63,10 +63,10 @@ public class OAuthAuthenticator {
     public static TokenInfo loginWithRefreshToken(URI tokenEndpointUrl, SSLSocketFactory socketFactory,
                                                   HostnameVerifier hostnameVerifier, String refreshToken,
                                                   String clientId, String clientSecret, boolean isJwt,
-                                                  PrincipalExtractor principalExtractor) throws IOException {
+                                                  PrincipalExtractor principalExtractor, String scope) throws IOException {
         if (log.isDebugEnabled()) {
-            log.debug("loginWithRefreshToken() - tokenEndpointUrl: {}, refreshToken: {}, clientId: {}, clientSecret: {}",
-                    tokenEndpointUrl, refreshToken, clientId, mask(clientSecret));
+            log.debug("loginWithRefreshToken() - tokenEndpointUrl: {}, refreshToken: {}, clientId: {}, clientSecret: {}, scope: {}",
+                    tokenEndpointUrl, refreshToken, clientId, mask(clientSecret), scope);
         }
 
         String authorization = clientSecret != null ?
@@ -76,6 +76,10 @@ public class OAuthAuthenticator {
         StringBuilder body = new StringBuilder("grant_type=refresh_token")
                 .append("&refresh_token=").append(urlencode(refreshToken))
                 .append("&client_id=").append(urlencode(clientId));
+
+        if (scope != null) {
+            body.append("&scope=").append(urlencode(scope));
+        }
 
         return post(tokenEndpointUrl, socketFactory, hostnameVerifier, authorization, body.toString(), isJwt, principalExtractor);
     }

--- a/testsuite/client-secret-jwt-keycloak-authz-test/docker-compose.yml
+++ b/testsuite/client-secret-jwt-keycloak-authz-test/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       - TIMEOUT=90
 
   kafka:
-    image: strimzi/kafka:latest-kafka-2.3.0
+    image: strimzi/kafka:latest-kafka-2.5.0
     container_name: kafka
     ports:
       - 9092:9092
@@ -80,7 +80,7 @@ services:
       - TIMEOUT=90
 
   zookeeper:
-    image: strimzi/zookeeper:0.11.4-kafka-2.1.0
+    image: strimzi/kafka:latest-kafka-2.5.0
     container_name: zookeeper
     ports:
       - 2181:2181


### PR DESCRIPTION
The newly added `scope` support allows setting the `scope` parameter in a token request, which wasn't possible before. This PR addresses a tiny omission in initial `scope` support where authenticating with a refresh token (by setting oauth.refresh.token) didn't take `scope` configuration into account.