### PR TITLE
Add support for passing audience and scope to token endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -846,6 +846,12 @@ Some authorization servers require that scope is specified:
 
 Scope is sent to the Token Endpoint when obtaining the access token.
 
+Similarly, sometimes the authorization server may require that audience is specified:
+
+- `oauth.audience`
+
+Audience is sent to the Token Endpoint when obtaining the access token.
+
 For debug purposes you may want to properly configure which JWT token attribute contains the user id of the account used to obtain the access token:
 
 - `oauth.username.claim` (e.g.: "preferred_username")

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -8,6 +8,14 @@ Release Notes
 
 Now JWT token validation uses a different third-party library. As a result ECDSA support no longer requires the BouncyCastle library. Also, some JWT tokens that would fail previously, can now be handled, widening the support of different authorization servers.
 
+### Option `oauth.audience` has been added to client and server configuration
+
+Sometimes authorization server may require `audience` option to 
+
+### Pass the configured `oauth.scope` option on the Kafka broker as `scope` when performing clientId + secret authentication on the broker
+
+While the option has existed, it was only used for inter-broker authentication, but not for `OAuth over PLAIN`. 
+
 0.7.2
 -----
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,7 +10,7 @@ Now JWT token validation uses a different third-party library. As a result ECDSA
 
 ### Option `oauth.audience` has been added to client and server configuration
 
-Sometimes authorization server may require `audience` option to 
+Sometimes authorization server may require `audience` option to be passed when authenticating to the token endpoint.
 
 ### Pass the configured `oauth.scope` option on the Kafka broker as `scope` when performing clientId + secret authentication on the broker
 

--- a/oauth-client/src/main/java/io/strimzi/kafka/oauth/client/JaasClientOauthLoginCallbackHandler.java
+++ b/oauth-client/src/main/java/io/strimzi/kafka/oauth/client/JaasClientOauthLoginCallbackHandler.java
@@ -45,6 +45,7 @@ public class JaasClientOauthLoginCallbackHandler implements AuthenticateCallback
     private String clientId;
     private String clientSecret;
     private String scope;
+    private String audience;
     private URI tokenEndpoint;
 
     private boolean isJwt;
@@ -94,6 +95,7 @@ public class JaasClientOauthLoginCallbackHandler implements AuthenticateCallback
             }
 
             scope = config.getValue(Config.OAUTH_SCOPE);
+            audience = config.getValue(Config.OAUTH_AUDIENCE);
             socketFactory = ConfigUtil.createSSLFactory(config);
             hostnameVerifier = ConfigUtil.createHostnameVerifier(config);
         }
@@ -120,6 +122,7 @@ public class JaasClientOauthLoginCallbackHandler implements AuthenticateCallback
                     + "\n    clientId: " + clientId
                     + "\n    clientSecret: " + mask(clientSecret)
                     + "\n    scope: " + scope
+                    + "\n    audience: " + audience
                     + "\n    isJwt: " + isJwt
                     + "\n    maxTokenExpirySeconds: " + maxTokenExpirySeconds
                     + "\n    principalExtractor: " + principalExtractor);
