### PR TITLE
Fix CVE-2021-27568 by updating Jayway Jsonpath to 2.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
         <scala.version>2.12.8</scala.version>
         <jackson.version>2.10.5</jackson.version>
         <jackson.databind.version>2.10.5.1</jackson.databind.version>
-        <jsonpath.version>2.5.0</jsonpath.version>
+        <jsonpath.version>2.6.0</jsonpath.version>
         <junit.version>4.13.1</junit.version>
         <slf4j.version>1.7.26</slf4j.version>
         <nimbus.jose.version>9.9.2</nimbus.jose.version>


### PR DESCRIPTION
This PR tries to update Jayway Jsonpath to 2.6.0. 2.6.0 uses newer version of Json-smart dependency which fixes a CVE CVE-2021-27568.