### PR TITLE
Fix for intermittent authentication failures with OAuth over PLAIN

### DIFF
--- a/README.md
+++ b/README.md
@@ -892,9 +892,9 @@ There is no OAuth specific configuration that would be required on the client wh
 The Kafka Broker has to have the SASL_PLAIN mechanism enabled and properly configured with `JaasServerOauthOverPlainValidatorCallbackHandler` validation callback handler. 
 
 Then, the standard SASL_PLAIN configuration is used on the client with the following two options:
-- the client can authenticate using the service account client ID and secret. Setting the `username` to the value of client ID, and setting the `password` to the value of client secret
+- the client can authenticate using the service account client ID and secret. Setting the `username` to the value of client ID, and setting the `password` to the value of client secret. The Kafka broker will use the client credentials to obtain the access token from the authorization server. 
 - the client can authenticate using a long-lived access token obtained through a browser sign-in or through using `curl` or similar CLI tool to obtain the access token with `client credentials` or the `password` authentication, 
-  then setting the `username` to `$accessToken` reserved word and setting `password` to the access token string. 
+  then setting the `username` to the same principal id that the broker will resolve from the provided access token, and setting `password` to prefix `$accessToken:` followed by the access token string. It is the presence of the `$accessToken:` prefix that tells the broker that it should extract the access token from the `password`
 
 For example, when using the Kafka Client Java library the configuration might look like:
 

--- a/README.md
+++ b/README.md
@@ -892,7 +892,7 @@ There is no OAuth specific configuration that would be required on the client wh
 The Kafka Broker has to have the SASL_PLAIN mechanism enabled and properly configured with `JaasServerOauthOverPlainValidatorCallbackHandler` validation callback handler. 
 
 Then, the standard SASL_PLAIN configuration is used on the client with the following two options:
-- the client can authenticate using the service account client ID and secret. Setting the `username` to the value of client ID, and setting the `password` to the value of client secret. The Kafka broker will use the client credentials to obtain the access token from the authorization server. 
+- the client can authenticate using the service account client ID and secret. Setting the `username` to the value of client ID, and setting the `password` to the value of client secret. The Kafka broker will use these client credentials to obtain the access token from the authorization server. 
 - the client can authenticate using a long-lived access token obtained through a browser sign-in or through using `curl` or similar CLI tool to obtain the access token with `client credentials` or the `password` authentication, 
   then setting the `username` to the same principal id that the broker will resolve from the provided access token, and setting `password` to prefix `$accessToken:` followed by the access token string. It is the presence of the `$accessToken:` prefix that tells the broker that it should extract the access token from the `password`
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,22 @@
 Release Notes
 =============
 
+0.7.1
+-----
+
+### Fixed OAuth over PLAIN intermittent failures
+
+The initial implementation of OAuth over PLAIN was based on an invalid assumptions about how threads are assigned to handle messages from different connections in Kafka. An internal assertion often got triggered during concurrent usage, causing authentication failures.
+
+A breaking change with how `$accessToken` is used in 0.7.0 had to be introduced.
+
+Before, you could authenticate with an access token by setting `username` to `$accessToken` and setting the `password` to the access token string.
+
+Now, you have to set `username` to be the same as the principal name that the broker will extract from the given access token (for example, the value of the claim configured by `oauth.username.claim`) and set the `password` to `$accessToken:` followed by the access token string.
+
+So, compared to before, you now prefix the access token string with `$accessToken:` in the `password` parameter, and you have to be careful to properly set the `username` parameter to the principal name matching that in the access token.
+
+
 0.7.0
 -----
 

--- a/examples/docker/README.md
+++ b/examples/docker/README.md
@@ -31,7 +31,7 @@ Then, you have to add some entries to your `/etc/hosts` file:
 That's needed for host resolution, because Kafka brokers and Kafka clients connecting to Keycloak / Hydra have to use the 
 same hostname to ensure compatibility of generated access tokens.
 
