### PR TITLE
Added zk dependency to kafka and restart policy to compose files

### DIFF
--- a/examples/docker/kafka-oauth-strimzi/compose-authz.yml
+++ b/examples/docker/kafka-oauth-strimzi/compose-authz.yml
@@ -82,6 +82,9 @@ services:
       # For start.sh script to know where the keycloak is listening
       KEYCLOAK_HOST: ${KEYCLOAK_HOST:-keycloak}
       REALM: ${REALM:-kafka-authz}
+    depends_on:
+      - zookeeper
+    restart: on-failure
 
   zookeeper:
     image: strimzi/example-zookeeper

--- a/examples/docker/kafka-oauth-strimzi/compose-hydra-jwt.yml
+++ b/examples/docker/kafka-oauth-strimzi/compose-hydra-jwt.yml
@@ -72,6 +72,9 @@ services:
 
       # For start_with_hydra.sh script to know where hydra is listening
       HYDRA_HOST: ${HYDRA_HOST:-hydra}
+    depends_on:
+      - zookeeper
+    restart: on-failure
 
   zookeeper:
     image: strimzi/example-zookeeper

--- a/examples/docker/kafka-oauth-strimzi/compose-hydra.yml
+++ b/examples/docker/kafka-oauth-strimzi/compose-hydra.yml
@@ -70,6 +70,9 @@ services:
 
       # For start_with_hydra.sh script to know where hydra is listening
       HYDRA_HOST: ${HYDRA_HOST:-hydra}
+    depends_on:
+      - zookeeper
+    restart: on-failure
 
   zookeeper:
     image: strimzi/example-zookeeper

--- a/examples/docker/kafka-oauth-strimzi/compose-plain.yml
+++ b/examples/docker/kafka-oauth-strimzi/compose-plain.yml
@@ -85,6 +85,9 @@ services:
       # For start.sh script to know where the keycloak is listening
       KEYCLOAK_HOST: ${KEYCLOAK_HOST:-keycloak}
       REALM: ${REALM:-kafka-authz}
+    depends_on:
+      - zookeeper
+    restart: on-failure
 
   zookeeper:
     image: strimzi/example-zookeeper

--- a/examples/docker/kafka-oauth-strimzi/compose-spring.yml
+++ b/examples/docker/kafka-oauth-strimzi/compose-spring.yml
@@ -70,6 +70,9 @@ services:
 
       # For start.sh script to know where the keycloak is listening
       SPRING_HOST: ${SPRING_HOST:-spring}
+    depends_on:
+      - zookeeper
+    restart: on-failure
 
   zookeeper:
     image: strimzi/example-zookeeper

--- a/examples/docker/kafka-oauth-strimzi/compose-ssl.yml
+++ b/examples/docker/kafka-oauth-strimzi/compose-ssl.yml
@@ -74,6 +74,9 @@ services:
       KEYCLOAK_HOST: ${KEYCLOAK_HOST:-keycloak}
       REALM: ${REALM:-demo}
       KEYCLOAK_URI: "https://${KEYCLOAK_HOST:-keycloak}:8443/auth"
+    depends_on:
+      - zookeeper
+    restart: on-failure
 
   zookeeper:
     image: strimzi/example-zookeeper

--- a/examples/docker/kafka-oauth-strimzi/compose.yml
+++ b/examples/docker/kafka-oauth-strimzi/compose.yml
@@ -65,6 +65,9 @@ services:
       # For start.sh script to know where the keycloak is listening
       KEYCLOAK_HOST: ${KEYCLOAK_HOST:-keycloak}
       REALM: ${REALM:-demo}
+    depends_on:
+      - zookeeper
+    restart: on-failure
 
   zookeeper:
     image: strimzi/example-zookeeper


### PR DESCRIPTION
While deploying Kafka with Hydra there are times where Kafka shuts down because Zookeeper just wasn't ready to accept connections. 
To tweak it just a little bit I added small dependency to Kafka + restart policy just in case it dies for some unknown reason to tackle "Did you try to turn it off and on again". 