### PR TITLE
Add `token_type` claim as a failover to `typ` when checking the access token is of type `Bearer`

### DIFF
--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/TokenInfo.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/TokenInfo.java
@@ -17,6 +17,7 @@ public class TokenInfo {
     public static final String EXP = "exp";
     public static final String ISS = "iss";
     public static final String TYP = "typ";
+    public static final String TOKEN_TYPE = "token_type";
     public static final String AUD = "aud";
 
     private String token;

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/validator/JWTSignatureValidator.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/validator/JWTSignatureValidator.java
@@ -349,13 +349,16 @@ public class JWTSignatureValidator implements TokenValidator {
             }
         }
         if (checkAccessTokenType) {
-            JsonNode typ = token.get(TokenInfo.TYP);
-            if (typ == null) {
-                throw new TokenValidationException("Token validation failed: Token type not set");
+            JsonNode type = token.get(TokenInfo.TYP);
+            if (type == null) {
+                type = token.get(TokenInfo.TOKEN_TYPE);
+                if (type == null) {
+                    throw new TokenValidationException("Token validation failed: Token type not set ('token_type' or 'typ' claim not present)");
+                }
             }
-            String type = typ.asText();
-            if (!"Bearer".equals(type)) {
-                throw new TokenValidationException("Token validation failed: Token type not allowed: " + type);
+            String value = type.asText();
+            if (!"Bearer".equals(value)) {
+                throw new TokenValidationException("Token validation failed: Token type not allowed: " + value);
             }
         }
         if (audience != null) {


### PR DESCRIPTION
There appears to be no standard JWT token payload claim for marking the access token as being of type `Bearer`. Up until now, unless the authorization server included 'typ' claim (done by default by Keycloak, but probably no other authorization server), it was necessary to disable the access token type check by setting `oauth.check.access.token.type=\"false\"` parameter in listener configuration of the `server.properties` file.

Since `typ` is not standard, and some authorization servers use `token_type` for the same, it makes sense to also check if JWT token contains `token_type: Bearer` when performing the default access token type check.

It's always possible to turn off the default access token type check, and use `oauth.custom.claim.check`.

Signed-off-by: Marko Strukelj <marko.strukelj@gmail.com>