@@ -153,9 +156,9 @@ public class JaasClientOauthLoginCallbackHandler implements AuthenticateCallback
             // we could check if it's a JWT - in that case we could check if it's expired
             result = loginWithAccessToken(token, isJwt, principalExtractor);
         } else if (refreshToken != null) {
-            result = loginWithRefreshToken(tokenEndpoint, socketFactory, hostnameVerifier, refreshToken, clientId, clientSecret, isJwt, principalExtractor, scope);
+            result = loginWithRefreshToken(tokenEndpoint, socketFactory, hostnameVerifier, refreshToken, clientId, clientSecret, isJwt, principalExtractor, scope, audience);
         } else if (clientSecret != null) {
-            result = loginWithClientSecret(tokenEndpoint, socketFactory, hostnameVerifier, clientId, clientSecret, isJwt, principalExtractor, scope);
+            result = loginWithClientSecret(tokenEndpoint, socketFactory, hostnameVerifier, clientId, clientSecret, isJwt, principalExtractor, scope, audience);
         } else {
             throw new IllegalStateException("Invalid oauth client configuration - no credentials");
         }

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/Config.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/Config.java
@@ -12,6 +12,7 @@ public class Config {
     public static final String OAUTH_CLIENT_ID = "oauth.client.id";
     public static final String OAUTH_CLIENT_SECRET = "oauth.client.secret";
     public static final String OAUTH_SCOPE = "oauth.scope";
+    public static final String OAUTH_AUDIENCE = "oauth.audience";
     public static final String OAUTH_USERNAME_CLAIM = "oauth.username.claim";
     public static final String OAUTH_FALLBACK_USERNAME_CLAIM = "oauth.fallback.username.claim";
     public static final String OAUTH_FALLBACK_USERNAME_PREFIX = "oauth.fallback.username.prefix";

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/OAuthAuthenticator.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/OAuthAuthenticator.java
@@ -45,9 +45,18 @@ public class OAuthAuthenticator {
                                                   HostnameVerifier hostnameVerifier,
                                                   String clientId, String clientSecret, boolean isJwt,
                                                   PrincipalExtractor principalExtractor, String scope) throws IOException {
+
+        return loginWithClientSecret(tokenEndpointUrl, socketFactory, hostnameVerifier,
+                clientId, clientSecret, isJwt, principalExtractor, scope, null);
+    }
+
+    public static TokenInfo loginWithClientSecret(URI tokenEndpointUrl, SSLSocketFactory socketFactory,
+                                                  HostnameVerifier hostnameVerifier,
+                                                  String clientId, String clientSecret, boolean isJwt,
+                                                  PrincipalExtractor principalExtractor, String scope, String audience) throws IOException {
         if (log.isDebugEnabled()) {
-            log.debug("loginWithClientSecret() - tokenEndpointUrl: {}, clientId: {}, clientSecret: {}, scope: {}",
-                    tokenEndpointUrl, clientId, mask(clientSecret), scope);
+            log.debug("loginWithClientSecret() - tokenEndpointUrl: {}, clientId: {}, clientSecret: {}, scope: {}, audience: {}",
+                    tokenEndpointUrl, clientId, mask(clientSecret), scope, audience);
         }
 
         String authorization = "Basic " + base64encode(clientId + ':' + clientSecret);
@@ -55,6 +64,9 @@ public class OAuthAuthenticator {
         StringBuilder body = new StringBuilder("grant_type=client_credentials");
         if (scope != null) {
             body.append("&scope=").append(urlencode(scope));
+        }
+        if (audience != null) {
+            body.append("&audience=").append(urlencode(audience));
         }
 
         return post(tokenEndpointUrl, socketFactory, hostnameVerifier, authorization, body.toString(), isJwt, principalExtractor);
@@ -64,9 +76,18 @@ public class OAuthAuthenticator {
                                                   HostnameVerifier hostnameVerifier, String refreshToken,
                                                   String clientId, String clientSecret, boolean isJwt,
                                                   PrincipalExtractor principalExtractor, String scope) throws IOException {
+
+        return loginWithRefreshToken(tokenEndpointUrl, socketFactory, hostnameVerifier,
+                refreshToken, clientId, clientSecret, isJwt, principalExtractor, scope, null);
+    }
+
+    public static TokenInfo loginWithRefreshToken(URI tokenEndpointUrl, SSLSocketFactory socketFactory,
+                                                  HostnameVerifier hostnameVerifier, String refreshToken,
+                                                  String clientId, String clientSecret, boolean isJwt,
+                                                  PrincipalExtractor principalExtractor, String scope, String audience) throws IOException {
         if (log.isDebugEnabled()) {
-            log.debug("loginWithRefreshToken() - tokenEndpointUrl: {}, refreshToken: {}, clientId: {}, clientSecret: {}, scope: {}",
-                    tokenEndpointUrl, refreshToken, clientId, mask(clientSecret), scope);
+            log.debug("loginWithRefreshToken() - tokenEndpointUrl: {}, refreshToken: {}, clientId: {}, clientSecret: {}, scope: {}, audience: {}",
+                    tokenEndpointUrl, refreshToken, clientId, mask(clientSecret), scope, audience);
         }
 
         String authorization = clientSecret != null ?
@@ -79,6 +100,9 @@ public class OAuthAuthenticator {
 
         if (scope != null) {
             body.append("&scope=").append(urlencode(scope));
+        }
+        if (audience != null) {
+            body.append("&audience=").append(urlencode(audience));
         }
 
         return post(tokenEndpointUrl, socketFactory, hostnameVerifier, authorization, body.toString(), isJwt, principalExtractor);


### PR DESCRIPTION
Some authorization servers may require `audience` parameter to be passed to the token endpoint.

- Add `oauth.audience` config option for client and server config.
- Use existing `oauth.scope` on the server to get scope parameter value to pass to the token endpoint when OAuth over PLAIN is used (was already being passed for inter-broker authentication).

Signed-off-by: Marko Strukelj <marko.strukelj@gmail.com>