### PR TITLE
docs: fix typo

### DIFF
--- a/examples/kubernetes/README.md
+++ b/examples/kubernetes/README.md
@@ -8,7 +8,7 @@ They assume Keycloak is used as an authorization server, with properly configure
 
   A Keycloak pod you can use to start an ephemeral instance of Keycloak. Any changes to realms will be lost when the pod shuts down. This is the first yaml you'll want to deploy.
 
-* `kafka-oauth-singe.yaml`
+* `kafka-oauth-single.yaml`
 
   A single node Kafka cluster using Apache Kafka 2.3.1 with OAuth 2 authentication using the 'demo' realm, and fast local signature validation (with keys loaded from the JWKS endpoint) for validating access tokens.
 


### PR DESCRIPTION
The file name is not the same as the actual file.