-Also, when Kafka client connects to Kafka broker running inside docker image, the broker will redirect the client to: kafka:9292.
+Also, when Kafka client connects to Kafka broker running inside docker image, the broker will redirect the client to: kafka:9092.
 
 
 Running 

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/services/Credentials.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/services/Credentials.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2017-2020, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.kafka.oauth.services;
+
+import org.apache.kafka.common.security.auth.KafkaPrincipal;
+
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.Map;
+
+/**
+ * A mechanism for OAuth over PLAIN to associate credentials with the PlainSaslServer
+ */
+public class Credentials {
+
+    /**
+     * There seems to be no way to associate a principal with PlainSaslServer at authentication phase.
+     * The only information we have available there is clientId, and a secret.
+     * Multiple connections established concurrently will each store their own validated KafkaPrincipal indexed by clientId.
+     * Connections with the same clientId will each receive one validated access token.
+     * The flow should guarantee that each store is followed by a corresponding take.
+     */
+    private Map<String, LinkedList<KafkaPrincipal>> validatedCredentials = new HashMap<>();
+
+    /**
+     * Store credentials to communicate them from PLAIN callback handler to OAuthKafkaPrincipalBuilder when OAuth over PLAIN is used.
+     *
+     * @param clientId A clientId as passed to the 'username' parameter of SASL_PLAIN mechanism
+     * @param principal The OAuthKafkaPrincipal containing the validated token
+     */
+    public synchronized void storeCredentials(String clientId, KafkaPrincipal principal) {
+        LinkedList<KafkaPrincipal> queue = validatedCredentials.computeIfAbsent(clientId, k -> new LinkedList<>());
+        queue.add(principal);
+    }
+
+    /**
+     * Take credentials in order to associate them with PlainSaslServer
+     *
+     * @param clientId A clientId as passed to the 'username' parameter of SASL_PLAIN mechanism
+     * @return Stored OAuthKafkaPrincipal
+     */
+    public synchronized KafkaPrincipal takeCredentials(String clientId) {
+        LinkedList<KafkaPrincipal> queue = validatedCredentials.get(clientId);
+        if (queue == null) {
+            return null;
+        }
+
+        KafkaPrincipal result = queue.poll();
+
+        if (queue.size() == 0) {
+            validatedCredentials.remove(clientId);
+        }
+
+        return result;
+    }
+}

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/services/Services.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/services/Services.java
@@ -19,6 +19,8 @@ public class Services {
 
     private Principals principals = new Principals();
 
+    private Credentials credentials = new Credentials();
+
     public static void configure(Map<String, ?> configs) {
         services = new Services();
     }
@@ -47,5 +49,9 @@ public class Services {
 
     public Principals getPrincipals() {
         return principals;
+    }
+
+    public Credentials getCredentials() {
+        return credentials;
     }
 }

--- a/oauth-server/src/main/java/io/strimzi/kafka/oauth/server/OAuthKafkaPrincipal.java
+++ b/oauth-server/src/main/java/io/strimzi/kafka/oauth/server/OAuthKafkaPrincipal.java
@@ -20,8 +20,6 @@ import static io.strimzi.kafka.oauth.common.LogUtil.mask;
 @SuppressFBWarnings("EQ_DOESNT_OVERRIDE_EQUALS")
 public final class OAuthKafkaPrincipal extends KafkaPrincipal {
 
-    private static ThreadLocal<OAuthKafkaPrincipal> currentTL = new ThreadLocal<>();
-
     private final BearerTokenWithPayload jwt;
 
     public OAuthKafkaPrincipal(String principalType, String name) {
@@ -35,19 +33,6 @@ public final class OAuthKafkaPrincipal extends KafkaPrincipal {
 
     public BearerTokenWithPayload getJwt() {
         return jwt;
-    }
-
-    public static OAuthKafkaPrincipal takeFromThreadContext() {
-        OAuthKafkaPrincipal current = currentTL.get();
-        currentTL.remove();
-        return current;
-    }
-
-    public static void setToThreadContext(OAuthKafkaPrincipal principal) {
-        if (currentTL.get() != null) {
-            throw new RuntimeException("Internal error - current principal already set. Make sure you have 'principal.builder.class=io.strimzi.kafka.oauth.server.OAuthKafkaPrincipalBuilder' in your broker configuration file");
-        }
-        currentTL.set(principal);
     }
 
     @Override

--- a/testsuite/docker/keycloak/realms/flood-realm.json
+++ b/testsuite/docker/keycloak/realms/flood-realm.json
@@ -1,0 +1,862 @@
+{
+  "realm": "flood",
+  "accessTokenLifespan": 300,
+  "ssoSessionMaxLifespan": 32140800,
+  "ssoSessionIdleTimeout": 32140800,
+  "enabled": true,
+  "sslRequired": "external",
+  "users": [
+    {
+      "username": "service-account-kafka-producer-client-1",
+      "enabled": true,
+      "email": "service-account-kafka-producer-client-1@placeholder.org",
+      "serviceAccountClientId": "kafka-producer-client-1"
+    },
+    {
+      "username": "service-account-kafka-producer-client-2",
+      "enabled": true,
+      "email": "service-account-kafka-producer-client-2@placeholder.org",
+      "serviceAccountClientId": "kafka-producer-client-2"
+    },
+    {
+      "username": "service-account-kafka-producer-client-3",
+      "enabled": true,
+      "email": "service-account-kafka-producer-client-3@placeholder.org",
+      "serviceAccountClientId": "kafka-producer-client-3"
+    },
+    {
+      "username": "service-account-kafka-producer-client-4",
+      "enabled": true,
+      "email": "service-account-kafka-producer-client-4@placeholder.org",
+      "serviceAccountClientId": "kafka-producer-client-4"
+    },
+    {
+      "username": "service-account-kafka-producer-client-5",
+      "enabled": true,
+      "email": "service-account-kafka-producer-client-5@placeholder.org",
+      "serviceAccountClientId": "kafka-producer-client-5"
+    },
+    {
+      "username": "service-account-kafka-consumer-client-1",
+      "enabled": true,
+      "email": "service-account-kafka-consumer-client-1@placeholder.org",
+      "serviceAccountClientId": "kafka-consumer-client-1"
+    },
+    {
+      "username": "service-account-kafka-consumer-client-2",
+      "enabled": true,
+      "email": "service-account-kafka-consumer-client-2@placeholder.org",
+      "serviceAccountClientId": "kafka-consumer-client-2"
+    },
+    {
+      "username": "service-account-kafka-consumer-client-3",
+      "enabled": true,
+      "email": "service-account-kafka-consumer-client-3@placeholder.org",
+      "serviceAccountClientId": "kafka-consumer-client-3"
+    },
+    {
+      "username": "service-account-kafka-consumer-client-4",
+      "enabled": true,
+      "email": "service-account-kafka-consumer-client-4@placeholder.org",
+      "serviceAccountClientId": "kafka-consumer-client-4"
+    },
+    {
+      "username": "service-account-kafka-consumer-client-5",
+      "enabled": true,
+      "email": "service-account-kafka-consumer-client-5@placeholder.org",
+      "serviceAccountClientId": "kafka-consumer-client-5"
+    }
+  ],
+  "roles": {
+    "realm": [
+      {
+        "name": "user",
+        "description": "User privileges"
+      },
+      {
+        "name": "admin",
+        "description": "Administrator privileges"
+      }
+    ],
+    "client": {
+      "kafka": [
+        {
+          "name": "kafka-admin",
+          "description": "Kafka administrator - can perform any action on any Kafka resource",
+          "clientRole": true
+        }
+      ]
+    }
+  },
+  "scopeMappings": [
+    {
+      "client": "kafka-producer-client-1",
+      "roles": [
+        "offline_access"
+      ]
+    },
+    {
+      "client": "kafka-producer-client-2",
+      "roles": [
+        "offline_access"
+      ]
+    },
+    {
+      "client": "kafka-producer-client-3",
+      "roles": [
+        "offline_access"
+      ]
+    },
+    {
+      "client": "kafka-producer-client-4",
+      "roles": [
+        "offline_access"
+      ]
+    },
+    {
+      "client": "kafka-producer-client-5",
+      "roles": [
+        "offline_access"
+      ]
+    },
+    {
+      "client": "kafka-consumer-client-1",
+      "roles": [
+        "offline_access"
+      ]
+    },
+    {
+      "client": "kafka-consumer-client-2",
+      "roles": [
+        "offline_access"
+      ]
+    },
+    {
+      "client": "kafka-consumer-client-3",
+      "roles": [
+        "offline_access"
+      ]
+    },
+    {
+      "client": "kafka-consumer-client-4",
+      "roles": [
+        "offline_access"
+      ]
+    },
+    {
+      "client": "kafka-consumer-client-5",
+      "roles": [
+        "offline_access"
+      ]
+    },
+    {
+      "clientScope": "offline_access",
+      "roles": [
+        "offline_access"
+      ]
+    }
+  ],
+  "clientScopeMappings": {
+  },
+  "clients": [
+    {
+      "clientId": "kafka",
+      "enabled": true,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "kafka-secret",
+      "publicClient": false,
+      "bearerOnly": false,
+      "standardFlowEnabled": false,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": true,
+      "authorizationServicesEnabled": true,
+      "publicClient": false,
+      "fullScopeAllowed" : false,
+      "attributes": {
+        "access.token.lifespan": "32140800"
+      },
+      "authorizationSettings": {
+        "allowRemoteResourceManagement": true,
+        "policyEnforcementMode": "ENFORCING",
+        "resources": [
+          {
+            "name": "Topic:messages-1",
+            "type": "topic",
+            "scopes": [
+              {
+                "name": "Delete"
+              },
+              {
+                "name": "Describe"
+              },
+              {
+                "name": "Create"
+              },
+              {
+                "name": "Write"
+              },
+              {
+                "name": "Alter"
+              },
+              {
+                "name": "Read"
+              },
+              {
+                "name": "DescribeConfigs"
+              },
+              {
+                "name": "AlterConfigs"
+              }
+            ]
+          },
+          {
+            "name": "Topic:messages-2",
+            "type": "topic",
+            "scopes": [
+              {
+                "name": "Delete"
+              },
+              {
+                "name": "Describe"
+              },
+              {
+                "name": "Create"
+              },
+              {
+                "name": "Write"
+              },
+              {
+                "name": "Alter"
+              },
+              {
+                "name": "Read"
+              },
+              {
+                "name": "DescribeConfigs"
+              },
+              {
+                "name": "AlterConfigs"
+              }
+            ]
+          },
+          {
+            "name": "Topic:messages-3",
+            "type": "topic",
+            "scopes": [
+              {
+                "name": "Delete"
+              },
+              {
+                "name": "Describe"
+              },
+              {
+                "name": "Create"
+              },
+              {
+                "name": "Write"
+              },
+              {
+                "name": "Alter"
+              },
+              {
+                "name": "Read"
+              },
+              {
+                "name": "DescribeConfigs"
+              },
+              {
+                "name": "AlterConfigs"
+              }
+            ]
+          },
+          {
+            "name": "Topic:messages-4",
+            "type": "topic",
+            "scopes": [
+              {
+                "name": "Delete"
+              },
+              {
+                "name": "Describe"
+              },
+              {
+                "name": "Create"
+              },
+              {
+                "name": "Write"
+              },
+              {
+                "name": "Alter"
+              },
+              {
+                "name": "Read"
+              },
+              {
+                "name": "DescribeConfigs"
+              },
+              {
+                "name": "AlterConfigs"
+              }
+            ]
+          },
+          {
+            "name": "Topic:messages-5",
+            "type": "topic",
+            "scopes": [
+              {
+                "name": "Delete"
+              },
+              {
+                "name": "Describe"
+              },
+              {
+                "name": "Create"
+              },
+              {
+                "name": "Write"
+              },
+              {
+                "name": "Alter"
+              },
+              {
+                "name": "Read"
+              },
+              {
+                "name": "DescribeConfigs"
+              },
+              {
+                "name": "AlterConfigs"
+              }
+            ]
+          },
+          {
+            "name": "Group:g1*",
+            "type": "group",
+            "scopes": [
+              {
+                "name": "Describe"
+              },
+              {
+                "name": "Write"
+              },
+              {
+                "name": "Read"
+              }
+            ]
+          },
+          {
+            "name": "Group:g2*",
+            "type": "group",
+            "scopes": [
+              {
+                "name": "Describe"
+              },
+              {
+                "name": "Write"
+              },
+              {
+                "name": "Read"
+              }
+            ]
+          },
+          {
+            "name": "Group:g3*",
+            "type": "group",
+            "scopes": [
+              {
+                "name": "Describe"
+              },
+              {
+                "name": "Write"
+              },
+              {
+                "name": "Read"
+              }
+            ]
+          },
+          {
+            "name": "Group:g4*",
+            "type": "group",
+            "scopes": [
+              {
+                "name": "Describe"
+              },
+              {
+                "name": "Write"
+              },
+              {
+                "name": "Read"
+              }
+            ]
+          },
+          {
+            "name": "Group:g5*",
+            "type": "group",
+            "scopes": [
+              {
+                "name": "Describe"
+              },
+              {
+                "name": "Write"
+              },
+              {
+                "name": "Read"
+              }
+            ]
+          }
+        ],
+        "policies": [
+          {
+            "name": "Producer Client 1",
+            "type": "client",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "clients": "[\"kafka-producer-client-1\"]"
+            }
+          },
+          {
+            "name": "Consumer Client 1",
+            "type": "client",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "clients": "[\"kafka-consumer-client-1\"]"
+            }
+          },
+          {
+            "name": "Producer Client 2",
+            "type": "client",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "clients": "[\"kafka-producer-client-2\"]"
+            }
+          },
+          {
+            "name": "Consumer Client 2",
+            "type": "client",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "clients": "[\"kafka-consumer-client-2\"]"
+            }
+          },
+          {
+            "name": "Producer Client 3",
+            "type": "client",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "clients": "[\"kafka-producer-client-3\"]"
+            }
+          },
+          {
+            "name": "Consumer Client 3",
+            "type": "client",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "clients": "[\"kafka-consumer-client-3\"]"
+            }
+          },
+          {
+            "name": "Producer Client 4",
+            "type": "client",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "clients": "[\"kafka-producer-client-4\"]"
+            }
+          },
+          {
+            "name": "Consumer Client 4",
+            "type": "client",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "clients": "[\"kafka-consumer-client-4\"]"
+            }
+          },
+          {
+            "name": "Producer Client 5",
+            "type": "client",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "clients": "[\"kafka-producer-client-5\"]"
+            }
+          },
+          {
+            "name": "Consumer Client 5",
+            "type": "client",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "clients": "[\"kafka-consumer-client-5\"]"
+            }
+          },
+          {
+            "name": "Producer Client 1 can write to topic 'messages-1'",
+            "type": "scope",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "resources": "[\"Topic:messages-1\"]",
+              "scopes": "[\"Delete\",\"Describe\",\"Create\",\"Write\"]",
+              "applyPolicies": "[\"Producer Client 1\"]"
+            }
+          },
+          {
+            "name": "Consumer Client 1 can read from topic 'messages-1'",
+            "type": "scope",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "resources": "[\"Topic:messages-1\"]",
+              "scopes": "[\"Describe\",\"Read\"]"
+            }
+          },
+          {
+            "name": "Consumer Client 1 can use any group that starts with 'g1'",
+            "type": "scope",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "resources": "[\"Group:g1*\"]",
+              "scopes": "[\"Describe\",\"Write\",\"Read\"]"
+            }
+          },
+          {
+            "name": "Producer Client 2 can write to topic 'messages-2'",
+            "type": "scope",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "resources": "[\"Topic:messages-2\"]",
+              "scopes": "[\"Delete\",\"Describe\",\"Create\",\"Write\"]",
+              "applyPolicies": "[\"Producer Client 2\"]"
+            }
+          },
+          {
+            "name": "Consumer Client 2 can read from topic 'messages-2'",
+            "type": "scope",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "resources": "[\"Topic:messages-2\"]",
+              "scopes": "[\"Describe\",\"Read\"]"
+            }
+          },
+          {
+            "name": "Consumer Client 2 can use any group that starts with 'g2'",
+            "type": "scope",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "resources": "[\"Group:g2*\"]",
+              "scopes": "[\"Describe\",\"Write\",\"Read\"]"
+            }
+          },
+          {
+            "name": "Producer Client 3 can write to topic 'messages-3'",
+            "type": "scope",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "resources": "[\"Topic:messages-3\"]",
+              "scopes": "[\"Delete\",\"Describe\",\"Create\",\"Write\"]",
+              "applyPolicies": "[\"Producer Client 3\"]"
+            }
+          },
+          {
+            "name": "Consumer Client 3 can read from topic 'messages-3'",
+            "type": "scope",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "resources": "[\"Topic:messages-3\"]",
+              "scopes": "[\"Describe\",\"Read\"]"
+            }
+          },
+          {
+            "name": "Consumer Client 3 can use any group that starts with 'g3'",
+            "type": "scope",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "resources": "[\"Group:g3*\"]",
+              "scopes": "[\"Describe\",\"Write\",\"Read\"]"
+            }
+          },
+          {
+            "name": "Producer Client 4 can write to topic 'messages-4'",
+            "type": "scope",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "resources": "[\"Topic:messages-4\"]",
+              "scopes": "[\"Delete\",\"Describe\",\"Create\",\"Write\"]",
+              "applyPolicies": "[\"Producer Client 4\"]"
+            }
+          },
+          {
+            "name": "Consumer Client 4 can read from topic 'messages-4'",
+            "type": "scope",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "resources": "[\"Topic:messages-4\"]",
+              "scopes": "[\"Describe\",\"Read\"]"
+            }
+          },
+          {
+            "name": "Consumer Client 4 can use any group that starts with 'g4'",
+            "type": "scope",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "resources": "[\"Group:g4*\"]",
+              "scopes": "[\"Describe\",\"Write\",\"Read\"]"
+            }
+          },
+          {
+            "name": "Producer Client 5 can write to topic 'messages-5'",
+            "type": "scope",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "resources": "[\"Topic:messages-5\"]",
+              "scopes": "[\"Delete\",\"Describe\",\"Create\",\"Write\"]",
+              "applyPolicies": "[\"Producer Client 5\"]"
+            }
+          },
+          {
+            "name": "Consumer Client 5 can read from topic 'messages-5'",
+            "type": "scope",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "resources": "[\"Topic:messages-5\"]",
+              "scopes": "[\"Describe\",\"Read\"]"
+            }
+          },
+          {
+            "name": "Consumer Client 5 can use any group that starts with 'g5'",
+            "type": "scope",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "resources": "[\"Group:g5*\"]",
+              "scopes": "[\"Describe\",\"Write\",\"Read\"]"
+            }
+          }
+        ],
+        "scopes": [
+          {
+            "name": "Create"
+          },
+          {
+            "name": "Read"
+          },
+          {
+            "name": "Write"
+          },
+          {
+            "name": "Delete"
+          },
+          {
+            "name": "Alter"
+          },
+          {
+            "name": "Describe"
+          },
+          {
+            "name": "ClusterAction"
+          },
+          {
+            "name": "DescribeConfigs"
+          },
+          {
+            "name": "AlterConfigs"
+          },
+          {
+            "name": "IdempotentWrite"
+          }
+        ],
+        "decisionStrategy": "AFFIRMATIVE"
+      }
+    },
+    {
+      "clientId": "kafka-producer-client-1",
+      "enabled": true,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "kafka-producer-client-1-secret",
+      "publicClient": false,
+      "bearerOnly": false,
+      "standardFlowEnabled": false,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": true,
+      "consentRequired" : false,
+      "fullScopeAllowed" : false,
+      "attributes": {
+        "access.token.lifespan": "36000"
+      }
+    },
+    {
+      "clientId": "kafka-producer-client-2",
+      "enabled": true,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "kafka-producer-client-2-secret",
+      "publicClient": false,
+      "bearerOnly": false,
+      "standardFlowEnabled": false,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": true,
+      "consentRequired" : false,
+      "fullScopeAllowed" : false,
+      "attributes": {
+        "access.token.lifespan": "36000"
+      }
+    },
+    {
+      "clientId": "kafka-producer-client-3",
+      "enabled": true,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "kafka-producer-client-3-secret",
+      "publicClient": false,
+      "bearerOnly": false,
+      "standardFlowEnabled": false,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": true,
+      "consentRequired" : false,
+      "fullScopeAllowed" : false,
+      "attributes": {
+        "access.token.lifespan": "36000"
+      }
+    },
+    {
+      "clientId": "kafka-producer-client-4",
+      "enabled": true,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "kafka-producer-client-4-secret",
+      "publicClient": false,
+      "bearerOnly": false,
+      "standardFlowEnabled": false,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": true,
+      "consentRequired" : false,
+      "fullScopeAllowed" : false,
+      "attributes": {
+        "access.token.lifespan": "36000"
+      }
+    },
+    {
+      "clientId": "kafka-producer-client-5",
+      "enabled": true,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "kafka-producer-client-5-secret",
+      "publicClient": false,
+      "bearerOnly": false,
+      "standardFlowEnabled": false,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": true,
+      "consentRequired" : false,
+      "fullScopeAllowed" : false,
+      "attributes": {
+        "access.token.lifespan": "36000"
+      }
+    },
+    {
+      "clientId": "kafka-consumer-client-1",
+      "enabled": true,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "kafka-consumer-client-1-secret",
+      "publicClient": false,
+      "bearerOnly": false,
+      "standardFlowEnabled": false,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": true,
+      "consentRequired" : false,
+      "fullScopeAllowed" : false,
+      "attributes": {
+        "access.token.lifespan": "36000"
+      }
+    },
+    {
+      "clientId": "kafka-consumer-client-2",
+      "enabled": true,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "kafka-consumer-client-2-secret",
+      "publicClient": false,
+      "bearerOnly": false,
+      "standardFlowEnabled": false,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": true,
+      "consentRequired" : false,
+      "fullScopeAllowed" : false,
+      "attributes": {
+        "access.token.lifespan": "36000"
+      }
+    },
+    {
+      "clientId": "kafka-consumer-client-3",
+      "enabled": true,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "kafka-consumer-client-3-secret",
+      "publicClient": false,
+      "bearerOnly": false,
+      "standardFlowEnabled": false,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": true,
+      "consentRequired" : false,
+      "fullScopeAllowed" : false,
+      "attributes": {
+        "access.token.lifespan": "36000"
+      }
+    },
+    {
+      "clientId": "kafka-consumer-client-4",
+      "enabled": true,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "kafka-consumer-client-4-secret",
+      "publicClient": false,
+      "bearerOnly": false,
+      "standardFlowEnabled": false,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": true,
+      "consentRequired" : false,
+      "fullScopeAllowed" : false,
+      "attributes": {
+        "access.token.lifespan": "36000"
+      }
+    },
+    {
+      "clientId": "kafka-consumer-client-5",
+      "enabled": true,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "kafka-consumer-client-5-secret",
+      "publicClient": false,
+      "bearerOnly": false,
+      "standardFlowEnabled": false,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": true,
+      "consentRequired" : false,
+      "fullScopeAllowed" : false,
+      "attributes": {
+        "access.token.lifespan": "36000"
+      }
+    }
+  ]
+}

