### PR TITLE
Fix the javadoc build on Java 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -342,6 +342,8 @@
                             <show>public</show>
                             <failOnError>true</failOnError>
                             <failOnWarnings>true</failOnWarnings>
+                            <source>8</source>
+                            <detectJavaApiLink>false</detectJavaApiLink>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
The OAuth library targets Java 8 to make it possible to use it with Java 8 apps. But it would be nice to have it compile on Java 11. This sets the right Java target version for the JavaDoc plugin to make it work. 

This should close #91.