### PR TITLE
Prepare for 0.6.1 release

### DIFF
--- a/examples/docker/kafka-oauth-strimzi/kafka/pom.xml
+++ b/examples/docker/kafka-oauth-strimzi/kafka/pom.xml
@@ -7,7 +7,7 @@
         <groupId>io.strimzi.oauth.docker</groupId>
         <artifactId>kafka-oauth-docker-strimzi</artifactId>
         <relativePath>../pom.xml</relativePath>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>0.6.1</version>
     </parent>
 
     <artifactId>kafka-oauth-docker-strimzi-kafka</artifactId>

--- a/examples/docker/kafka-oauth-strimzi/pom.xml
+++ b/examples/docker/kafka-oauth-strimzi/pom.xml
@@ -7,7 +7,7 @@
         <groupId>io.strimzi.oauth.docker</groupId>
         <artifactId>kafka-oauth-docker-parent</artifactId>
         <relativePath>../pom.xml</relativePath>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>0.6.1</version>
     </parent>
 
     <artifactId>kafka-oauth-docker-strimzi</artifactId>

--- a/examples/docker/kafka-oauth-strimzi/zookeeper/pom.xml
+++ b/examples/docker/kafka-oauth-strimzi/zookeeper/pom.xml
@@ -7,7 +7,7 @@
         <groupId>io.strimzi.oauth.docker</groupId>
         <artifactId>kafka-oauth-docker-strimzi</artifactId>
         <relativePath>../pom.xml</relativePath>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>0.6.1</version>
     </parent>
 
     <artifactId>kafka-oauth-docker-strimzi-zookeeper</artifactId>

--- a/examples/docker/pom.xml
+++ b/examples/docker/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.strimzi.oauth.docker</groupId>
     <artifactId>kafka-oauth-docker-parent</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>0.6.1</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/examples/docker/spring/pom.xml
+++ b/examples/docker/spring/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>io.strimzi.oauth.docker</groupId>
     <artifactId>kafka-oauth-docker-spring</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>0.6.1</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/examples/docker/strimzi-kafka-image/pom.xml
+++ b/examples/docker/strimzi-kafka-image/pom.xml
@@ -7,12 +7,12 @@
         <groupId>io.strimzi.oauth.docker</groupId>
         <artifactId>kafka-oauth-docker-parent</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>0.6.1</version>
     </parent>
 
     <groupId>org.example</groupId>
     <artifactId>kafka-oauth-docker-strimzi-kafka</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>0.6.1</version>
 
     <packaging>pom</packaging>
 

--- a/testsuite/access-token-introspection-hydra-test/pom.xml
+++ b/testsuite/access-token-introspection-hydra-test/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.strimzi.oauth.testsuite</groupId>
         <artifactId>kafka-oauth-testsuite</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>0.6.1</version>
     </parent>
 
     <artifactId>access-token-introspection-hydra-test</artifactId>

--- a/testsuite/access-token-introspection-keycloak-test/pom.xml
+++ b/testsuite/access-token-introspection-keycloak-test/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.strimzi.oauth.testsuite</groupId>
         <artifactId>kafka-oauth-testsuite</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>0.6.1</version>
     </parent>
 
     <artifactId>access-token-introspection-keycloak-test</artifactId>

--- a/testsuite/client-secret-jwt-hydra-test/pom.xml
+++ b/testsuite/client-secret-jwt-hydra-test/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.strimzi.oauth.testsuite</groupId>
         <artifactId>kafka-oauth-testsuite</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>0.6.1</version>
     </parent>
 
     <artifactId>client-secret-jwt-hydra-test</artifactId>

--- a/testsuite/client-secret-jwt-keycloak-authz-refresh-test/pom.xml
+++ b/testsuite/client-secret-jwt-keycloak-authz-refresh-test/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.strimzi.oauth.testsuite</groupId>
         <artifactId>kafka-oauth-testsuite</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>0.6.1</version>
     </parent>
 
     <artifactId>client-secret-jwt-keycloak-authz-refresh-test</artifactId>

--- a/testsuite/client-secret-jwt-keycloak-authz-test/pom.xml
+++ b/testsuite/client-secret-jwt-keycloak-authz-test/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.strimzi.oauth.testsuite</groupId>
         <artifactId>kafka-oauth-testsuite</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>0.6.1</version>
     </parent>
 
     <artifactId>client-secret-jwt-keycloak-authz-test</artifactId>

--- a/testsuite/client-secret-jwt-keycloak-test/pom.xml
+++ b/testsuite/client-secret-jwt-keycloak-test/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.strimzi.oauth.testsuite</groupId>
         <artifactId>kafka-oauth-testsuite</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>0.6.1</version>
     </parent>
 
     <artifactId>client-secret-jwt-keycloak-test</artifactId>

--- a/testsuite/docker/hydra-import/pom.xml
+++ b/testsuite/docker/hydra-import/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.strimzi.oauth.testsuite</groupId>
         <artifactId>kafka-oauth-testsuite-docker-pom</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>0.6.1</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/testsuite/docker/pom.xml
+++ b/testsuite/docker/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.strimzi.oauth.testsuite</groupId>
         <artifactId>kafka-oauth-testsuite</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>0.6.1</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.strimzi.oauth.testsuite</groupId>
     <artifactId>kafka-oauth-testsuite</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>0.6.1</version>
 
     <packaging>pom</packaging>
 

--- a/testsuite/refresh-token-jwt-keycloak-test/pom.xml
+++ b/testsuite/refresh-token-jwt-keycloak-test/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.strimzi.oauth.testsuite</groupId>
         <artifactId>kafka-oauth-testsuite</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>0.6.1</version>
     </parent>
 
     <artifactId>refresh-token-jwt-keycloak-test</artifactId>


### PR DESCRIPTION
I suggest replacing <version> in all poms. I've encountered situations where the tests or examples were using 1.0.0-SNAPSHOT rather than the just built 0.6.x tag, resulting in non-reproducable build, non-working examples and similar.

Signed-off-by: Marko Strukelj <marko.strukelj@gmail.com>