--- a/testsuite/docker/keycloak/realms/kafka-authz-realm.json
+++ b/testsuite/docker/keycloak/realms/kafka-authz-realm.json
@@ -108,6 +108,76 @@
         "account" : [ "manage-account", "view-profile" ]
       },
       "groups" : [ ]
+    },
+    {
+      "username": "service-account-kafka-producer-client-1",
+      "enabled": true,
+      "realmRoles" : [ "offline_access" ],
+      "email": "service-account-kafka-producer-client-1@placeholder.org",
+      "serviceAccountClientId": "kafka-producer-client-1"
+    },
+    {
+      "username": "service-account-kafka-producer-client-2",
+      "enabled": true,
+      "realmRoles" : [ "offline_access" ],
+      "email": "service-account-kafka-producer-client-2@placeholder.org",
+      "serviceAccountClientId": "kafka-producer-client-2"
+    },
+    {
+      "username": "service-account-kafka-producer-client-3",
+      "enabled": true,
+      "realmRoles" : [ "offline_access" ],
+      "email": "service-account-kafka-producer-client-3@placeholder.org",
+      "serviceAccountClientId": "kafka-producer-client-3"
+    },
+    {
+      "username": "service-account-kafka-producer-client-4",
+      "enabled": true,
+      "realmRoles" : [ "offline_access" ],
+      "email": "service-account-kafka-producer-client-4@placeholder.org",
+      "serviceAccountClientId": "kafka-producer-client-4"
+    },
+    {
+      "username": "service-account-kafka-producer-client-5",
+      "enabled": true,
+      "realmRoles" : [ "offline_access" ],
+      "email": "service-account-kafka-producer-client-5@placeholder.org",
+      "serviceAccountClientId": "kafka-producer-client-5"
+    },
+    {
+      "username": "service-account-kafka-consumer-client-1",
+      "enabled": true,
+      "realmRoles" : [ "offline_access" ],
+      "email": "service-account-kafka-consumer-client-1@placeholder.org",
+      "serviceAccountClientId": "kafka-consumer-client-1"
+    },
+    {
+      "username": "service-account-kafka-consumer-client-2",
+      "enabled": true,
+      "realmRoles" : [ "offline_access" ],
+      "email": "service-account-kafka-consumer-client-2@placeholder.org",
+      "serviceAccountClientId": "kafka-consumer-client-2"
+    },
+    {
+      "username": "service-account-kafka-consumer-client-3",
+      "enabled": true,
+      "realmRoles" : [ "offline_access" ],
+      "email": "service-account-kafka-consumer-client-3@placeholder.org",
+      "serviceAccountClientId": "kafka-consumer-client-3"
+    },
+    {
+      "username": "service-account-kafka-consumer-client-4",
+      "enabled": true,
+      "realmRoles" : [ "offline_access" ],
+      "email": "service-account-kafka-consumer-client-4@placeholder.org",
+      "serviceAccountClientId": "kafka-consumer-client-4"
+    },
+    {
+      "username": "service-account-kafka-consumer-client-5",
+      "enabled": true,
+      "realmRoles" : [ "offline_access" ],
+      "email": "service-account-kafka-consumer-client-5@placeholder.org",
+      "serviceAccountClientId": "kafka-consumer-client-5"
     }
   ],
   "clients": [
@@ -449,6 +519,231 @@
             "ownerManagedAccess" : false,
             "attributes" : { },
             "uris" : [ ]
+          },
+          {
+            "name": "Topic:messages-1",
+            "type": "topic",
+            "scopes": [
+              {
+                "name": "Delete"
+              },
+              {
+                "name": "Describe"
+              },
+              {
+                "name": "Create"
+              },
+              {
+                "name": "Write"
+              },
+              {
+                "name": "Alter"
+              },
+              {
+                "name": "Read"
+              },
+              {
+                "name": "DescribeConfigs"
+              },
+              {
+                "name": "AlterConfigs"
+              }
+            ]
+          },
+          {
+            "name": "Topic:messages-2",
+            "type": "topic",
+            "scopes": [
+              {
+                "name": "Delete"
+              },
+              {
+                "name": "Describe"
+              },
+              {
+                "name": "Create"
+              },
+              {
+                "name": "Write"
+              },
+              {
+                "name": "Alter"
+              },
+              {
+                "name": "Read"
+              },
+              {
+                "name": "DescribeConfigs"
+              },
+              {
+                "name": "AlterConfigs"
+              }
+            ]
+          },
+          {
+            "name": "Topic:messages-3",
+            "type": "topic",
+            "scopes": [
+              {
+                "name": "Delete"
+              },
+              {
+                "name": "Describe"
+              },
+              {
+                "name": "Create"
+              },
+              {
+                "name": "Write"
+              },
+              {
+                "name": "Alter"
+              },
+              {
+                "name": "Read"
+              },
+              {
+                "name": "DescribeConfigs"
+              },
+              {
+                "name": "AlterConfigs"
+              }
+            ]
+          },
+          {
+            "name": "Topic:messages-4",
+            "type": "topic",
+            "scopes": [
+              {
+                "name": "Delete"
+              },
+              {
+                "name": "Describe"
+              },
+              {
+                "name": "Create"
+              },
+              {
+                "name": "Write"
+              },
+              {
+                "name": "Alter"
+              },
+              {
+                "name": "Read"
+              },
+              {
+                "name": "DescribeConfigs"
+              },
+              {
+                "name": "AlterConfigs"
+              }
+            ]
+          },
+          {
+            "name": "Topic:messages-5",
+            "type": "topic",
+            "scopes": [
+              {
+                "name": "Delete"
+              },
+              {
+                "name": "Describe"
+              },
+              {
+                "name": "Create"
+              },
+              {
+                "name": "Write"
+              },
+              {
+                "name": "Alter"
+              },
+              {
+                "name": "Read"
+              },
+              {
+                "name": "DescribeConfigs"
+              },
+              {
+                "name": "AlterConfigs"
+              }
+            ]
+          },
+          {
+            "name": "Group:g1*",
+            "type": "group",
+            "scopes": [
+              {
+                "name": "Describe"
+              },
+              {
+                "name": "Write"
+              },
+              {
+                "name": "Read"
+              }
+            ]
+          },
+          {
+            "name": "Group:g2*",
+            "type": "group",
+            "scopes": [
+              {
+                "name": "Describe"
+              },
+              {
+                "name": "Write"
+              },
+              {
+                "name": "Read"
+              }
+            ]
+          },
+          {
+            "name": "Group:g3*",
+            "type": "group",
+            "scopes": [
+              {
+                "name": "Describe"
+              },
+              {
+                "name": "Write"
+              },
+              {
+                "name": "Read"
+              }
+            ]
+          },
+          {
+            "name": "Group:g4*",
+            "type": "group",
+            "scopes": [
+              {
+                "name": "Describe"
+              },
+              {
+                "name": "Write"
+              },
+              {
+                "name": "Read"
+              }
+            ]
+          },
+          {
+            "name": "Group:g5*",
+            "type": "group",
+            "scopes": [
+              {
+                "name": "Describe"
+              },
+              {
+                "name": "Write"
+              },
+              {
+                "name": "Read"
+              }
+            ]
           }
         ],
         "policies": [
@@ -625,6 +920,251 @@
               "resources" : "[\"Cluster:*\"]",
               "applyPolicies" : "[\"ClusterManager Group\"]"
             }
