### PR TITLE
Fix debug logging of JWT token payload

### DIFF
--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/TokenIntrospection.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/TokenIntrospection.java
@@ -49,7 +49,7 @@ public class TokenIntrospection {
         JWSObject jws;
         try {
             jws = JWSObject.parse(token);
-            log.debug("Token: {}", jws.getParsedString());
+            log.debug("Token: {}", jws.getPayload());
         } catch (Exception e) {
             log.debug("[IGNORED] Token doesn't seem to be JWT token: " + mask(token), e);
             return;


### PR DESCRIPTION
Fixes a bug introduced in strimzi/strimzi-kafka-oauth#111 that debug logged on the server the received access token rather than its payload in clear text.

The bug did not make it in any release.

Signed-off-by: Marko Strukelj <marko.strukelj@gmail.com>