### PR TITLE
Audience checking

### DIFF
--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -61,11 +61,11 @@ if [ ${JAVA_MAJOR_VERSION} -eq 1 ] ; then
   EXIT=$?
   exitIfError
 
-  clearDockerEnv
-  docker pull strimzi/kafka:latest-kafka-2.3.0
-  mvn -e -V -B test -f testsuite -Pkafka-2_3_0
-  EXIT=$?
-  exitIfError
+#  clearDockerEnv
+#  docker pull strimzi/kafka:latest-kafka-2.3.0
+#  mvn -e -V -B test -f testsuite -Pkafka-2_3_0
+#  EXIT=$?
+#  exitIfError
 
   set -e
 fi

--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ Specify the following `oauth.*` properties:
 Some authorization servers don't provide the `iss` claim. In that case you would not set `oauth.valid.issuer.uri`, and you would explicitly turn off issuer checking by setting the following option to `false`:
 - `oauth.check.issuer` (e.g. "false")
 
-You can enforce audience checking, which is an OAuth2 mechanism to prevent successful authentication with tokens that are not explicitly issued for use by your resource server.
+You can enforce audience checking, which is an OAuth2 mechanism to prevent successful authentication with tokens unless they are explicitly issued for use by your resource server.
 The authorization server adds the allowed resource servers' `client IDs` into the `aud` claim of such tokens.
 
 Set the following option to `true` to enforce audience checking:
@@ -332,7 +332,7 @@ Introspection endpoint should be protected. The `oauth.client.id` and `oauth.cli
 Some authorization servers don't provide the `iss` claim. In that case you would not set `oauth.valid.issuer.uri`, and you would explicitly turn off issuer checking by setting the following option to `false`:
 - `oauth.check.issuer` (e.g.: "false")
 
-You can enforce audience checking, which is an OAuth2 mechanism to prevent successful authentication with tokens that are explicitly issued for use by your resource server.
+You can enforce audience checking, which is an OAuth2 mechanism to prevent successful authentication with tokens unless they are explicitly issued for use by your resource server.
 The authorization server adds the allowed resource servers' `client IDs` into the `aud` claim of such tokens.
 
 Set the following option to `true` to enforce audience checking:

--- a/README.md
+++ b/README.md
@@ -265,13 +265,18 @@ Specify the following `oauth.*` properties:
 Some authorization servers don't provide the `iss` claim. In that case you would not set `oauth.valid.issuer.uri`, and you would explicitly turn off issuer checking by setting the following option to `false`:
 - `oauth.check.issuer` (e.g. "false")
 
-You can enforce audience check, which is an OAuth2 mechanism to limit access to tokens that are explicitly issued for use by your protected server.
-The authorization server adds the allowed resource servers' `client ids` into `aud` claim of such tokens.
-Set the following option to `true` to enforce audience check (it is not enabled by default). 
+You can enforce audience check, which is an OAuth2 mechanism to limit access to tokens that are explicitly issued for use by your resource server.
+The authorization server adds the allowed resource servers' `client IDs` into `aud` claim of such tokens.
+
+Set the following option to `true` to enforce audience check:
 - `oauth.check.audience` (e.g. "true")
 
 When audience check is enabled the `oauth.client.id` has to be configured:
 - `oauth.client.id` (e.g.: "kafka" - this is the OAuth2 client configuration id for Kafka Broker)
+
+If the configured `oauth.client.id` is `kafka`, the following are valid examples of `aud` attribute in the JWT token:
+- "kafka"
+- ["rest-api", "kafka"]
 
 JWT tokens contain unique user identification in `sub` claim. However, this is often a long number or a UUID, but we usually prefer to use human readable usernames, which may also be present in JWT token.
 Use `oauth.username.claim` to map the claim (attribute) where the value you want to use as user id is stored:
@@ -327,10 +332,15 @@ Introspection endpoint should be protected. The `oauth.client.id` and `oauth.cli
 Some authorization servers don't provide the `iss` claim. In that case you would not set `oauth.valid.issuer.uri`, and you would explicitly turn off issuer checking by setting the following option to `false`:
 - `oauth.check.issuer` (e.g.: "false")
 
-You can enforce audience check, which is an OAuth2 mechanism to limit access to tokens that are explicitly issued for use by your protected server.
+You can enforce audience check, which is an OAuth2 mechanism to limit access to tokens that are explicitly issued for use by your resource server.
 The authorization server adds the allowed resource servers' `client IDs` into `aud` claim of such tokens.
-Set the following option to `true` to enforce audience check (it is not enabled by default). 
+
+Set the following option to `true` to enforce audience check:
 - `oauth.check.audience` (e.g. "true")
+
+If the configured `oauth.client.id` is `kafka`, the following are valid examples of `aud` attribute in the JWT token:
+- "kafka"
+- ["rest-api", "kafka"]
 
 By default, if the Introspection Endpoint response contains `token_type` claim, there is no checking performed on it.
 Some authorization servers use a non-standard `token_type` value. To give the most flexibility, you can specify the valid `token_type` for your authorization server:

--- a/README.md
+++ b/README.md
@@ -265,8 +265,8 @@ Specify the following `oauth.*` properties:
 Some authorization servers don't provide the `iss` claim. In that case you would not set `oauth.valid.issuer.uri`, and you would explicitly turn off issuer checking by setting the following option to `false`:
 - `oauth.check.issuer` (e.g. "false")
 
-You can enforce audience checking, which is an OAuth2 mechanism to prevent successful authentication with tokens that are explicitly issued for use by your resource server.
-The authorization server adds the allowed resource servers' `client IDs` into `aud` claim of such tokens.
+You can enforce audience checking, which is an OAuth2 mechanism to prevent successful authentication with tokens that are not explicitly issued for use by your resource server.
+The authorization server adds the allowed resource servers' `client IDs` into the `aud` claim of such tokens.
 
 Set the following option to `true` to enforce audience checking:
 - `oauth.check.audience` (e.g. "true")
@@ -324,7 +324,7 @@ This will result in Kafka Broker making a request to authorization server every 
 Specify the following `oauth.*` properties:
 - `oauth.introspection.endpoint.uri` (e.g.: "https://localhost:8443/auth/realms/demo/protocol/openid-connect/token/introspect")
 - `oauth.valid.issuer.uri` (e.g.: "https://localhost:8443/auth/realms/demo" - only access tokens issued by this issuer will be accepted)
-- `oauth.client.id` (e.g.: "kafka" - this is the OAuth2 client configuration id for the Kafka Broker)
+- `oauth.client.id` (e.g.: "kafka" - this is the OAuth2 client configuration id for the Kafka broker)
 - `oauth.client.secret` (e.g.: "kafka-secret")
  
 Introspection endpoint should be protected. The `oauth.client.id` and `oauth.client.secret` specify Kafka Broker credentials for authenticating to access the introspection endpoint. 
@@ -333,7 +333,7 @@ Some authorization servers don't provide the `iss` claim. In that case you would
 - `oauth.check.issuer` (e.g.: "false")
 
 You can enforce audience checking, which is an OAuth2 mechanism to prevent successful authentication with tokens that are explicitly issued for use by your resource server.
-The authorization server adds the allowed resource servers' `client IDs` into `aud` claim of such tokens.
+The authorization server adds the allowed resource servers' `client IDs` into the `aud` claim of such tokens.
 
 Set the following option to `true` to enforce audience checking:
 - `oauth.check.audience` (e.g. "true")