+          },
+          {
+            "name": "Producer Client 1",
+            "type": "client",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "clients": "[\"kafka-producer-client-1\"]"
+            }
+          },
+          {
+            "name": "Consumer Client 1",
+            "type": "client",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "clients": "[\"kafka-consumer-client-1\"]"
+            }
+          },
+          {
+            "name": "Producer Client 2",
+            "type": "client",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "clients": "[\"kafka-producer-client-2\"]"
+            }
+          },
+          {
+            "name": "Consumer Client 2",
+            "type": "client",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "clients": "[\"kafka-consumer-client-2\"]"
+            }
+          },
+          {
+            "name": "Producer Client 3",
+            "type": "client",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "clients": "[\"kafka-producer-client-3\"]"
+            }
+          },
+          {
+            "name": "Consumer Client 3",
+            "type": "client",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "clients": "[\"kafka-consumer-client-3\"]"
+            }
+          },
+          {
+            "name": "Producer Client 4",
+            "type": "client",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "clients": "[\"kafka-producer-client-4\"]"
+            }
+          },
+          {
+            "name": "Consumer Client 4",
+            "type": "client",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "clients": "[\"kafka-consumer-client-4\"]"
+            }
+          },
+          {
+            "name": "Producer Client 5",
+            "type": "client",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "clients": "[\"kafka-producer-client-5\"]"
+            }
+          },
+          {
+            "name": "Consumer Client 5",
+            "type": "client",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "clients": "[\"kafka-consumer-client-5\"]"
+            }
+          },
+          {
+            "name": "Producer Client 1 can write to topic 'messages-1'",
+            "type": "scope",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "resources": "[\"Topic:messages-1\"]",
+              "scopes": "[\"Delete\",\"Describe\",\"Create\",\"Write\"]",
+              "applyPolicies": "[\"Producer Client 1\"]"
+            }
+          },
+          {
+            "name": "Consumer Client 1 can read from topic 'messages-1'",
+            "type": "scope",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "resources": "[\"Topic:messages-1\"]",
+              "scopes": "[\"Describe\",\"Read\"]"
+            }
+          },
+          {
+            "name": "Consumer Client 1 can use any group that starts with 'g1'",
+            "type": "scope",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "resources": "[\"Group:g1*\"]",
+              "scopes": "[\"Describe\",\"Write\",\"Read\"]"
+            }
+          },
+          {
+            "name": "Producer Client 2 can write to topic 'messages-2'",
+            "type": "scope",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "resources": "[\"Topic:messages-2\"]",
+              "scopes": "[\"Delete\",\"Describe\",\"Create\",\"Write\"]",
+              "applyPolicies": "[\"Producer Client 2\"]"
+            }
+          },
+          {
+            "name": "Consumer Client 2 can read from topic 'messages-2'",
+            "type": "scope",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "resources": "[\"Topic:messages-2\"]",
+              "scopes": "[\"Describe\",\"Read\"]"
+            }
+          },
+          {
+            "name": "Consumer Client 2 can use any group that starts with 'g2'",
+            "type": "scope",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "resources": "[\"Group:g2*\"]",
+              "scopes": "[\"Describe\",\"Write\",\"Read\"]"
+            }
+          },
+          {
+            "name": "Producer Client 3 can write to topic 'messages-3'",
+            "type": "scope",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "resources": "[\"Topic:messages-3\"]",
+              "scopes": "[\"Delete\",\"Describe\",\"Create\",\"Write\"]",
+              "applyPolicies": "[\"Producer Client 3\"]"
+            }
+          },
+          {
+            "name": "Consumer Client 3 can read from topic 'messages-3'",
+            "type": "scope",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "resources": "[\"Topic:messages-3\"]",
+              "scopes": "[\"Describe\",\"Read\"]"
+            }
+          },
+          {
+            "name": "Consumer Client 3 can use any group that starts with 'g3'",
+            "type": "scope",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "resources": "[\"Group:g3*\"]",
+              "scopes": "[\"Describe\",\"Write\",\"Read\"]"
+            }
+          },
+          {
+            "name": "Producer Client 4 can write to topic 'messages-4'",
+            "type": "scope",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "resources": "[\"Topic:messages-4\"]",
+              "scopes": "[\"Delete\",\"Describe\",\"Create\",\"Write\"]",
+              "applyPolicies": "[\"Producer Client 4\"]"
+            }
+          },
+          {
+            "name": "Consumer Client 4 can read from topic 'messages-4'",
+            "type": "scope",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "resources": "[\"Topic:messages-4\"]",
+              "scopes": "[\"Describe\",\"Read\"]"
+            }
+          },
+          {
+            "name": "Consumer Client 4 can use any group that starts with 'g4'",
+            "type": "scope",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "resources": "[\"Group:g4*\"]",
+              "scopes": "[\"Describe\",\"Write\",\"Read\"]"
+            }
+          },
+          {
+            "name": "Producer Client 5 can write to topic 'messages-5'",
+            "type": "scope",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "resources": "[\"Topic:messages-5\"]",
+              "scopes": "[\"Delete\",\"Describe\",\"Create\",\"Write\"]",
+              "applyPolicies": "[\"Producer Client 5\"]"
+            }
+          },
+          {
+            "name": "Consumer Client 5 can read from topic 'messages-5'",
+            "type": "scope",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "resources": "[\"Topic:messages-5\"]",
+              "scopes": "[\"Describe\",\"Read\"]"
+            }
+          },
+          {
+            "name": "Consumer Client 5 can use any group that starts with 'g5'",
+            "type": "scope",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "resources": "[\"Group:g5*\"]",
+              "scopes": "[\"Describe\",\"Write\",\"Read\"]"
+            }
           }
         ],
         "scopes": [
@@ -675,6 +1215,176 @@
       "serviceAccountsEnabled": false,
       "publicClient": true,
       "fullScopeAllowed": true
+    },
+    {
+      "clientId": "kafka-producer-client-1",
+      "enabled": true,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "kafka-producer-client-1-secret",
+      "publicClient": false,
+      "bearerOnly": false,
+      "standardFlowEnabled": false,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": true,
+      "consentRequired" : false,
+      "fullScopeAllowed" : false,
+      "attributes": {
+        "access.token.lifespan": "36000"
+      }
+    },
+    {
+      "clientId": "kafka-producer-client-2",
+      "enabled": true,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "kafka-producer-client-2-secret",
+      "publicClient": false,
+      "bearerOnly": false,
+      "standardFlowEnabled": false,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": true,
+      "consentRequired" : false,
+      "fullScopeAllowed" : false,
+      "attributes": {
+        "access.token.lifespan": "36000"
+      }
+    },
+    {
+      "clientId": "kafka-producer-client-3",
+      "enabled": true,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "kafka-producer-client-3-secret",
+      "publicClient": false,
+      "bearerOnly": false,
+      "standardFlowEnabled": false,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": true,
+      "consentRequired" : false,
+      "fullScopeAllowed" : false,
+      "attributes": {
+        "access.token.lifespan": "36000"
+      }
+    },
+    {
+      "clientId": "kafka-producer-client-4",
+      "enabled": true,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "kafka-producer-client-4-secret",
+      "publicClient": false,
+      "bearerOnly": false,
+      "standardFlowEnabled": false,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": true,
+      "consentRequired" : false,
+      "fullScopeAllowed" : false,
+      "attributes": {
+        "access.token.lifespan": "36000"
+      }
+    },
+    {
+      "clientId": "kafka-producer-client-5",
+      "enabled": true,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "kafka-producer-client-5-secret",
+      "publicClient": false,
+      "bearerOnly": false,
+      "standardFlowEnabled": false,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": true,
+      "consentRequired" : false,
+      "fullScopeAllowed" : false,
+      "attributes": {
+        "access.token.lifespan": "36000"
+      }
+    },
+    {
+      "clientId": "kafka-consumer-client-1",
+      "enabled": true,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "kafka-consumer-client-1-secret",
+      "publicClient": false,
+      "bearerOnly": false,
+      "standardFlowEnabled": false,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": true,
+      "consentRequired" : false,
+      "fullScopeAllowed" : false,
+      "attributes": {
+        "access.token.lifespan": "36000"
+      }
+    },
+    {
+      "clientId": "kafka-consumer-client-2",
+      "enabled": true,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "kafka-consumer-client-2-secret",
+      "publicClient": false,
+      "bearerOnly": false,
+      "standardFlowEnabled": false,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": true,
+      "consentRequired" : false,
+      "fullScopeAllowed" : false,
+      "attributes": {
+        "access.token.lifespan": "36000"
+      }
+    },
+    {
+      "clientId": "kafka-consumer-client-3",
+      "enabled": true,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "kafka-consumer-client-3-secret",
+      "publicClient": false,
+      "bearerOnly": false,
+      "standardFlowEnabled": false,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": true,
+      "consentRequired" : false,
+      "fullScopeAllowed" : false,
+      "attributes": {
+        "access.token.lifespan": "36000"
+      }
+    },
+    {
+      "clientId": "kafka-consumer-client-4",
+      "enabled": true,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "kafka-consumer-client-4-secret",
+      "publicClient": false,
+      "bearerOnly": false,
+      "standardFlowEnabled": false,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": true,
+      "consentRequired" : false,
+      "fullScopeAllowed" : false,
+      "attributes": {
+        "access.token.lifespan": "36000"
+      }
+    },
+    {
+      "clientId": "kafka-consumer-client-5",
+      "enabled": true,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "kafka-consumer-client-5-secret",
+      "publicClient": false,
+      "bearerOnly": false,
+      "standardFlowEnabled": false,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": true,
+      "consentRequired" : false,
+      "fullScopeAllowed" : false,
+      "attributes": {
+        "access.token.lifespan": "36000"
+      }
     }
   ]
 }

