### PR TITLE
Enable ppc64le for strimzi-kafka-oauth

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: xenial
+dist: bionic
 sudo: required
 language: java
 jobs:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,13 @@ jobs:
       apt:
         packages:
         - maven
+  - os: linux
+    arch: ppc64le
+    jdk: openjdk11
+    addons:
+      apt:
+        packages:
+        - maven
 jdk:
 - openjdk8
 - openjdk11


### PR DESCRIPTION
Enables ppc64le on strimzi-kafka-oauth CI/CD, fixes #94