@@ -385,7 +385,7 @@ When you have a DEBUG logging configured for the `io.strimzi` category you may n
 
 ##### Configuring the client side of inter-broker communication
 
-All the Kafka Brokers in the cluster should be configured with the same client ID and secret, and the corresponding user should be added to `super.users` since inter-broker client requires super-user permissions.
+All the Kafka brokers in the cluster should be configured with the same client ID and secret, and the corresponding user should be added to `super.users` since inter-broker client requires super-user permissions.
 
 Specify the following `oauth.*` properties:
 - `oauth.token.endpoint.uri` (e.g.: "https://localhost:8443/auth/realms/demo/protocol/openid-connect/token")

--- a/README.md
+++ b/README.md
@@ -271,8 +271,8 @@ The authorization server adds the allowed resource servers' `client IDs` into `a
 Set the following option to `true` to enforce audience check:
 - `oauth.check.audience` (e.g. "true")
 
-When audience check is enabled the `oauth.client.id` has to be configured:
-- `oauth.client.id` (e.g.: "kafka" - this is the OAuth2 client configuration id for Kafka Broker)
+When audience checking is enabled the `oauth.client.id` has to be configured:
+- `oauth.client.id` (e.g.: "kafka" - this is the OAuth2 client configuration id for the Kafka Broker)
 
 If the configured `oauth.client.id` is `kafka`, the following are valid examples of `aud` attribute in the JWT token:
 - "kafka"
@@ -324,7 +324,7 @@ This will result in Kafka Broker making a request to authorization server every 
 Specify the following `oauth.*` properties:
 - `oauth.introspection.endpoint.uri` (e.g.: "https://localhost:8443/auth/realms/demo/protocol/openid-connect/token/introspect")
 - `oauth.valid.issuer.uri` (e.g.: "https://localhost:8443/auth/realms/demo" - only access tokens issued by this issuer will be accepted)
-- `oauth.client.id` (e.g.: "kafka" - this is the OAuth2 client configuration id for Kafka Broker)
+- `oauth.client.id` (e.g.: "kafka" - this is the OAuth2 client configuration id for the Kafka Broker)
 - `oauth.client.secret` (e.g.: "kafka-secret")
  
 Introspection endpoint should be protected. The `oauth.client.id` and `oauth.client.secret` specify Kafka Broker credentials for authenticating to access the introspection endpoint. 

--- a/README.md
+++ b/README.md
@@ -265,10 +265,10 @@ Specify the following `oauth.*` properties:
 Some authorization servers don't provide the `iss` claim. In that case you would not set `oauth.valid.issuer.uri`, and you would explicitly turn off issuer checking by setting the following option to `false`:
 - `oauth.check.issuer` (e.g. "false")
 
-You can enforce audience check, which is an OAuth2 mechanism to limit access to tokens that are explicitly issued for use by your resource server.
+You can enforce audience checking, which is an OAuth2 mechanism to limit access to tokens that are explicitly issued for use by your resource server.
 The authorization server adds the allowed resource servers' `client IDs` into `aud` claim of such tokens.
 
-Set the following option to `true` to enforce audience check:
+Set the following option to `true` to enforce audience checking:
 - `oauth.check.audience` (e.g. "true")
 
 When audience checking is enabled the `oauth.client.id` has to be configured:
@@ -332,10 +332,10 @@ Introspection endpoint should be protected. The `oauth.client.id` and `oauth.cli
 Some authorization servers don't provide the `iss` claim. In that case you would not set `oauth.valid.issuer.uri`, and you would explicitly turn off issuer checking by setting the following option to `false`:
 - `oauth.check.issuer` (e.g.: "false")
 
-You can enforce audience check, which is an OAuth2 mechanism to limit access to tokens that are explicitly issued for use by your resource server.
+You can enforce audience checking, which is an OAuth2 mechanism to limit access to tokens that are explicitly issued for use by your resource server.
 The authorization server adds the allowed resource servers' `client IDs` into `aud` claim of such tokens.
 
-Set the following option to `true` to enforce audience check:
+Set the following option to `true` to enforce audience checking:
 - `oauth.check.audience` (e.g. "true")
 
 If the configured `oauth.client.id` is `kafka`, the following are valid examples of `aud` attribute in the JWT token:

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ For example, the order of looking for configuration for `strimzi.client.id` woul
 
 ##### Configuring the token validation
 
-The most essential OAuth2 configuration on the Kafka Broker is the configuration related to validation of the access tokens passed from Kafka clients to the Kafka broker during SASL based authentication mechanism.
+The most essential OAuth2 configuration on the Kafka broker is the configuration related to validation of the access tokens passed from Kafka clients to the Kafka broker during SASL based authentication mechanism.
 
 There are two options for token validation:
 - Using the JWKS endpoint in combination with signed JWT formatted access tokens
@@ -265,7 +265,7 @@ Specify the following `oauth.*` properties:
 Some authorization servers don't provide the `iss` claim. In that case you would not set `oauth.valid.issuer.uri`, and you would explicitly turn off issuer checking by setting the following option to `false`:
 - `oauth.check.issuer` (e.g. "false")
 
-You can enforce audience checking, which is an OAuth2 mechanism to limit access to tokens that are explicitly issued for use by your resource server.
+You can enforce audience checking, which is an OAuth2 mechanism to prevent successful authentication with tokens that are explicitly issued for use by your resource server.
 The authorization server adds the allowed resource servers' `client IDs` into `aud` claim of such tokens.
 
 Set the following option to `true` to enforce audience checking:
@@ -332,7 +332,7 @@ Introspection endpoint should be protected. The `oauth.client.id` and `oauth.cli
 Some authorization servers don't provide the `iss` claim. In that case you would not set `oauth.valid.issuer.uri`, and you would explicitly turn off issuer checking by setting the following option to `false`:
 - `oauth.check.issuer` (e.g.: "false")
 
-You can enforce audience checking, which is an OAuth2 mechanism to limit access to tokens that are explicitly issued for use by your resource server.
+You can enforce audience checking, which is an OAuth2 mechanism to prevent successful authentication with tokens that are explicitly issued for use by your resource server.
 The authorization server adds the allowed resource servers' `client IDs` into `aud` claim of such tokens.
 
 Set the following option to `true` to enforce audience checking:

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,9 +10,9 @@ SASL_PLAIN can now be used to perform the authentication using a service account
 
 See [README.md] for instructions on how to set up the brokers and the clients.
 
-### Audience check
+### Audience checking
 
-Additional server-side configuration option was added to enable / disable the audience check:
+Additional server-side configuration option was added to enable / disable the audience checking:
 * `oauth.check.audience` (e.g. "true") 
 
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,6 +10,11 @@ SASL_PLAIN can now be used to perform the authentication using a service account
 
 See [README.md] for instructions on how to set up the brokers and the clients.
 
+### Audience check
+
+Additional server-side configuration option was added to enable / disable the audience check:
+* `oauth.check.audience` (e.g. "true") 
+
 
 0.6.0
 -----

--- a/examples/kubernetes/keycloak-realms-configmap.yaml
+++ b/examples/kubernetes/keycloak-realms-configmap.yaml
@@ -254,6 +254,10 @@ data:
             {
               "name": "uma_protection",
               "clientRole": true
+            },
+            {
+              "name": "kafka-user",
+              "clientRole": true
             }
           ]
         }