--- a/testsuite/keycloak-auth-tests/docker-compose.yml
+++ b/testsuite/keycloak-auth-tests/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       - KEYCLOAK_PASSWORD=admin
       - KEYCLOAK_HTTPS_PORT=8443
       - PROXY_ADDRESS_FORWARDING=true
-      - KEYCLOAK_IMPORT=/opt/jboss/keycloak/realms/demo-realm.json,/opt/jboss/keycloak/realms/kafka-authz-realm.json,/opt/jboss/keycloak/realms/demo-ec-realm.json
+      - KEYCLOAK_IMPORT=/opt/jboss/keycloak/realms/demo-realm.json,/opt/jboss/keycloak/realms/kafka-authz-realm.json,/opt/jboss/keycloak/realms/demo-ec-realm.json,/opt/jboss/keycloak/realms/flood-realm.json
 
   kafka:
     image: ${KAFKA_DOCKER_IMAGE}
@@ -40,6 +40,7 @@ services:
       - 9099:9099
       - 9100:9100
       - 9101:9101
+      - 9102:9102
 
       # javaagent debug port
       #- 5006:5006
@@ -59,8 +60,8 @@ services:
 
       - KAFKA_BROKER_ID=1
       - KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181
-      - KAFKA_LISTENERS=JWT://kafka:9092,INTROSPECT://kafka:9093,AUDIENCE://kafka:9094,AUDIENCEINTROSPECT://kafka:9095,JWTPLAIN://kafka:9096,INTROSPECTPLAIN://kafka:9097,CUSTOM://kafka:9098,CUSTOMINTROSPECT://kafka:9099,PLAIN://kafka:9100,SCRAM://kafka:9101
-      - KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=JWT:SASL_PLAINTEXT,INTROSPECT:SASL_PLAINTEXT,AUDIENCE:SASL_PLAINTEXT,AUDIENCEINTROSPECT:SASL_PLAINTEXT,JWTPLAIN:SASL_PLAINTEXT,INTROSPECTPLAIN:SASL_PLAINTEXT,CUSTOM:SASL_PLAINTEXT,CUSTOMINTROSPECT:SASL_PLAINTEXT,PLAIN:SASL_PLAINTEXT,SCRAM:SASL_PLAINTEXT
+      - KAFKA_LISTENERS=JWT://kafka:9092,INTROSPECT://kafka:9093,AUDIENCE://kafka:9094,AUDIENCEINTROSPECT://kafka:9095,JWTPLAIN://kafka:9096,INTROSPECTPLAIN://kafka:9097,CUSTOM://kafka:9098,CUSTOMINTROSPECT://kafka:9099,PLAIN://kafka:9100,SCRAM://kafka:9101,FLOOD://kafka:9102
+      - KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=JWT:SASL_PLAINTEXT,INTROSPECT:SASL_PLAINTEXT,AUDIENCE:SASL_PLAINTEXT,AUDIENCEINTROSPECT:SASL_PLAINTEXT,JWTPLAIN:SASL_PLAINTEXT,INTROSPECTPLAIN:SASL_PLAINTEXT,CUSTOM:SASL_PLAINTEXT,CUSTOMINTROSPECT:SASL_PLAINTEXT,PLAIN:SASL_PLAINTEXT,SCRAM:SASL_PLAINTEXT,FLOOD:SASL_PLAINTEXT
       - KAFKA_SASL_ENABLED_MECHANISMS=OAUTHBEARER
       - KAFKA_INTER_BROKER_LISTENER_NAME=INTROSPECT
       - KAFKA_SASL_MECHANISM_INTER_BROKER_PROTOCOL=OAUTHBEARER
@@ -111,10 +112,16 @@ services:
       - KAFKA_LISTENER_NAME_SCRAM_SASL_ENABLED_MECHANISMS=SCRAM-SHA-512
       - KAFKA_LISTENER_NAME_SCRAM_SCRAM__2DSHA__2D512_SASL_JAAS_CONFIG=org.apache.kafka.common.security.scram.ScramLoginModule required    username=\"admin\"    password=\"admin-secret\" ;
 
+      - KAFKA_LISTENER_NAME_FLOOD_SASL_ENABLED_MECHANISMS=OAUTHBEARER,PLAIN
+      - KAFKA_LISTENER_NAME_FLOOD_OAUTHBEARER_SASL_JAAS_CONFIG=org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required    oauth.jwks.endpoint.uri=\"http://keycloak:8080/auth/realms/flood/protocol/openid-connect/certs\"    oauth.valid.issuer.uri=\"http://keycloak:8080/auth/realms/flood\"    unsecuredLoginStringClaim_sub=\"admin\" ;
+      - KAFKA_LISTENER_NAME_FLOOD_OAUTHBEARER_SASL_SERVER_CALLBACK_HANDLER_CLASS=io.strimzi.kafka.oauth.server.JaasServerOauthValidatorCallbackHandler
+
+      - KAFKA_LISTENER_NAME_FLOOD_PLAIN_SASL_JAAS_CONFIG=org.apache.kafka.common.security.plain.PlainLoginModule required    oauth.token.endpoint.uri=\"http://keycloak:8080/auth/realms/flood/protocol/openid-connect/token\"    oauth.client.id=\"kafka\"    oauth.client.secret=\"kafka-secret\"    oauth.jwks.endpoint.uri=\"http://keycloak:8080/auth/realms/flood/protocol/openid-connect/certs\"    oauth.valid.issuer.uri=\"http://keycloak:8080/auth/realms/flood\"    unsecuredLoginStringClaim_sub=\"admin\" ;
+      - KAFKA_LISTENER_NAME_FLOOD_PLAIN_SASL_SERVER_CALLBACK_HANDLER_CLASS=io.strimzi.kafka.oauth.server.plain.JaasServerOauthOverPlainValidatorCallbackHandler
 
       # For start.sh script to know where the keycloak is listening
       - KEYCLOAK_HOST=${KEYCLOAK_HOST:-keycloak}
-      - REALM=${REALM:-demo-ec}
+      - REALM=${REALM:-flood}
 
   zookeeper:
     image: ${KAFKA_DOCKER_IMAGE}

--- a/testsuite/keycloak-auth-tests/docker-compose.yml
+++ b/testsuite/keycloak-auth-tests/docker-compose.yml
@@ -65,6 +65,13 @@ services:
       - KAFKA_INTER_BROKER_LISTENER_NAME=INTROSPECT
       - KAFKA_SASL_MECHANISM_INTER_BROKER_PROTOCOL=OAUTHBEARER
 
+      # Common settings for all the listeners
+      # username extraction from JWT token claim
+      - OAUTH_USERNAME_CLAIM=preferred_username
+      - KAFKA_PRINCIPAL_BUILDER_CLASS=io.strimzi.kafka.oauth.server.OAuthKafkaPrincipalBuilder
+      - KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1
+
+      # Configuration of individual listeners
       - KAFKA_LISTENER_NAME_INTROSPECT_OAUTHBEARER_SASL_JAAS_CONFIG=org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required    oauth.introspection.endpoint.uri=\"http://keycloak:8080/auth/realms/demo/protocol/openid-connect/token/introspect\"    oauth.client.id=\"kafka-broker\"    oauth.client.secret=\"kafka-broker-secret\"    oauth.valid.issuer.uri=\"http://keycloak:8080/auth/realms/demo\"     oauth.token.endpoint.uri=\"http://keycloak:8080/auth/realms/demo/protocol/openid-connect/token\" ;
       - KAFKA_LISTENER_NAME_INTROSPECT_OAUTHBEARER_SASL_SERVER_CALLBACK_HANDLER_CLASS=io.strimzi.kafka.oauth.server.JaasServerOauthValidatorCallbackHandler
       - KAFKA_LISTENER_NAME_INTROSPECT_OAUTHBEARER_SASL_LOGIN_CALLBACK_HANDLER_CLASS=io.strimzi.kafka.oauth.client.JaasClientOauthLoginCallbackHandler
@@ -104,9 +111,6 @@ services:
       - KAFKA_LISTENER_NAME_SCRAM_SASL_ENABLED_MECHANISMS=SCRAM-SHA-512
       - KAFKA_LISTENER_NAME_SCRAM_SCRAM__2DSHA__2D512_SASL_JAAS_CONFIG=org.apache.kafka.common.security.scram.ScramLoginModule required    username=\"admin\"    password=\"admin-secret\" ;
 
-      - KAFKA_PRINCIPAL_BUILDER_CLASS=io.strimzi.kafka.oauth.server.OAuthKafkaPrincipalBuilder
-
-      - KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1
 
       # For start.sh script to know where the keycloak is listening
       - KEYCLOAK_HOST=${KEYCLOAK_HOST:-keycloak}

--- a/testsuite/keycloak-auth-tests/src/test/java/io/strimzi/testsuite/oauth/auth/FloodProducer.java
+++ b/testsuite/keycloak-auth-tests/src/test/java/io/strimzi/testsuite/oauth/auth/FloodProducer.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2017-2019, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.testsuite.oauth.auth;
+
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static io.strimzi.testsuite.oauth.auth.Common.buildProducerConfigPlain;
+
+/**
+ * This class uses multiple KafkaProducers, configured with different clientIds to concurrently produce
+ * messages as quickly as possible.
+ */
+public class FloodProducer implements Runnable {
+
+    private static ArrayList<Thread> threads = new ArrayList<>();
+
+    static private AtomicInteger startedCount;
+
+    static int sendLimit = 1;
+
+    final private String kafkaBootstrap;
+    final private String clientId;
+    final private String secret;
+    final private String topic;
+
+    Producer<String, String> producer;
+
+
+    FloodProducer(String kafkaBootstrap, String clientId, String secret, String topic) {
+        this.kafkaBootstrap = kafkaBootstrap;
+        this.clientId = clientId;
+        this.secret = secret;
+        this.topic = topic;
+    }
+
+    public static void clearThreads() {
+        threads.clear();
+    }
+
+    public static void startThreads() {
+        startedCount = new AtomicInteger(0);
+        for (Thread t : threads) {
+            t.start();
+        }
+    }
+
+    public static void joinThreads() {
+        for (Thread t : threads) {
+            try {
+                t.join();
+            } catch (InterruptedException e) {
+                throw new RuntimeException("Interrupted - exiting ...");
+            }
+        }
+    }
+
+    public static void addProducerThread(String kafkaBootstrap, String clientId, String secret, String topic) {
+        FloodProducer p = new FloodProducer(kafkaBootstrap, clientId, secret, topic);
+        p.initProducer();
+    }
+
+    private void initProducer() {
+        Map<String, String> plainConfig = new HashMap<>();
+        plainConfig.put("username", clientId);
+        plainConfig.put("password", secret);
+
+        Properties props = buildProducerConfigPlain(kafkaBootstrap, plainConfig);
+        producer = new KafkaProducer<>(props);
+
+        threads.add(new Thread(this, "FloodProducer Runner Thread - " + threads.size()));
+    }
+
+    public void run() {
+        int started = startedCount.addAndGet(1);
+
+        try {
+
+            while (started < threads.size()) {
+                Thread.sleep(10);
+                started = startedCount.get();
+            }
+
+            for (int i = 0; i < sendLimit; i++) {
+                producer.send(new ProducerRecord<>(topic, "Message " + i))
+                        .get();
+
+                System.out.println("[" + clientId + "] Produced message to '" + topic + "': Message " + i);
+
+                if (i < sendLimit - 1) {
+                    Thread.sleep(2000);
+                }
+            }
+        } catch (InterruptedException e) {
+            throw new RuntimeException("Interrupted while sending!");
+
+        } catch (ExecutionException e) {
+            throw new RuntimeException("Failed to send message: ", e);
+
+        } finally {
+            if (producer != null) {
+                producer.close();
+            }
+        }
+    }
+}