@@ -326,6 +330,7 @@ data:
           "serviceAccountClientId" : "team-b-client",
           "realmRoles" : [ "offline_access", "Dev Team B" ],
           "clientRoles" : {
+            "kafka" : [ "kafka-user" ],
             "account" : [ "manage-account", "view-profile" ]
           },
           "groups" : [ ]

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/services/ValidatorKey.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/services/ValidatorKey.java
@@ -9,6 +9,7 @@ import java.util.Objects;
 public class ValidatorKey {
 
     private final String validIssuerUri;
+    private final String audience;
     private final String usernameClaim;
     private final String fallbackUsernameClaim;
     private final String fallbackUsernamePrefix;
@@ -20,6 +21,7 @@ public class ValidatorKey {
     private final boolean hasHostnameVerifier;
 
     ValidatorKey(String validIssuerUri,
+            String audience,
             String usernameClaim,
             String fallbackUsernameClaim,
             String fallbackUsernamePrefix,
@@ -30,6 +32,7 @@ public class ValidatorKey {
             boolean hasHostnameVerifier) {
 
         this.validIssuerUri = validIssuerUri;
+        this.audience = audience;
         this.usernameClaim = usernameClaim;
         this.fallbackUsernameClaim = fallbackUsernameClaim;
         this.fallbackUsernamePrefix = fallbackUsernamePrefix;
@@ -47,6 +50,7 @@ public class ValidatorKey {
         ValidatorKey that = (ValidatorKey) o;
         return hasHostnameVerifier == that.hasHostnameVerifier &&
                 Objects.equals(validIssuerUri, that.validIssuerUri) &&
+                Objects.equals(audience, that.audience) &&
                 Objects.equals(usernameClaim, that.usernameClaim) &&
                 Objects.equals(fallbackUsernameClaim, that.fallbackUsernameClaim) &&
                 Objects.equals(fallbackUsernamePrefix, that.fallbackUsernamePrefix) &&
@@ -58,7 +62,7 @@ public class ValidatorKey {
 
     @Override
     public int hashCode() {
-        return Objects.hash(validIssuerUri, usernameClaim, fallbackUsernameClaim, fallbackUsernamePrefix, sslTruststore, sslStorePassword, sslStoreType, sslRandom, hasHostnameVerifier);
+        return Objects.hash(validIssuerUri, audience, usernameClaim, fallbackUsernameClaim, fallbackUsernamePrefix, sslTruststore, sslStorePassword, sslStoreType, sslRandom, hasHostnameVerifier);
     }
 
 
@@ -74,6 +78,7 @@ public class ValidatorKey {
 
         @SuppressWarnings("checkstyle:parameternumber")
         public JwtValidatorKey(String validIssuerUri,
+                        String audience,
                         String usernameClaim,
                         String fallbackUsernameClaim,
                         String fallbackUsernamePrefix,
@@ -91,7 +96,7 @@ public class ValidatorKey {
                         boolean enableBouncy,
                         int bouncyPosition) {
 
-            super(validIssuerUri, usernameClaim, fallbackUsernameClaim, fallbackUsernamePrefix, sslTruststore, sslStorePassword, sslStoreType, sslRandom, hasHostnameVerifier);
+            super(validIssuerUri, audience, usernameClaim, fallbackUsernameClaim, fallbackUsernamePrefix, sslTruststore, sslStorePassword, sslStoreType, sslRandom, hasHostnameVerifier);
             this.jwksEndpointUri = jwksEndpointUri;
             this.jwksRefreshSeconds = jwksRefreshSeconds;
             this.jwksExpirySeconds = jwksExpirySeconds;
@@ -132,6 +137,7 @@ public class ValidatorKey {
 
         @SuppressWarnings("checkstyle:parameternumber")
         public IntrospectionValidatorKey(String validIssuerUri,
+                                  String audience,
                                   String usernameClaim,
                                   String fallbackUsernameClaim,
                                   String fallbackUsernamePrefix,
@@ -147,7 +153,7 @@ public class ValidatorKey {
                                   String clientId,
                                   String clientSecret) {
 
-            super(validIssuerUri, usernameClaim, fallbackUsernameClaim, fallbackUsernamePrefix, sslTruststore, sslStorePassword, sslStoreType, sslRandom, hasHostnameVerifier);
+            super(validIssuerUri, audience, usernameClaim, fallbackUsernameClaim, fallbackUsernamePrefix, sslTruststore, sslStorePassword, sslStoreType, sslRandom, hasHostnameVerifier);
             this.introspectionEndpoint = introspectionEndpoint;
             this.userInfoEndpoint = userInfoEndpoint;
             this.validTokenType = validTokenType;

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/validator/JWTSignatureValidator.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/validator/JWTSignatureValidator.java
@@ -180,6 +180,7 @@ public class JWTSignatureValidator implements TokenValidator {
                     + "\n    certsRefreshMinPauseSeconds: " + refreshMinPauseSeconds
                     + "\n    certsExpirySeconds: " + expirySeconds
                     + "\n    checkAccessTokenType: " + checkAccessTokenType
+                    + "\n    audience: " + audience
                     + "\n    enableBouncyCastleProvider: " + enableBouncyCastleProvider
                     + "\n    bouncyCastleProviderPosition: " + bouncyCastleProviderPosition);
         }

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/validator/OAuthIntrospectionValidator.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/validator/OAuthIntrospectionValidator.java
@@ -18,6 +18,7 @@ import javax.net.ssl.SSLSocketFactory;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Collections;
 import java.util.List;
 
 import static io.strimzi.kafka.oauth.common.HttpUtil.post;
@@ -212,8 +213,8 @@ public class OAuthIntrospectionValidator implements TokenValidator {
 
         if (audience != null) {
             value = response.get("aud");
-            List<String> audienceList = JSONUtil.asListOfString(value);
-            if (value == null || !audienceList.contains(audience)) {
+            List<String> audienceList = value != null ? JSONUtil.asListOfString(value) : Collections.emptyList();
+            if (!audienceList.contains(audience)) {
                 throw new TokenValidationException("Token check failed - invalid audience: " + value)
                         .status(Status.INVALID_TOKEN);
             }

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/validator/OAuthIntrospectionValidator.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/validator/OAuthIntrospectionValidator.java
@@ -18,6 +18,7 @@ import javax.net.ssl.SSLSocketFactory;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.List;
 
 import static io.strimzi.kafka.oauth.common.HttpUtil.post;
 import static io.strimzi.kafka.oauth.common.HttpUtil.get;
@@ -106,7 +107,8 @@ public class OAuthIntrospectionValidator implements TokenValidator {
                     + "\n    userInfoUri: " + userInfoURI
                     + "\n    validTokenType: " + validTokenType
                     + "\n    clientId: " + clientId
-                    + "\n    clientSecret: " + mask(clientSecret));
+                    + "\n    clientSecret: " + mask(clientSecret)
+                    + "\n    audience: " + audience);
         }
     }
 
@@ -210,7 +212,8 @@ public class OAuthIntrospectionValidator implements TokenValidator {
 
         if (audience != null) {
             value = response.get("aud");
-            if (value == null || !audience.equals(value.asText())) {
+            List<String> audienceList = JSONUtil.asListOfString(value);
+            if (value == null || !audienceList.contains(audience)) {
                 throw new TokenValidationException("Token check failed - invalid audience: " + value)
                         .status(Status.INVALID_TOKEN);
             }

--- a/oauth-server/src/main/java/io/strimzi/kafka/oauth/server/JaasServerOauthValidatorCallbackHandler.java
+++ b/oauth-server/src/main/java/io/strimzi/kafka/oauth/server/JaasServerOauthValidatorCallbackHandler.java
@@ -136,7 +136,7 @@ import static io.strimzi.kafka.oauth.common.LogUtil.mask;
  * Common optional <em>sasl.jaas.config</em> configuration:
  * <ul>
  * <li><em>oauth.crypto.provider.bouncycastle</em> If set to `true` the BouncyCastle crypto provider is installed. <br>
- * Installing BouncyCastle crypto provider adds suport for ECDSA signing algorithm. Default value is `false`.
+ * Installing BouncyCastle crypto provider adds suport for ECDSA signing algorithm. Default value is <em>false</em>.
  * </li>
  * <li><em>oauth.crypto.provider.bouncycastle.position</em> The position in the list of crypto providers where BouncyCastle provider should be installed.<br>
  * The position counting starts at 1. Any value less than 1 installs the provider at the end of the crypto providers list. Default value is '0'.</li>
@@ -250,7 +250,7 @@ public class JaasServerOauthValidatorCallbackHandler implements AuthenticateCall
         String clientSecret = config.getValue(Config.OAUTH_CLIENT_SECRET);
 
         if (checkAudience && clientId == null) {
-            throw new RuntimeException("Oauth validator configuration error: OAUTH_CLIENT_ID must be set when OAUTH_CHECK_AUDIENCE is set");
+            throw new RuntimeException("Oauth validator configuration error: OAUTH_CLIENT_ID must be set when OAUTH_CHECK_AUDIENCE is 'true'");
         }
         String audience = checkAudience ? clientId : null;
 

--- a/oauth-server/src/main/java/io/strimzi/kafka/oauth/server/JaasServerOauthValidatorCallbackHandler.java
+++ b/oauth-server/src/main/java/io/strimzi/kafka/oauth/server/JaasServerOauthValidatorCallbackHandler.java
@@ -107,11 +107,11 @@ import static io.strimzi.kafka.oauth.common.LogUtil.mask;
  * Optional <em>sasl.jaas.config</em> configuration:
  * </p>
  * <ul>
- * <li><em>oauth.jwks.refresh.seconds</em> Configures how often the JWKS certificates are refreshed. <br/>
+ * <li><em>oauth.jwks.refresh.seconds</em> Configures how often the JWKS certificates are refreshed. <br>
  * The refresh interval has to be at least 60 seconds shorter then the expiry interval specified in <em>oauth.jwks.expiry.seconds</em>. Default value is <em>300</em>.</li>
- * <li><em>oauth.jwks.expiry.seconds</em> Configures how often the JWKS certificates are considered valid. <br/>
+ * <li><em>oauth.jwks.expiry.seconds</em> Configures how often the JWKS certificates are considered valid. <br>
  * The expiry interval has to be at least 60 seconds longer then the refresh interval specified in <em>oauth.jwks.refresh.seconds</em>. Default value is <em>360</em>.</li>
- * <li><em>oauth.jwks.refresh.min.pause.seconds</em> The minimum pause between two consecutive refreshes. <br/>
+ * <li><em>oauth.jwks.refresh.min.pause.seconds</em> The minimum pause between two consecutive refreshes. <br>
  * When an unknown signing key is encountered the refresh is scheduled immediately, but will always wait for this minimum pause. Default value is <em>1</em>.</li>
  * </ul>
  * <p>
@@ -120,7 +120,7 @@ import static io.strimzi.kafka.oauth.common.LogUtil.mask;
  * Required <em>sasl.jaas.config</em> configuration:
  * </p>
  * <ul>
- * <li><em>oauth.introspection.endpoint.uri</em> A URL of the token introspection endpoint to which token validation is delegates. <br/>
+ * <li><em>oauth.introspection.endpoint.uri</em> A URL of the token introspection endpoint to which token validation is delegates. <br>
  * It can be used to validate opaque non-JWT tokens which can't be checked using fast local token validation.</li>
  * <li><em>oauth.client.id</em> OAuth client id which the Kafka broker uses to authenticate against the authorization server to use the introspection endpoint.</li>
  * <li><em>oauth.client.secret</em> The OAuth client secret which the Kafka broker uses to authenticate to the authorization server and use the introspection endpoint.</li>
@@ -135,28 +135,29 @@ import static io.strimzi.kafka.oauth.common.LogUtil.mask;
  * <p>
  * Common optional <em>sasl.jaas.config</em> configuration:
  * <ul>
- * <li><em>oauth.crypto.provider.bouncycastle</em> If set to `true` the BouncyCastle crypto provider is installed. <br/>
+ * <li><em>oauth.crypto.provider.bouncycastle</em> If set to `true` the BouncyCastle crypto provider is installed. <br>
  * Installing BouncyCastle crypto provider adds suport for ECDSA signing algorithm. Default value is `false`.
  * </li>
- * <li><em>oauth.crypto.provider.bouncycastle.position</em> The position in the list of crypto providers where BouncyCastle provider should be installed.<br/>
+ * <li><em>oauth.crypto.provider.bouncycastle.position</em> The position in the list of crypto providers where BouncyCastle provider should be installed.<br>
  * The position counting starts at 1. Any value less than 1 installs the provider at the end of the crypto providers list. Default value is '0'.</li>
- * <li><em>oauth.username.claim</em> The attribute key that should be used to extract the user id. If not set `sub` attribute is used.<br/>
+ * <li><em>oauth.username.claim</em> The attribute key that should be used to extract the user id. If not set `sub` attribute is used.<br>
  * The attribute key refers to the JWT token claim when fast local validation is used, or to attribute in the response by introspection endpoint when introspection based validation is used. It has no default value.</li>
- * <li><em>oauth.fallback.username.claim</em> The fallback username claim to be used for the user id if the attribute key specified by `oauth.username.claim` <br/>
+ * <li><em>oauth.fallback.username.claim</em> The fallback username claim to be used for the user id if the attribute key specified by `oauth.username.claim` <br>
  * is not present. This is useful when `client_credentials` authentication only results in the client id being provided in another claim.
- * <li><em>oauth.fallback.username.prefix</em> The prefix to use with the value of <em>oauth.fallback.username.claim</em> to construct the user id.  <br/>
+ * <li><em>oauth.fallback.username.prefix</em> The prefix to use with the value of <em>oauth.fallback.username.claim</em> to construct the user id.  <br>
  * This only takes effect if <em>oauth.fallback.username.claim</em> is <em>true</em>, and the value is present for the claim.
  * Mapping usernames and client ids into the same user id space is useful in preventing name collisions.</li>
- * <li><em>oauth.check.issuer</em> Enable or disable issuer checking. <br/>
+ * <li><em>oauth.check.issuer</em> Enable or disable issuer checking. <br>
  * By default issuer is checked using the value configured by <em>oauth.valid.issuer.uri</em>. Default value is <em>true</em></li>
- * <li><em>oauth.access.token.is.jwt</em> Configure whether the access token is treated as JWT. <br/>
+ * <li><em>oauth.check.audience</em> Enable or disable audience checking. <br>
+ * Enabling audience check limits access only to tokens explicitly issued for access to your Kafka broker. If enabled, the <em>oauth.client.id</em> also has to be configured. Default value is <em>false</em></li>
+ * <li><em>oauth.access.token.is.jwt</em> Configure whether the access token is treated as JWT. <br>
  * This must be set to <em>false</em> if the authorization server returns opaque tokens. Default value is <em>true</em>.</li>
  * <li><em>oauth.tokens.not.jwt</em> Deprecated. Same as <em>oauth.access.token.is.jwt</em> with opposite meaning.</li>
- * <li><em>oauth.check.access.token.type</em> Configure whether the access token type check is performed or not. <br/>
+ * <li><em>oauth.check.access.token.type</em> Configure whether the access token type check is performed or not. <br>
  * This should be set to <em>false</em> if the authorization server does not include <em>typ</em> claim in JWT token. Default value is <em>true</em>.</li>
  * <li><em>oauth.validation.skip.type.check</em> Deprecated. Same as <em>oauth.check.access.token.type</em> with opposite meaning.</li>
  * </ul>
- * </p>
  * <p>
  * TLS <em>sasl.jaas.config</em> configuration for TLS connectivity with the authorization server:
  * </p>
@@ -180,7 +181,6 @@ import static io.strimzi.kafka.oauth.common.LogUtil.mask;
  * If not set, the default value is <em>HTTPS</em> which enforces hostname verification for server certificates.
  * </li>
  * </ul>
- * </p>
  */
 public class JaasServerOauthValidatorCallbackHandler implements AuthenticateCallbackHandler {
 
@@ -227,6 +227,7 @@ public class JaasServerOauthValidatorCallbackHandler implements AuthenticateCall
         }
 
         boolean checkTokenType = isCheckAccessTokenType(config);
+        boolean checkAudience = config.getValueAsBoolean(ServerConfig.OAUTH_CHECK_AUDIENCE, false);
 
         String usernameClaim = config.getValue(Config.OAUTH_USERNAME_CLAIM);
         String fallbackUsernameClaim = config.getValue(Config.OAUTH_FALLBACK_USERNAME_CLAIM);
@@ -244,6 +245,14 @@ public class JaasServerOauthValidatorCallbackHandler implements AuthenticateCall
                 usernameClaim,
                 fallbackUsernameClaim,
                 fallbackUsernamePrefix);
+
+        String clientId = config.getValue(Config.OAUTH_CLIENT_ID);
+        String clientSecret = config.getValue(Config.OAUTH_CLIENT_SECRET);
+
+        if (checkAudience && clientId == null) {
+            throw new RuntimeException("Oauth validator configuration error: OAUTH_CLIENT_ID must be set when OAUTH_CHECK_AUDIENCE is set");
+        }
+        String audience = checkAudience ? clientId : null;
 
         if (!Services.isAvailable()) {
             Services.configure(configs);
@@ -265,6 +274,7 @@ public class JaasServerOauthValidatorCallbackHandler implements AuthenticateCall
 
             vkey = new ValidatorKey.JwtValidatorKey(
                     validIssuerUri,
+                    audience,
                     usernameClaim,
                     fallbackUsernameClaim,
                     fallbackUsernamePrefix,
@@ -291,7 +301,7 @@ public class JaasServerOauthValidatorCallbackHandler implements AuthenticateCall
                     jwksMinPauseSeconds,
                     jwksExpirySeconds,
                     checkTokenType,
-                    null,
+                    audience,
                     enableBouncy,
                     bouncyPosition);
 
@@ -300,11 +310,10 @@ public class JaasServerOauthValidatorCallbackHandler implements AuthenticateCall
             String introspectionEndpoint = config.getValue(ServerConfig.OAUTH_INTROSPECTION_ENDPOINT_URI);
             String userInfoEndpoint = config.getValue(ServerConfig.OAUTH_USERINFO_ENDPOINT_URI);
             String validTokenType = config.getValue(ServerConfig.OAUTH_VALID_TOKEN_TYPE);
-            String clientId = config.getValue(Config.OAUTH_CLIENT_ID);
-            String clientSecret = config.getValue(Config.OAUTH_CLIENT_SECRET);
 
             vkey = new ValidatorKey.IntrospectionValidatorKey(
                     validIssuerUri,
+                    audience,
                     usernameClaim,
                     fallbackUsernameClaim,
                     fallbackUsernamePrefix,
@@ -329,7 +338,7 @@ public class JaasServerOauthValidatorCallbackHandler implements AuthenticateCall
                     validTokenType,
                     clientId,
                     clientSecret,
-                    null);
+                    audience);
         }
 
         validator = Services.getInstance().getValidators().get(vkey, factory);

--- a/oauth-server/src/main/java/io/strimzi/kafka/oauth/server/ServerConfig.java
+++ b/oauth-server/src/main/java/io/strimzi/kafka/oauth/server/ServerConfig.java
@@ -19,6 +19,7 @@ public class ServerConfig extends Config {
     public static final String OAUTH_USERINFO_ENDPOINT_URI = "oauth.userinfo.endpoint.uri";
     public static final String OAUTH_CHECK_ACCESS_TOKEN_TYPE = "oauth.check.access.token.type";
     public static final String OAUTH_CHECK_ISSUER = "oauth.check.issuer";
+    public static final String OAUTH_CHECK_AUDIENCE = "oauth.check.audience";
     public static final String OAUTH_CRYPTO_PROVIDER_BOUNCYCASTLE = "oauth.crypto.provider.bouncycastle";
     public static final String OAUTH_CRYPTO_PROVIDER_BOUNCYCASTLE_POSITION = "oauth.crypto.provider.bouncycastle.position";
     public static final String OAUTH_VALID_TOKEN_TYPE = "oauth.valid.token.type";

--- a/testsuite/README.md
+++ b/testsuite/README.md
@@ -57,8 +57,11 @@ Only one at a time can be applied. For example:
 
 If you only want to run a single test, you first have to build the testsuite 'parent':
 
-    mvn clean install -f testsuite -pl .
+Note: just building the testsuite module is not enough (`mvn clean install -f testsuite -pl .`)
+
+    mvn clean install -f testsuite
     mvn test -f testsuite/client-secret-jwt-keycloak-test
+
 
 Troubleshooting
 ===============

--- a/testsuite/README.md
+++ b/testsuite/README.md
@@ -55,9 +55,9 @@ Only one at a time can be applied. For example:
  
     mvn clean install -f testsuite -Pkafka-2_4_1
 
-If you want to run only a single test, you first have to build the whole testsuite:
+If you only want to run a single test, you first have to build the testsuite 'parent':
 
-    mvn clean install -f testsuite -DskipTests
+    mvn clean install -f testsuite -pl .
     mvn test -f testsuite/client-secret-jwt-keycloak-test
 
 Troubleshooting

--- a/testsuite/access-token-introspection-keycloak-test/docker-compose.yml
+++ b/testsuite/access-token-introspection-keycloak-test/docker-compose.yml
@@ -32,7 +32,7 @@ services:
     ports:
       - 9092:9092
     volumes:
-      - ${PWD}/../target/kafka/libs:/opt/kafka/libs/strimzi
+      - ${PWD}/../docker/target/kafka/libs:/opt/kafka/libs/strimzi
       - ${PWD}/../docker/kafka/config:/opt/kafka/config/strimzi
       - ${PWD}/../docker/kafka/scripts:/opt/kafka/strimzi
     command:

--- a/testsuite/client-secret-introspection-keycloak-audience-test/arquillian.xml
+++ b/testsuite/client-secret-introspection-keycloak-audience-test/arquillian.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<arquillian xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns="http://jboss.org/schema/arquillian"
+            xsi:schemaLocation="http://jboss.org/schema/arquillian
+  http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+
+    <extension qualifier="docker">
+        <property name="dockerContainersFile">docker-compose.yml</property>
+        <property name="cubeSpecificProperties">
+            zookeeper:
+              await:
+                strategy: sleeping
+                sleepTime: 5 s
+            kafka:
+              await:
+                strategy: log
+                match: '[KafkaServer id=1] started'
+                timeout: 120
+              beforeStop:
+                - log:
+                    to: ${PWD}/../kafka.log
+                    stdout: true
+                    stderr: true
+            keycloak:
+              await:
+                strategy: log
+                match: 'regexp:.* Keycloak .* started in .*'
+                timeout: 120
+        </property>
+    </extension>
+</arquillian>

--- a/testsuite/client-secret-introspection-keycloak-audience-test/docker-compose.yml
+++ b/testsuite/client-secret-introspection-keycloak-audience-test/docker-compose.yml
@@ -56,16 +56,9 @@ services:
       - KAFKA_SUPER_USERS=User:service-account-kafka
       - KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1
 
-      # Enable re-authentication
-      - KAFKA_LISTENER_NAME_CLIENT_OAUTHBEARER_CONNECTIONS_MAX_REAUTH_MS=3600000
-
       - KAFKA_AUTHORIZER_CLASS_NAME=io.strimzi.kafka.oauth.server.authorizer.KeycloakRBACAuthorizer
-      - KAFKA_PRINCIPAL_BUILDER_CLASS=io.strimzi.kafka.oauth.server.OAuthKafkaPrincipalBuilder
+      - KAFKA_PRINCIPAL_BUILDER_CLASS=io.strimzi.kafka.oauth.server.authorizer.JwtKafkaPrincipalBuilder
       - KAFKA_STRIMZI_AUTHORIZATION_KAFKA_CLUSTER_NAME=cluster2
-
-      # Configure grants refresh parameters
-      - KAFKA_STRIMZI_AUTHORIZATION_GRANTS_REFRESH_POOL_SIZE=4
-      - KAFKA_STRIMZI_AUTHORIZATION_GRANTS_REFRESH_PERIOD_SECONDS=120
 
       # Authentication config
       - OAUTH_CLIENT_ID=kafka
@@ -74,13 +67,11 @@ services:
 
       # Validation config
       - OAUTH_VALID_ISSUER_URI=http://${KEYCLOAK_HOST:-keycloak}:8080/auth/realms/${REALM:-kafka-authz}
-      - OAUTH_JWKS_ENDPOINT_URI=http://${KEYCLOAK_HOST:-keycloak}:8080/auth/realms/${REALM:-kafka-authz}/protocol/openid-connect/certs
+      - OAUTH_INTROSPECTION_ENDPOINT_URI=http://${KEYCLOAK_HOST:-keycloak}:8080/auth/realms/${REALM:-kafka-authz}/protocol/openid-connect/token/introspect
+      - OAUTH_CHECK_AUDIENCE=true
 
       # username extraction from JWT token claim
       - OAUTH_USERNAME_CLAIM=preferred_username
-
-      # Minimum pause between two refreshes of JWKS keys when unknown key is encountered
-      - OAUTH_JWKS_REFRESH_MIN_PAUSE_SECONDS=5
 
       # For start.sh script to know where the keycloak is listening
       - KEYCLOAK_HOST=${KEYCLOAK_HOST:-keycloak}

--- a/testsuite/client-secret-introspection-keycloak-audience-test/pom.xml
+++ b/testsuite/client-secret-introspection-keycloak-audience-test/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.strimzi.oauth.testsuite</groupId>
+        <artifactId>kafka-oauth-testsuite</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>client-secret-introspection-keycloak-audience-test</artifactId>
+
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+        </license>
+    </licenses>
+
+    <properties>
+        <checkstyle.dir>../..</checkstyle.dir>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.arquillian.universe</groupId>
+            <artifactId>arquillian-junit-standalone</artifactId>
+            <type>pom</type>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${version.junit}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.arquillian.universe</groupId>
+            <artifactId>arquillian-cube-docker</artifactId>
+            <type>pom</type>
+        </dependency>
+
+        <dependency>
+            <groupId>io.strimzi</groupId>
+            <artifactId>kafka-oauth-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.strimzi</groupId>
+            <artifactId>kafka-oauth-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/testsuite/client-secret-introspection-keycloak-audience-test/src/test/java/io/strimzi/testsuite/oauth/KeycloakAuthWithIntrospectAudienceValidationTest.java
+++ b/testsuite/client-secret-introspection-keycloak-audience-test/src/test/java/io/strimzi/testsuite/oauth/KeycloakAuthWithIntrospectAudienceValidationTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2017-2019, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.testsuite.oauth;
+
+import io.strimzi.kafka.oauth.client.ClientConfig;
+import io.strimzi.kafka.oauth.common.ConfigProperties;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.errors.AuthenticationException;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.jboss.arquillian.junit.Arquillian;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.Properties;
+import java.util.concurrent.ExecutionException;
+
+@RunWith(Arquillian.class)
+public class KeycloakAuthWithIntrospectAudienceValidationTest {
+
+    private static final String HOST = "keycloak";
+    private static final String REALM = "kafka-authz";
+    private static final String TOKEN_ENDPOINT_URI = "http://" + HOST + ":8080/auth/realms/" + REALM + "/protocol/openid-connect/token";
+
+    private static final String TEAM_A_CLIENT = "team-a-client";
+    private static final String TEAM_B_CLIENT = "team-b-client";
+
+    @Test
+    public void doTest() throws Exception {
+        System.out.println("==== KeycloakAccessTokenWithIntrospectionAudienceValidationTest ====");
+
+        Properties defaults = new Properties();
+        defaults.setProperty(ClientConfig.OAUTH_TOKEN_ENDPOINT_URI, TOKEN_ENDPOINT_URI);
+        defaults.setProperty(ClientConfig.OAUTH_USERNAME_CLAIM, "preferred_username");
+
+        ConfigProperties.resolveAndExportToSystemProperties(defaults);
+
+        Properties p = System.getProperties();
+        for (Object key: p.keySet()) {
+            System.out.println("" + key + "=" + p.get(key));
+        }
+
+        Properties producerProps = buildProducerConfig(TEAM_B_CLIENT, TEAM_B_CLIENT + "-secret");
+        Producer<String, String> producer = new KafkaProducer<>(producerProps);
+        RecordMetadata result = producer.send(new ProducerRecord<>("b_topic", "message")).get();
+
+        Assert.assertTrue("Has offset", result.hasOffset());
+        producer.close();
+
+        producerProps = buildProducerConfig(TEAM_A_CLIENT, TEAM_A_CLIENT + "-secret");
+        producer = new KafkaProducer<>(producerProps);
+        try {
+            producer.send(new ProducerRecord<>("whatever", "message")).get();
+            Assert.fail();
+
+        } catch (ExecutionException e) {
+            Throwable cause = e.getCause();
+            Assert.assertTrue("instanceOf AuthenticationException", cause instanceof AuthenticationException);
+            Assert.assertTrue("audience check failed", cause.toString().contains("audience"));
+        }
+    }
+
+    static Properties buildProducerConfig(String clientId, String secret) {
+        Properties p = new Properties();
+        p.setProperty("security.protocol", "SASL_PLAINTEXT");
+        p.setProperty("sasl.mechanism", "OAUTHBEARER");
+        p.setProperty("sasl.jaas.config", "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required " +
+                " oauth.client.id=\"" + clientId + "\" oauth.client.secret=\"" + secret + "\";");
+        p.setProperty("sasl.login.callback.handler.class", "io.strimzi.kafka.oauth.client.JaasClientOauthLoginCallbackHandler");
+
+        p.setProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "kafka:9092");
+        p.setProperty(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+        p.setProperty(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+        p.setProperty(ProducerConfig.ACKS_CONFIG, "all");
+
+        return p;
+    }
+}

--- a/testsuite/client-secret-jwt-keycloak-audience-test/arquillian.xml
+++ b/testsuite/client-secret-jwt-keycloak-audience-test/arquillian.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<arquillian xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns="http://jboss.org/schema/arquillian"
+            xsi:schemaLocation="http://jboss.org/schema/arquillian
+  http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+
+    <extension qualifier="docker">
+        <property name="dockerContainersFile">docker-compose.yml</property>
+        <property name="cubeSpecificProperties">
+            zookeeper:
+              await:
+                strategy: sleeping
+                sleepTime: 5 s
+            kafka:
+              await:
+                strategy: log
+                match: '[KafkaServer id=1] started'
+                timeout: 120
+              beforeStop:
+                - log:
+                    to: ${PWD}/../kafka.log
+                    stdout: true
+                    stderr: true
+            keycloak:
+              await:
+                strategy: log
+                match: 'regexp:.* Keycloak .* started in .*'
+                timeout: 120
+        </property>
+    </extension>
+</arquillian>

--- a/testsuite/client-secret-jwt-keycloak-audience-test/docker-compose.yml
+++ b/testsuite/client-secret-jwt-keycloak-audience-test/docker-compose.yml
@@ -34,6 +34,8 @@ services:
     container_name: kafka
     ports:
       - 9092:9092
+      # javaagent debug port
+      #- 5006:5006
     volumes:
       - ${PWD}/../docker/target/kafka/libs:/opt/kafka/libs/strimzi
       - ${PWD}/../docker/kafka/config:/opt/kafka/config/strimzi
@@ -43,6 +45,10 @@ services:
       - -c
       - cd /opt/kafka/strimzi && ./start.sh
     environment:
+      #- KAFKA_DEBUG=y
+      #- DEBUG_SUSPEND_FLAG=y
+      #- JAVA_DEBUG_PORT=*:5006
+
       - KAFKA_BROKER_ID=1
       - KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181
       - KAFKA_LISTENERS=CLIENT://kafka:9092
@@ -56,16 +62,9 @@ services:
       - KAFKA_SUPER_USERS=User:service-account-kafka
       - KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1
 
-      # Enable re-authentication
-      - KAFKA_LISTENER_NAME_CLIENT_OAUTHBEARER_CONNECTIONS_MAX_REAUTH_MS=3600000
-
       - KAFKA_AUTHORIZER_CLASS_NAME=io.strimzi.kafka.oauth.server.authorizer.KeycloakRBACAuthorizer
-      - KAFKA_PRINCIPAL_BUILDER_CLASS=io.strimzi.kafka.oauth.server.OAuthKafkaPrincipalBuilder
+      - KAFKA_PRINCIPAL_BUILDER_CLASS=io.strimzi.kafka.oauth.server.authorizer.JwtKafkaPrincipalBuilder
       - KAFKA_STRIMZI_AUTHORIZATION_KAFKA_CLUSTER_NAME=cluster2
-
-      # Configure grants refresh parameters
-      - KAFKA_STRIMZI_AUTHORIZATION_GRANTS_REFRESH_POOL_SIZE=4
-      - KAFKA_STRIMZI_AUTHORIZATION_GRANTS_REFRESH_PERIOD_SECONDS=120
 
       # Authentication config
       - OAUTH_CLIENT_ID=kafka
@@ -75,12 +74,10 @@ services:
       # Validation config
       - OAUTH_VALID_ISSUER_URI=http://${KEYCLOAK_HOST:-keycloak}:8080/auth/realms/${REALM:-kafka-authz}
       - OAUTH_JWKS_ENDPOINT_URI=http://${KEYCLOAK_HOST:-keycloak}:8080/auth/realms/${REALM:-kafka-authz}/protocol/openid-connect/certs
+      - OAUTH_CHECK_AUDIENCE=true
 
       # username extraction from JWT token claim
       - OAUTH_USERNAME_CLAIM=preferred_username
-
-      # Minimum pause between two refreshes of JWKS keys when unknown key is encountered
-      - OAUTH_JWKS_REFRESH_MIN_PAUSE_SECONDS=5
 
       # For start.sh script to know where the keycloak is listening
       - KEYCLOAK_HOST=${KEYCLOAK_HOST:-keycloak}

--- a/testsuite/client-secret-jwt-keycloak-audience-test/pom.xml
+++ b/testsuite/client-secret-jwt-keycloak-audience-test/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.strimzi.oauth.testsuite</groupId>
+        <artifactId>kafka-oauth-testsuite</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>client-secret-jwt-keycloak-audience-test</artifactId>
+
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+        </license>
+    </licenses>
+
+    <properties>
+        <checkstyle.dir>../..</checkstyle.dir>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.arquillian.universe</groupId>
+            <artifactId>arquillian-junit-standalone</artifactId>
+            <type>pom</type>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${version.junit}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.arquillian.universe</groupId>
+            <artifactId>arquillian-cube-docker</artifactId>
+            <type>pom</type>
+        </dependency>
+
+        <dependency>
+            <groupId>io.strimzi</groupId>
+            <artifactId>kafka-oauth-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.strimzi</groupId>
+            <artifactId>kafka-oauth-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/testsuite/client-secret-jwt-keycloak-audience-test/src/test/java/io/strimzi/testsuite/oauth/KeycloakAuthWithJwtAudienceValidationTest.java
+++ b/testsuite/client-secret-jwt-keycloak-audience-test/src/test/java/io/strimzi/testsuite/oauth/KeycloakAuthWithJwtAudienceValidationTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2017-2019, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.testsuite.oauth;
+
+import io.strimzi.kafka.oauth.client.ClientConfig;
+import io.strimzi.kafka.oauth.common.ConfigProperties;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.errors.AuthenticationException;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.jboss.arquillian.junit.Arquillian;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.Properties;
+import java.util.concurrent.ExecutionException;
+
+
+@RunWith(Arquillian.class)
+public class KeycloakAuthWithJwtAudienceValidationTest {
+
+    private static final String HOST = "keycloak";
+    private static final String REALM = "kafka-authz";
+    private static final String TOKEN_ENDPOINT_URI = "http://" + HOST + ":8080/auth/realms/" + REALM + "/protocol/openid-connect/token";
+
+    private static final String TEAM_A_CLIENT = "team-a-client";
+    private static final String TEAM_B_CLIENT = "team-b-client";
+
+
+    @Test
+    public void doTest() throws Exception {
+        System.out.println("==== KeycloakAuthWithJwtAudienceValidationTest ====");
+
+        Properties defaults = new Properties();
+        defaults.setProperty(ClientConfig.OAUTH_TOKEN_ENDPOINT_URI, TOKEN_ENDPOINT_URI);
+        defaults.setProperty(ClientConfig.OAUTH_USERNAME_CLAIM, "preferred_username");
+
+        ConfigProperties.resolveAndExportToSystemProperties(defaults);
+
+        Properties p = System.getProperties();
+        for (Object key: p.keySet()) {
+            System.out.println("" + key + "=" + p.get(key));
+        }
+
+        Properties producerProps = buildProducerConfig(TEAM_B_CLIENT, TEAM_B_CLIENT + "-secret");
+        Producer<String, String> producer = new KafkaProducer<>(producerProps);
+        RecordMetadata result = producer.send(new ProducerRecord<>("b_topic", "message")).get();
+
+        Assert.assertTrue("Has offset", result.hasOffset());
+        producer.close();
+
+        producerProps = buildProducerConfig(TEAM_A_CLIENT, TEAM_A_CLIENT + "-secret");
+        producer = new KafkaProducer<>(producerProps);
+        try {
+            producer.send(new ProducerRecord<>("whatever", "message")).get();
+            Assert.fail();
+
+        } catch (ExecutionException e) {
+            Throwable cause = e.getCause();
+            Assert.assertTrue("instanceOf AuthenticationException", cause instanceof AuthenticationException);
+            Assert.assertTrue("audience check failed", cause.toString().contains("audience"));
+        }
+    }
+
+    static Properties buildProducerConfig(String clientId, String secret) {
+        Properties p = new Properties();
+        p.setProperty("security.protocol", "SASL_PLAINTEXT");
+        p.setProperty("sasl.mechanism", "OAUTHBEARER");
+        p.setProperty("sasl.jaas.config", "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required " +
+                " oauth.client.id=\"" + clientId + "\" oauth.client.secret=\"" + secret + "\";");
+        p.setProperty("sasl.login.callback.handler.class", "io.strimzi.kafka.oauth.client.JaasClientOauthLoginCallbackHandler");
+
+        p.setProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "kafka:9092");
+        p.setProperty(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+        p.setProperty(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+        p.setProperty(ProducerConfig.ACKS_CONFIG, "all");
+
+        return p;
+    }
+}

--- a/testsuite/client-secret-jwt-keycloak-authz-test/docker-compose.yml
+++ b/testsuite/client-secret-jwt-keycloak-authz-test/docker-compose.yml
@@ -35,7 +35,7 @@ services:
     ports:
       - 9092:9092
     volumes:
-      - ${PWD}/target/kafka/libs:/opt/kafka/libs/strimzi
+      - ${PWD}/../docker/target/kafka/libs:/opt/kafka/libs/strimzi
       - ${PWD}/../docker/kafka/config:/opt/kafka/config/strimzi
       - ${PWD}/../docker/kafka/scripts:/opt/kafka/strimzi
     command:

--- a/testsuite/client-secret-jwt-keycloak-test/docker-compose.yml
+++ b/testsuite/client-secret-jwt-keycloak-test/docker-compose.yml
@@ -35,7 +35,7 @@ services:
     ports:
       - 9092:9092
     volumes:
-      - ${PWD}/../target/kafka/libs:/opt/kafka/libs/strimzi
+      - ${PWD}/../docker/target/kafka/libs:/opt/kafka/libs/strimzi
       - ${PWD}/../docker/kafka/config:/opt/kafka/config/strimzi
       - ${PWD}/../docker/kafka/scripts:/opt/kafka/strimzi
     command:

--- a/testsuite/docker/keycloak/realms/kafka-authz-realm.json
+++ b/testsuite/docker/keycloak/realms/kafka-authz-realm.json
@@ -28,6 +28,10 @@
         {
           "name": "uma_protection",
           "clientRole": true
+        },
+        {
+          "name": "kafka-user",
+          "clientRole": true
         }
       ]
     }
@@ -100,6 +104,7 @@
       "serviceAccountClientId" : "team-b-client",
       "realmRoles" : [ "offline_access", "Dev Team B" ],
       "clientRoles" : {
+        "kafka" : [ "kafka-user" ],
         "account" : [ "manage-account", "view-profile" ]
       },
       "groups" : [ ]
@@ -148,6 +153,19 @@
       "authorizationServicesEnabled": true,
       "publicClient": false,
       "fullScopeAllowed": true,
+      "protocolMappers": [
+        {
+          "name": "kafka audience",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "consentRequired": false,
+          "config": {
+            "included.client.audience": "kafka",
+            "id.token.claim": "false",
+            "access.token.claim": "true"
+          }
+        }
+      ],
       "authorizationSettings": {
         "allowRemoteResourceManagement": true,
         "policyEnforcementMode": "ENFORCING",

--- a/testsuite/docker/pom.xml
+++ b/testsuite/docker/pom.xml
@@ -35,6 +35,10 @@
         </dependency>
         <dependency>
             <groupId>io.strimzi</groupId>
+            <artifactId>kafka-oauth-keycloak-authorizer</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.strimzi</groupId>
             <artifactId>kafka-oauth-server-plain</artifactId>
         </dependency>
         <dependency>
@@ -171,6 +175,10 @@
                         <artifactItem>
                             <groupId>io.strimzi</groupId>
                             <artifactId>kafka-oauth-client</artifactId>
+                        </artifactItem>
+                        <artifactItem>
+                            <groupId>io.strimzi</groupId>
+                            <artifactId>kafka-oauth-keycloak-authorizer</artifactId>
                         </artifactItem>
                         <artifactItem>
                             <groupId>io.strimzi</groupId>

--- a/testsuite/introspection-over-plain-keycloak-authz-test/docker-compose.yml
+++ b/testsuite/introspection-over-plain-keycloak-authz-test/docker-compose.yml
@@ -35,7 +35,7 @@ services:
     ports:
       - 9092:9092
     volumes:
-      - ${PWD}/target/kafka/libs:/opt/kafka/libs/strimzi
+      - ${PWD}/../docker/target/kafka/libs:/opt/kafka/libs/strimzi
       - ${PWD}/../docker/kafka/config:/opt/kafka/config/strimzi
       - ${PWD}/../docker/kafka/scripts:/opt/kafka/strimzi
     command:

--- a/testsuite/jwt-over-plain-keycloak-authz-test/docker-compose.yml
+++ b/testsuite/jwt-over-plain-keycloak-authz-test/docker-compose.yml
@@ -35,7 +35,7 @@ services:
     ports:
       - 9092:9092
     volumes:
-      - ${PWD}/target/kafka/libs:/opt/kafka/libs/strimzi
+      - ${PWD}/../docker/target/kafka/libs:/opt/kafka/libs/strimzi
       - ${PWD}/../docker/kafka/config:/opt/kafka/config/strimzi
       - ${PWD}/../docker/kafka/scripts:/opt/kafka/strimzi
     command:

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -21,6 +21,8 @@
         <module>client-secret-jwt-keycloak-authz-refresh-test</module>
         <module>jwt-over-plain-keycloak-authz-test</module>
         <module>introspection-over-plain-keycloak-authz-test</module>
+        <module>client-secret-jwt-keycloak-audience-test</module>
+        <module>client-secret-introspection-keycloak-audience-test</module>
     </modules>
 
     <licenses>
@@ -146,7 +148,7 @@
                 <executions>
                     <execution>
                         <id>copy-kafka-example-truststore</id>
-                        <phase>package</phase>
+                        <phase>install</phase>
                         <goals>
                             <goal>copy-resources</goal>
                         </goals>
@@ -165,7 +167,7 @@
                     </execution>
                     <execution>
                         <id>copy-keycloak-example-keystore</id>
-                        <phase>package</phase>
+                        <phase>install</phase>
                         <goals>
                             <goal>copy-resources</goal>
                         </goals>
@@ -191,7 +193,7 @@
                 <executions>
                     <execution>
                         <id>copy</id>
-                        <phase>package</phase>
+                        <phase>install</phase>
                         <goals>
                             <goal>copy</goal>
                         </goals>


### PR DESCRIPTION
Support for audience checking.

When enabled the Kafka broker rejects during authentication any access token that does not contain the Kafka broker's OAuth client ID in`aud` claim.