--- a/testsuite/keycloak-auth-tests/src/test/java/io/strimzi/testsuite/oauth/auth/MultiSaslTests.java
+++ b/testsuite/keycloak-auth-tests/src/test/java/io/strimzi/testsuite/oauth/auth/MultiSaslTests.java
@@ -103,7 +103,7 @@ public class MultiSaslTests {
         accessToken = Common.loginWithUsernamePassword(
                 URI.create("http://keycloak:8080/auth/realms/kafka-authz/protocol/openid-connect/token"),
                 username, password, "kafka-cli");
-        producerProps = producerConfigPlain(KAFKA_JWTPLAIN_LISTENER, "$accessToken", accessToken);
+        producerProps = producerConfigPlain(KAFKA_JWTPLAIN_LISTENER, username, "$accessToken:" + accessToken);
         produceToTopic("KeycloakAuthenticationTest-multiSaslTest-oauth-over-plain", producerProps);
     }
 

--- a/testsuite/keycloak-auth-tests/src/test/java/io/strimzi/testsuite/oauth/auth/OAuthOverPlainTests.java
+++ b/testsuite/keycloak-auth-tests/src/test/java/io/strimzi/testsuite/oauth/auth/OAuthOverPlainTests.java
@@ -84,8 +84,8 @@ public class OAuthOverPlainTests {
                 "team-a-client", "team-a-client-secret", true, null, null);
 
         Map<String, String> plainConfig = new HashMap<>();
-        plainConfig.put("username", "$accessToken");
-        plainConfig.put("password", info.token());
+        plainConfig.put("username", "service-account-team-a-client");
+        plainConfig.put("password", "$accessToken:" + info.token());
 
         Properties producerProps = buildProducerConfigPlain(kafkaBootstrap, plainConfig);
         Producer<String, String> producer = new KafkaProducer<>(producerProps);

--- a/testsuite/keycloak-auth-tests/src/test/java/io/strimzi/testsuite/oauth/auth/OAuthOverPlainTests.java
+++ b/testsuite/keycloak-auth-tests/src/test/java/io/strimzi/testsuite/oauth/auth/OAuthOverPlainTests.java
@@ -31,7 +31,7 @@ public class OAuthOverPlainTests {
         clientCredentialsOverPlainWithJwt();
         clientCredentialsOverPlainWithIntrospection();
         accessTokenOverPlainWithIntrospection();
-        clientCredentialsOverPlainWithJwtFloodTest();
+        clientCredentialsOverPlainWithFloodTest();
     }
 
     static void clientCredentialsOverPlainWithIntrospection() throws Exception {
@@ -164,9 +164,9 @@ public class OAuthOverPlainTests {
      *
      * @throws Exception
      */
-    static void clientCredentialsOverPlainWithJwtFloodTest() {
+    static void clientCredentialsOverPlainWithFloodTest() {
 
-        System.out.println("==== KeycloakAuthenticationTest :: clientCredentialsOverPlainWithJwtFloodTest ====");
+        System.out.println("==== KeycloakAuthenticationTest :: clientCredentialsOverPlainWithFloodTest ====");
 
         final String kafkaBootstrap = "kafka:9102";
 
@@ -188,6 +188,9 @@ public class OAuthOverPlainTests {
 
             // Wait for all threads to finish
             FloodProducer.joinThreads();
+
+            // Check for errors
+            FloodProducer.checkExceptions();
 
             // Prepare for the next run
             FloodProducer.clearThreads();

--- a/testsuite/keycloak-auth-tests/src/test/java/io/strimzi/testsuite/oauth/auth/OAuthOverPlainTests.java
+++ b/testsuite/keycloak-auth-tests/src/test/java/io/strimzi/testsuite/oauth/auth/OAuthOverPlainTests.java
@@ -31,6 +31,7 @@ public class OAuthOverPlainTests {
         clientCredentialsOverPlainWithJwt();
         clientCredentialsOverPlainWithIntrospection();
         accessTokenOverPlainWithIntrospection();
+        clientCredentialsOverPlainWithJwtFloodTest();
     }
 
     static void clientCredentialsOverPlainWithIntrospection() throws Exception {
@@ -154,5 +155,42 @@ public class OAuthOverPlainTests {
 
         Assert.assertEquals("Got message", 1, records.count());
         Assert.assertEquals("Is message text: 'The Message'", "The Message", records.iterator().next().value());
+    }
+
+    /**
+     * This test uses the Kafka listener configured with both OAUTHBEARER and PLAIN.
+     *
+     * It connects concurrently with multiple producers with different client IDs using the PLAIN mechanism, testing the OAuth over PLAIN functionality.
+     *
+     * @throws Exception
+     */
+    static void clientCredentialsOverPlainWithJwtFloodTest() {
+
+        System.out.println("==== KeycloakAuthenticationTest :: clientCredentialsOverPlainWithJwtFloodTest ====");
+
+        final String kafkaBootstrap = "kafka:9102";
+
+        String clientPrefix = "kafka-producer-client-";
+
+        // We do 10 iterations - each time hitting the broker with 5 parallel requests
+        for (int run = 0; run < 10; run++) {
+
+            for (int i = 1; i <= 5; i++) {
+                String clientId = clientPrefix + i;
+                String secret = clientId + "-secret";
+                String topic = "messages-" + i;
+
+                FloodProducer.addProducerThread(kafkaBootstrap, clientId, secret, topic);
+            }
+
+            // Start all threads
+            FloodProducer.startThreads();
+
+            // Wait for all threads to finish
+            FloodProducer.joinThreads();
+
+            // Prepare for the next run
+            FloodProducer.clearThreads();
+        }
     }
 }

--- a/testsuite/keycloak-authz-tests/arquillian.xml
+++ b/testsuite/keycloak-authz-tests/arquillian.xml
@@ -18,7 +18,7 @@
             kafka:
               await:
                 strategy: docker_health
-                iterations: 50
+                iterations: 80
                 sleepPollingTime: 5 s
                 command: ["sh", "-c", "grep 'started (kafka.server.KafkaServer)' &lt; /tmp/logs/server.log"]
               beforeStop:

--- a/testsuite/keycloak-authz-tests/src/test/java/io/strimzi/testsuite/oauth/authz/Common.java
+++ b/testsuite/keycloak-authz-tests/src/test/java/io/strimzi/testsuite/oauth/authz/Common.java
@@ -243,15 +243,15 @@ public class Common {
     }
 
     Map<String, String> buildAuthConfigForPlain(String name) {
-        Map<String, String> config = new HashMap<>();
-        if (name.endsWith("-client")) {
-            config.put("username", name);
-            config.put("password", name + "-secret");
-            return config;
-        }
+        return name.endsWith("-client")
+                ? buildAuthConfigForPlain(name, name + "-secret")
+                : buildAuthConfigForPlain(name, "$accessToken:" + tokens.get(name));
+    }
 
-        config.put("username", name);
-        config.put("password", "$accessToken:" + tokens.get(name));
+    Map<String, String> buildAuthConfigForPlain(String clientId, String secret) {
+        Map<String, String> config = new HashMap<>();
+        config.put("username", clientId);
+        config.put("password", secret);
         return config;
     }
 
@@ -298,6 +298,12 @@ public class Common {
         p.setProperty("sasl.login.callback.handler.class", "io.strimzi.kafka.oauth.client.JaasClientOauthLoginCallbackHandler");
 
         return p;
+    }
+
+    Properties buildProducerConfig(String kafkaBootstrap, boolean usePlain, String clientId, String secret) {
+        return usePlain ?
+                buildProducerConfigPlain(kafkaBootstrap, buildAuthConfigForPlain(clientId, secret)) :
+                buildProducerConfigOAuthBearer(kafkaBootstrap, buildAuthConfigForOAuthBearer(clientId));
     }
 
     static Properties buildProducerConfigPlain(String kafkaBootstrap, Map<String, String> plainConfig) {

--- a/testsuite/keycloak-authz-tests/src/test/java/io/strimzi/testsuite/oauth/authz/Common.java
+++ b/testsuite/keycloak-authz-tests/src/test/java/io/strimzi/testsuite/oauth/authz/Common.java
@@ -250,8 +250,8 @@ public class Common {
             return config;
         }
 
-        config.put("username", "$accessToken");
-        config.put("password", tokens.get(name));
+        config.put("username", name);
+        config.put("password", "$accessToken:" + tokens.get(name));
         return config;
     }
 

--- a/testsuite/keycloak-authz-tests/src/test/java/io/strimzi/testsuite/oauth/authz/Common.java
+++ b/testsuite/keycloak-authz-tests/src/test/java/io/strimzi/testsuite/oauth/authz/Common.java
@@ -279,7 +279,7 @@ public class Common {
         p.setProperty(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
         p.setProperty(ProducerConfig.ACKS_CONFIG, "all");
         p.setProperty(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, "5000");
-        p.setProperty(ProducerConfig.RETRIES_CONFIG, "0");
+        p.setProperty(ProducerConfig.RETRIES_CONFIG, "10");
     }
 
     static Properties buildConsumerConfigOAuthBearer(String kafkaBootstrap, Map<String, String> oauthConfig) {

--- a/testsuite/keycloak-authz-tests/src/test/java/io/strimzi/testsuite/oauth/authz/FloodTest.java
+++ b/testsuite/keycloak-authz-tests/src/test/java/io/strimzi/testsuite/oauth/authz/FloodTest.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2017-2021, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.testsuite.oauth.authz;
+
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Properties;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static io.strimzi.kafka.oauth.common.OAuthAuthenticator.loginWithClientSecret;
+
+public class FloodTest extends Common {
+
+    private static ArrayList<Thread> threads = new ArrayList<>();
+
+    private static AtomicInteger startedCount;
+
+    static int sendLimit = 1;
+
+
+    FloodTest(String kafkaBootstrap, boolean oauthOverPlain) {
+        super(kafkaBootstrap, oauthOverPlain);
+    }
+
+    public void doTest() throws IOException {
+        clientCredentialsWithFloodTest();
+    }
+
+
+    /**
+     * This test uses the Kafka listener configured with both OAUTHBEARER and PLAIN.
+     *
+     * It connects concurrently with multiple producers with different client IDs using the PLAIN mechanism, testing the OAuth over PLAIN functionality.
+     * With KeycloakRBACAuthorizer configured, any mixup of the credentials between different clients will be caught as
+     * AuthorizationException would be thrown trying to write to the topic if the user context was mismatched.
+     *
+     * @throws Exception
+     */
+    void clientCredentialsWithFloodTest() throws IOException {
+
+        String clientPrefix = "kafka-producer-client-";
+
+        if (!usePlain) {
+            HashMap<String, String> tokens = new HashMap<>();
+            for (int i = 1; i <= 5; i++) {
+                String clientId = clientPrefix + i;
+                String secret = clientId + "-secret";
+
+                tokens.put(clientId, loginWithClientSecret(URI.create(TOKEN_ENDPOINT_URI), null, null,
+                        clientId, secret, true, null, null).token());
+            }
+            this.tokens = tokens;
+        }
+
+        // We do 10 iterations - each time hitting the broker with 5 parallel requests
+        for (int run = 0; run < 10; run++) {
+
+            for (int i = 1; i <= 5; i++) {
+                String clientId = clientPrefix + i;
+                String secret = clientId + "-secret";
+                String topic = "messages-" + i;
+
+                addProducerThread(clientId, secret, topic);
+            }
+
+            // Start all threads
+            startThreads();
+
+            // Wait for all threads to finish
+            joinThreads();
+
+            checkExceptions();
+
+            // Prepare for the next run
+            clearThreads();
+        }
+
+        // Try write to the mismatched topic - we should get AuthorizationException
+    }
+
+
+    public static void clearThreads() {
+        threads.clear();
+    }
+
+    public static void startThreads() {
+        startedCount = new AtomicInteger(0);
+        for (Thread t : threads) {
+            t.start();
+        }
+    }
+
+    public static void joinThreads() {
+        for (Thread t : threads) {
+            try {
+                t.join();
+            } catch (InterruptedException e) {
+                throw new RuntimeException("Interrupted - exiting ...");
+            }
+        }
+    }
+
+    public static void checkExceptions() {
+        try {
+            for (Thread t : threads) {
+                ((FloodProducer) t).checkException();
+            }
+        } catch (RuntimeException e) {
+            throw e;
+        } catch (Throwable t) {
+            throw new RuntimeException("Test failed due to: ", t);
+        }
+    }
+
+    public void addProducerThread(String clientId, String secret, String topic) {
+        FloodProducer p = new FloodProducer(clientId, secret, topic);
+        p.initProducer();
+    }
+
+
+    class FloodProducer extends Thread {
+
+        final private String clientId;
+        final private String secret;
+        final private String topic;
+        private Throwable error;
+
+        Producer<String, String> producer;
+
+        FloodProducer(String clientId, String secret, String topic) {
+
+            this.clientId = clientId;
+            this.secret = secret;
+            this.topic = topic;
+        }
+
+        private void initProducer() {
+            Properties props = buildProducerConfig(kafkaBootstrap, usePlain, clientId, secret);
+            producer = new KafkaProducer<>(props);
+            setName("FloodProducer Runner Thread - " + threads.size());
+            threads.add(this);
+        }
+
+        private void checkException() throws Throwable {
+            if (error != null) {
+                throw error;
+            }
+        }
+
+        public void run() {
+            int started = startedCount.addAndGet(1);
+
+            try {
+
+                while (started < threads.size()) {
+                    Thread.sleep(10);
+                    started = startedCount.get();
+                }
+
+                for (int i = 0; i < sendLimit; i++) {
+                    producer.send(new ProducerRecord<>(topic, "Message " + i))
+                            .get();
+
+                    System.out.println("[" + clientId + "] Produced message to '" + topic + "': Message " + i);
+
+                    if (i < sendLimit - 1) {
+                        Thread.sleep(2000);
+                    }
+                }
+            } catch (InterruptedException e) {
+                error = new RuntimeException("Interrupted while sending!");
+            } catch (ExecutionException e) {
+                error = new RuntimeException("Failed to send message: ", e);
+            } catch (Throwable t) {
+                error = t;
+            } finally {
+                if (producer != null) {
+                    producer.close();
+                }
+            }
+        }
+    }
+
+}

--- a/testsuite/keycloak-authz-tests/src/test/java/io/strimzi/testsuite/oauth/authz/FloodTest.java
+++ b/testsuite/keycloak-authz-tests/src/test/java/io/strimzi/testsuite/oauth/authz/FloodTest.java
@@ -78,6 +78,7 @@ public class FloodTest extends Common {
             // Wait for all threads to finish
             joinThreads();
 
+            // Check for errors
             checkExceptions();
 
             // Prepare for the next run

--- a/testsuite/keycloak-authz-tests/src/test/java/io/strimzi/testsuite/oauth/authz/KeycloakAuthorizationTest.java
+++ b/testsuite/keycloak-authz-tests/src/test/java/io/strimzi/testsuite/oauth/authz/KeycloakAuthorizationTest.java
@@ -26,6 +26,7 @@ public class KeycloakAuthorizationTest {
     @Test
     public void doTest() throws Exception {
         try {
+
             logStart("KeycloakAuthorizationTest :: MultiSaslTests");
             MultiSaslTests.doTests();
 
@@ -40,6 +41,15 @@ public class KeycloakAuthorizationTest {
 
             logStart("KeycloakAuthorizationTest :: OAuthOverPlain + IntrospectionValidationAuthzTest");
             new OAuthOverPlainTest("kafka:9095", true).doTest();
+
+            logStart("KeycloakAuthorizationTest :: OAuthOverPLain + FloodTest");
+            new FloodTest("kafka:9094", true).doTest();
+
+            logStart("KeycloakAuthorizationTest :: JWT FloodTest");
+            new FloodTest("kafka:9092", false).doTest();
+
+            logStart("KeycloakAuthorizationTest :: Introspection FloodTest");
+            new FloodTest("kafka:9093", false).doTest();
 
             // This test has to be the last one - it changes the team-a-client, and team-b-client permissions in Keycloak
             logStart("KeycloakAuthorizationTest :: JwtValidationAuthzTest + RefreshGrants");

--- a/testsuite/keycloak-authz-tests/src/test/java/io/strimzi/testsuite/oauth/authz/MultiSaslTests.java
+++ b/testsuite/keycloak-authz-tests/src/test/java/io/strimzi/testsuite/oauth/authz/MultiSaslTests.java
@@ -117,7 +117,7 @@ public class MultiSaslTests {
         produceToTopic("KeycloakAuthenticationTest-multiSaslTest-oauthbearer", producerProps);
 
         // producing to JWTPLAIN listener using SASL_PLAIN using $accessToken should succeed
-        producerProps = producerConfigPlain(KAFKA_JWTPLAIN_LISTENER, "$accessToken", accessToken);
+        producerProps = producerConfigPlain(KAFKA_JWTPLAIN_LISTENER, username, "$accessToken:" + accessToken);
         produceToTopic("KeycloakAuthenticationTest-multiSaslTest-oauth-over-plain", producerProps);
     }
 


### PR DESCRIPTION
OAuth over PLAIN implementation had to be slightly reworked.

This fix introduces a breaking change with 0.7.0 in how to authenticate with an access token over SASL_PLAIN by using `$accessToken` as a username.

Signed-off-by: Marko Strukelj <marko.strukelj@gmail.com>