### PR TITLE
Add `oauth.jwks.ignore.key.use` config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,6 +350,9 @@ You can control the minimum pause between two consecutive scheduled keys refresh
 
 All access tokens can be invalidated by rotating the keys on authorization server and expiring old keys.
 
+Some authorization servers don't specify the `"use": "sig"` attribute in validation keys in the JWKS endpoint response. By default only the public keys with `"use": "sig"` are considered for signature validation. There is an option to ignore the `use` attribute, and consider all the keys for token signature validation:
+- `oauth.jwks.ignore.key.use` (e.g.: "true" - ignore the `use` attribute on the keys in JWKS response)
+
 During the Kafka broker startup, a request to the JWKS endpoint immediately tries to load the keys.
 If JWKS keys can not be loaded or can not be successfully parsed during startup, the Kafka broker will exit.
 That behaviour can be turned off:

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/OAuthAuthenticator.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/OAuthAuthenticator.java
@@ -192,6 +192,10 @@ public class OAuthAuthenticator {
         return Base64.getUrlEncoder().encodeToString(value.getBytes(StandardCharsets.UTF_8));
     }
 
+    public static String base64decode(String value) {
+        return new String(Base64.getUrlDecoder().decode(value), StandardCharsets.UTF_8);
+    }
+
     public static String urlencode(String value) {
         try {
             return URLEncoder.encode(value, "utf-8");

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/services/ValidatorKey.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/services/ValidatorKey.java
@@ -143,6 +143,7 @@ public class ValidatorKey {
         private final int jwksRefreshMinPauseSeconds;
         private final boolean checkAccessTokenType;
         private final boolean failFast;
+        private final boolean jwksIgnoreKeyUse;
 
         private final String configIdHash;
 
@@ -165,6 +166,7 @@ public class ValidatorKey {
                                int jwksRefreshSeconds,
                                int jwksExpirySeconds,
                                int jwksRefreshMinPauseSeconds,
+                               boolean jwksIgnoreKeyUse,
                                boolean checkAccessTokenType,
                                int connectTimeout,
                                int readTimeout,
@@ -191,6 +193,7 @@ public class ValidatorKey {
             this.jwksRefreshSeconds = jwksRefreshSeconds;
             this.jwksExpirySeconds = jwksExpirySeconds;
             this.jwksRefreshMinPauseSeconds = jwksRefreshMinPauseSeconds;
+            this.jwksIgnoreKeyUse = jwksIgnoreKeyUse;
             this.checkAccessTokenType = checkAccessTokenType;
             this.failFast = failFast;
 
@@ -199,6 +202,7 @@ public class ValidatorKey {
                     jwksRefreshSeconds,
                     jwksExpirySeconds,
                     jwksRefreshMinPauseSeconds,
+                    jwksIgnoreKeyUse,
                     checkAccessTokenType,
                     failFast);
         }
@@ -212,6 +216,7 @@ public class ValidatorKey {
             return jwksRefreshSeconds == that.jwksRefreshSeconds &&
                     jwksExpirySeconds == that.jwksExpirySeconds &&
                     jwksRefreshMinPauseSeconds == that.jwksRefreshMinPauseSeconds &&
+                    jwksIgnoreKeyUse == that.jwksIgnoreKeyUse &&
                     checkAccessTokenType == that.checkAccessTokenType &&
                     failFast == that.failFast &&
                     Objects.equals(jwksEndpointUri, that.jwksEndpointUri);
@@ -224,6 +229,7 @@ public class ValidatorKey {
                     jwksRefreshSeconds,
                     jwksExpirySeconds,
                     jwksRefreshMinPauseSeconds,
+                    jwksIgnoreKeyUse,
                     checkAccessTokenType,
                     failFast);
         }

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/validator/JWTSignatureValidator.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/validator/JWTSignatureValidator.java
@@ -107,6 +107,7 @@ public class JWTSignatureValidator implements TokenValidator {
      * @param refreshSeconds The optional time interval between two consecutive regular JWKS keys refresh runs
      * @param refreshMinPauseSeconds The optional minimum pause between two consecutive JWKS keys refreshes.
      * @param expirySeconds The maximum time to trust the unrefreshed JWKS keys. If keys are not successfully refreshed within this time, the validation will start failing.
+     * @param ignoreKeyUse Should any key present in JWKS key set be considered a public key for signature checking
      * @param checkAccessTokenType Should the 'typ' claim in the token be validated (be equal to 'Bearer')
      * @param audience The optional audience
      * @param customClaimCheck The optional JSONPath filter query for additional custom claim checking
@@ -114,7 +115,6 @@ public class JWTSignatureValidator implements TokenValidator {
      * @param readTimeoutSeconds The maximum time to wait for response from authorization server after connection has been established and request sent (in seconds)
      * @param enableMetrics The switch that enables metrics collection
      * @param failFast Should exception be thrown during initialisation if unable to retrieve JWKS keys
-     * @param ignoreKeyUse Should any key present in JWKS key set be considered a public key for signature checking
      */
     @SuppressWarnings("checkstyle:ParameterNumber")
     public JWTSignatureValidator(String validatorId,

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/validator/JWTSignatureValidator.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/validator/JWTSignatureValidator.java
@@ -77,6 +77,7 @@ public class JWTSignatureValidator implements TokenValidator {
     private final SSLSocketFactory socketFactory;
     private final HostnameVerifier hostnameVerifier;
     private final PrincipalExtractor principalExtractor;
+    private final boolean ignoreKeyUse;
 
     private final int connectTimeout;
     private final int readTimeout;
@@ -113,6 +114,7 @@ public class JWTSignatureValidator implements TokenValidator {
      * @param readTimeoutSeconds The maximum time to wait for response from authorization server after connection has been established and request sent (in seconds)
      * @param enableMetrics The switch that enables metrics collection
      * @param failFast Should exception be thrown during initialisation if unable to retrieve JWKS keys
+     * @param ignoreKeyUse Should any key present in JWKS key set be considered a public key for signature checking
      */
     @SuppressWarnings("checkstyle:ParameterNumber")
     public JWTSignatureValidator(String validatorId,
@@ -126,6 +128,7 @@ public class JWTSignatureValidator implements TokenValidator {
                                  int refreshSeconds,
                                  int refreshMinPauseSeconds,
                                  int expirySeconds,
+                                 boolean ignoreKeyUse,
                                  boolean checkAccessTokenType,
                                  String audience,
                                  String customClaimCheck,
@@ -186,7 +189,7 @@ public class JWTSignatureValidator implements TokenValidator {
         metrics = enableMetrics ? Services.getInstance().getMetrics() : null;
 
         jwksHttpSensorKeyProducer = new JwksHttpSensorKeyProducer(validatorId, keysUri);
-
+        this.ignoreKeyUse = ignoreKeyUse;
         ScheduledExecutorService executor = setupExecutorAndFetchInitialKeys(refreshSeconds, refreshMinPauseSeconds, failFast);
 
         // set up periodic timer to trigger fastScheduler job every refreshSeconds
@@ -205,6 +208,7 @@ public class JWTSignatureValidator implements TokenValidator {
                     + "\n    certsRefreshSeconds: " + refreshSeconds
                     + "\n    certsRefreshMinPauseSeconds: " + refreshMinPauseSeconds
                     + "\n    certsExpirySeconds: " + expirySeconds
+                    + "\n    certsIgnoreKeyUse: " + ignoreKeyUse
                     + "\n    checkAccessTokenType: " + checkAccessTokenType
                     + "\n    audience: " + audience
                     + "\n    customClaimCheck: " + customClaimCheck
@@ -332,7 +336,7 @@ public class JWTSignatureValidator implements TokenValidator {
             JWKSet jwks = JWKSet.parse(response);
 
             for (JWK jwk : jwks.getKeys()) {
-                if (jwk.getKeyUse().equals(KeyUse.SIGNATURE)) {
+                if (ignoreKeyUse || KeyUse.SIGNATURE.equals(jwk.getKeyUse())) {
 
                     PublicKey publicKey;
 

--- a/oauth-server/src/main/java/io/strimzi/kafka/oauth/server/JaasServerOauthValidatorCallbackHandler.java
+++ b/oauth-server/src/main/java/io/strimzi/kafka/oauth/server/JaasServerOauthValidatorCallbackHandler.java
@@ -117,6 +117,7 @@ import static io.strimzi.kafka.oauth.common.TokenIntrospection.debugLogJWT;
  * The expiry interval has to be at least 60 seconds longer then the refresh interval specified in <em>oauth.jwks.refresh.seconds</em>. Default value is <em>360</em>.</li>
  * <li><em>oauth.jwks.refresh.min.pause.seconds</em> The minimum pause between two consecutive refreshes. <br>
  * When an unknown signing key is encountered the refresh is scheduled immediately, but will always wait for this minimum pause. Default value is <em>1</em>.</li>
+ * <li><em>oauth.jwks.ignore.key.use</em> Configure whether any public key in JWKS response should be considered for signature checking or only those explicitly marked as such (some authorization servers require setting this to `true`). Default value is <em>false</em>.</li>
  * </ul>
  * <p>
  * Configuring the introspection endpoint based token validation
@@ -377,6 +378,7 @@ public class JaasServerOauthValidatorCallbackHandler implements AuthenticateCall
         int jwksExpirySeconds = config.getValueAsInt(ServerConfig.OAUTH_JWKS_EXPIRY_SECONDS, 360);
         int jwksMinPauseSeconds = config.getValueAsInt(ServerConfig.OAUTH_JWKS_REFRESH_MIN_PAUSE_SECONDS, 1);
         boolean failFast = config.getValueAsBoolean(ServerConfig.OAUTH_FAIL_FAST, true);
+        boolean jwksIgnoreKeyUse = config.getValueAsBoolean(ServerConfig.OAUTH_JWKS_IGNORE_KEY_USE, false);
 
         ValidatorKey vkey = new ValidatorKey.JwtValidatorKey(
                 validIssuerUri,
@@ -396,11 +398,13 @@ public class JaasServerOauthValidatorCallbackHandler implements AuthenticateCall
                 jwksRefreshSeconds,
                 jwksExpirySeconds,
                 jwksMinPauseSeconds,
+                jwksIgnoreKeyUse,
                 checkTokenType,
                 connectTimeout,
                 readTimeout,
                 enableMetrics,
-                failFast);
+                failFast
+        );
 
         String effectiveConfigId = configId != null ? configId : vkey.getConfigIdHash();
 
@@ -416,6 +420,7 @@ public class JaasServerOauthValidatorCallbackHandler implements AuthenticateCall
                 jwksRefreshSeconds,
                 jwksMinPauseSeconds,
                 jwksExpirySeconds,
+                jwksIgnoreKeyUse,
                 checkTokenType,
                 audience,
                 customClaimCheck,

--- a/oauth-server/src/main/java/io/strimzi/kafka/oauth/server/ServerConfig.java
+++ b/oauth-server/src/main/java/io/strimzi/kafka/oauth/server/ServerConfig.java
@@ -14,6 +14,7 @@ public class ServerConfig extends Config {
     public static final String OAUTH_JWKS_EXPIRY_SECONDS = "oauth.jwks.expiry.seconds";
     public static final String OAUTH_JWKS_REFRESH_SECONDS = "oauth.jwks.refresh.seconds";
     public static final String OAUTH_JWKS_REFRESH_MIN_PAUSE_SECONDS = "oauth.jwks.refresh.min.pause.seconds";
+    public static final String OAUTH_JWKS_IGNORE_KEY_USE = "oauth.jwks.ignore.key.use";
     public static final String OAUTH_VALID_ISSUER_URI = "oauth.valid.issuer.uri";
     public static final String OAUTH_INTROSPECTION_ENDPOINT_URI = "oauth.introspection.endpoint.uri";
     public static final String OAUTH_USERINFO_ENDPOINT_URI = "oauth.userinfo.endpoint.uri";

--- a/testsuite/README.md
+++ b/testsuite/README.md
@@ -47,13 +47,19 @@ By using `clean` you make sure that the latest project jars are included into th
 
 There are several profiles available to test with a specific version of Kafka images:
 
-- kafka-2_3_0
+- kafka-2_3_1
 - kafka-2_4_0
 - kafka-2_4_1
 - kafka-2_5_0
 - kafka-2_5_1
 - kafka-2_6_0
+- kafka-2_6_2
 - kafka-2_7_0
+- kafka-2_7_1
+- kafka-2_8_0
+- kafka-2_8_1
+- kafka-3_0_0
+- kafka-3_1_0
 
 Only one at a time can be applied. For example:
  
@@ -181,6 +187,6 @@ Thus, you don't need to use the latest local build of strimzi/kafka libraries to
 
 But if you want you can specify the kafka image to use for the test as follows:
 
-    mvn clean test -Dkafka.docker.image=strimzi/kafka:build-kafka-2.6.0  -f testsuite/keycloak-auth-tests
+    mvn clean test -Dkafka.docker.image=quay.io/strimzi/kafka:0.28.0-kafka-3.1.0 -f testsuite/keycloak-auth-tests
 
 This will use the latest locally built kafka image of strimzi-kafka-operator project.

--- a/testsuite/metrics-tests/docker-compose.yml
+++ b/testsuite/metrics-tests/docker-compose.yml
@@ -12,9 +12,9 @@ services:
       - ${PWD}/../docker/certificates:/application/config
 
     environment:
-      - JAVA_DEBUG=y
-      - DEBUG_SUSPEND_FLAG=n
-      - JAVA_DEBUG_PORT=0.0.0.0:5005
+      #- JAVA_DEBUG=y
+      #- DEBUG_SUSPEND_FLAG=n
+      #- JAVA_DEBUG_PORT=0.0.0.0:5005
 
       - KEYSTORE_ONE_PATH=/application/config/mockoauth.server.keystore.p12
       - KEYSTORE_ONE_PASSWORD=changeit

--- a/testsuite/mock-oauth-server/pom.xml
+++ b/testsuite/mock-oauth-server/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <checkstyle.dir>../..</checkstyle.dir>
-        <vertx.version>4.1.2</vertx.version>
+        <vertx.version>4.3.0</vertx.version>
 
         <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
         <maven-shade-plugin.version>3.2.4</maven-shade-plugin.version>
@@ -54,12 +54,12 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.30</version>
+            <version>1.7.36</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.2.3</version>
+            <version>1.2.11</version>
         </dependency>
 
 <!--

--- a/testsuite/mock-oauth-server/src/main/java/io/strimzi/testsuite/oauth/server/AuthServerRequestHandler.java
+++ b/testsuite/mock-oauth-server/src/main/java/io/strimzi/testsuite/oauth/server/AuthServerRequestHandler.java
@@ -4,15 +4,49 @@
  */
 package io.strimzi.testsuite.oauth.server;
 
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.JWSSigner;
+import com.nimbusds.jose.crypto.RSASSASigner;
+import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import io.strimzi.kafka.oauth.common.JSONUtil;
 import io.vertx.core.Handler;
-import io.vertx.core.http.HttpMethod;
+import io.vertx.core.MultiMap;
 import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.json.JsonObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.security.NoSuchAlgorithmException;
+import java.util.Date;
+
+import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
+import static io.netty.handler.codec.http.HttpResponseStatus.FORBIDDEN;
+import static io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERROR;
+import static io.netty.handler.codec.http.HttpResponseStatus.METHOD_NOT_ALLOWED;
+import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
+import static io.netty.handler.codec.http.HttpResponseStatus.OK;
+import static io.netty.handler.codec.http.HttpResponseStatus.SERVICE_UNAVAILABLE;
+import static io.netty.handler.codec.http.HttpResponseStatus.UNAUTHORIZED;
+import static io.strimzi.kafka.oauth.common.OAuthAuthenticator.base64decode;
+import static io.strimzi.testsuite.oauth.server.Commons.handleFailure;
+import static io.strimzi.testsuite.oauth.server.Commons.isOneOf;
+import static io.strimzi.testsuite.oauth.server.Commons.sendResponse;
+import static io.strimzi.testsuite.oauth.server.Commons.setContextLog;
+import static io.strimzi.testsuite.oauth.server.Endpoint.TOKEN;
+import static io.strimzi.testsuite.oauth.server.Mode.MODE_200;
+import static io.strimzi.testsuite.oauth.server.Mode.MODE_JWKS_RSA_WITHOUT_SIG_USE;
+import static io.strimzi.testsuite.oauth.server.Mode.MODE_JWKS_RSA_WITH_SIG_USE;
+import static io.vertx.core.http.HttpMethod.GET;
+import static io.vertx.core.http.HttpMethod.POST;
+
 public class AuthServerRequestHandler implements Handler<HttpServerRequest> {
 
-    private static final Logger log = LoggerFactory.getLogger(AuthServerRequestHandler.class);
+    private static final Logger log = LoggerFactory.getLogger("oauth");
 
     private final MockOAuthServerMainVerticle verticle;
 
@@ -22,62 +56,176 @@ public class AuthServerRequestHandler implements Handler<HttpServerRequest> {
 
     @Override
     public void handle(HttpServerRequest req) {
-        if (req.method() != HttpMethod.GET) {
-            req.response().setStatusCode(405)
-                    .setStatusMessage("Method not allowed")
-                    .end();
+        log.info("> " + req.method().name() + " " + req.path());
+        setContextLog(log);
+
+        if (!isOneOf(req.method(), GET, POST)) {
+            sendResponse(req, METHOD_NOT_ALLOWED);
             return;
         }
 
         String[] path = req.path().split("/");
 
         if (path.length != 2) {
-            req.response().setStatusCode(404)
-                    .setStatusMessage("Not Found")
-                    .end();
+            sendResponse(req, NOT_FOUND);
             return;
         }
 
         Endpoint endpoint = Endpoint.fromString(path[1]);
         Mode mode = verticle.getMode(endpoint);
 
+        try {
+            if (endpoint == Endpoint.JWKS &&
+                    isOneOf(mode, MODE_200, MODE_JWKS_RSA_WITH_SIG_USE, MODE_JWKS_RSA_WITHOUT_SIG_USE)) {
+                processJwksRequest(req, mode);
+                return;
+
+            } else if (endpoint == TOKEN && mode == MODE_200) {
+                processTokenRequest(req);
+                return;
+            }
+
+            switch (mode) {
+                case MODE_400:
+                    sendResponse(req, BAD_REQUEST);
+                    break;
+                case MODE_401:
+                    sendResponse(req, UNAUTHORIZED);
+                    break;
+                case MODE_403:
+                    sendResponse(req, FORBIDDEN);
+                    break;
+                case MODE_404:
+                    sendResponse(req, NOT_FOUND);
+                    break;
+                case MODE_500:
+                    sendResponse(req, INTERNAL_SERVER_ERROR);
+                    break;
+                case MODE_503:
+                    sendResponse(req, SERVICE_UNAVAILABLE);
+                    break;
+                default:
+                    log.error("Unexpected mode: " + mode);
+                    sendResponse(req, OK, "" + verticle.getMode(endpoint));
+            }
+
+        } catch (Throwable t) {
+            handleFailure(req, t, log);
+        }
+    }
+
+    private void processTokenRequest(HttpServerRequest req) {
+        if (req.method() != POST) {
+            sendResponse(req, METHOD_NOT_ALLOWED);
+            return;
+        }
+
+        // Need to read the complete body before we can get the form attributes
+        req.setExpectMultipart(true);
+        req.endHandler(v -> {
+
+            MultiMap form = req.formAttributes();
+            log.info(form.toString());
+
+            String grantType = form.get("grant_type");
+            if (grantType == null) {
+                sendResponse(req, BAD_REQUEST);
+                return;
+            }
+
+            String authorization = req.headers().get("Authorization");
+            String clientId = authorize(authorization);
+
+            if (!grantType.equals("client_credentials") || clientId == null) {
+                sendResponse(req, UNAUTHORIZED);
+                return;
+            }
+
+            try {
+                // Create a signed JWT token
+                String accessToken = createSignedAccessToken(clientId);
+
+                JsonObject result = new JsonObject();
+                result.put("access_token", accessToken);
+                result.put("expires_in", 60_000);
+                result.put("scope", "all");
+
+                String jsonString = result.encode();
+                sendResponse(req, OK, jsonString);
+
+            } catch (Throwable t) {
+                handleFailure(req, t, log);
+            }
+        });
+    }
+
+    private String createSignedAccessToken(String clientId) throws JOSEException, NoSuchAlgorithmException {
+
+        // Create RSA-signer with the private key
+        JWSSigner signer = new RSASSASigner(verticle.getSigKey());
+
+        // Prepare JWT with claims set
+        JWTClaimsSet claimsSet = new JWTClaimsSet.Builder()
+                .subject(clientId)
+                .issuer("https://mockoauth:8090")
+                .expirationTime(new Date(new Date().getTime() + 60 * 1000))
+                .build();
+
+        SignedJWT signedJWT = new SignedJWT(
+                new JWSHeader.Builder(JWSAlgorithm.RS256).keyID(verticle.getSigKey().getKeyID()).build(),
+                claimsSet);
+
+        // Compute the RSA signature
+        signedJWT.sign(signer);
+
+        return signedJWT.serialize();
+    }
+
+    private String authorize(String authorization) {
+        if (authorization == null || !authorization.startsWith("Basic ")) {
+            return null;
+        }
+        String decoded = base64decode(authorization.substring(6));
+        String[] idSecret = decoded.split(":");
+        if (idSecret.length != 2) {
+            return null;
+        }
+
+        if (!idSecret[1].equals(verticle.getClients().get(idSecret[0]))) {
+            return null;
+        }
+        return idSecret[0];
+    }
+
+    private void processJwksRequest(HttpServerRequest req, Mode mode) throws NoSuchAlgorithmException, JOSEException {
+        if (req.method() != GET) {
+            sendResponse(req, METHOD_NOT_ALLOWED);
+            return;
+        }
         switch (mode) {
-            case MODE_400:
-                req.response().setStatusCode(400)
-                        .setStatusMessage("Bad Request")
-                        .end();
+            case MODE_200:
+            case MODE_JWKS_RSA_WITH_SIG_USE:
+                sendResponse(req, OK, jwksWithSig());
                 break;
-            case MODE_401:
-                req.response().setStatusCode(401)
-                        .setStatusMessage("Unauthorized")
-                        .end();
-                break;
-            case MODE_403:
-                req.response().setStatusCode(403)
-                        .setStatusMessage("Forbidden")
-                        .end();
-                break;
-            case MODE_404:
-                req.response().setStatusCode(404)
-                        .setStatusMessage("Not Found")
-                        .end();
-                break;
-            case MODE_500:
-                req.response().setStatusCode(500)
-                        .setStatusMessage("Internal Server Error")
-                        .end();
-                break;
-            case MODE_503:
-                req.response().setStatusCode(503)
-                        .setStatusMessage("Service Unavailable")
-                        .end();
+            case MODE_JWKS_RSA_WITHOUT_SIG_USE:
+                sendResponse(req, OK, jwksWithoutSig());
                 break;
             default:
-                log.error("Unexpected mode: " + mode);
-                req.response()
-                        .putHeader("Content-Type", "text/plain")
-                        .end("" + verticle.getMode(endpoint));
-
+                throw new IllegalStateException("Internal error");
         }
+    }
+
+
+    private String jwksWithSig() throws NoSuchAlgorithmException {
+        return JSONUtil.asJson(new JWKSet(verticle.getSigKey()).toJSONObject()).toPrettyString();
+    }
+
+    private String jwksWithoutSig() throws NoSuchAlgorithmException, JOSEException {
+        RSAKey jwk = verticle.getSigKey();
+        jwk = new RSAKey.Builder(jwk.toRSAPublicKey())
+                .privateKey(jwk.toRSAPrivateKey())
+                .keyID(jwk.getKeyID())
+                .build();
+        return JSONUtil.asJson(new JWKSet(jwk).toJSONObject()).toPrettyString();
     }
 }

--- a/testsuite/mock-oauth-server/src/main/java/io/strimzi/testsuite/oauth/server/Commons.java
+++ b/testsuite/mock-oauth-server/src/main/java/io/strimzi/testsuite/oauth/server/Commons.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2017-2022, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.testsuite.oauth.server;
+
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.vertx.core.http.HttpServerRequest;
+import org.slf4j.Logger;
+import org.slf4j.helpers.NOPLogger;
+
+import java.util.Arrays;
+import java.util.EnumSet;
+
+import static io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERROR;
+
+
+public class Commons {
+
+    private static final ThreadLocal<Logger> contextLog = new ThreadLocal<>();
+
+    public static void setContextLog(Logger log) {
+        contextLog.set(log);
+    }
+
+    public static Logger getContextLog() {
+        Logger log = contextLog.get();
+        return log != null ? log : NOPLogger.NOP_LOGGER;
+    }
+
+    @SafeVarargs
+    public static <T extends Enum<T>> boolean isOneOf(T mode, T... modes) {
+        return EnumSet.copyOf(Arrays.asList(modes)).contains(mode);
+    }
+
+    @SafeVarargs
+    public static <T> boolean isOneOf(T mode, T... modes) {
+        for (T element: modes) {
+            if (element.equals(mode)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public static void sendResponse(HttpServerRequest req, HttpResponseStatus status) {
+        sendResponse(req, status.code(), status.reasonPhrase());
+    }
+
+    public static void sendResponse(HttpServerRequest req, HttpResponseStatus status, String text) {
+        sendResponse(req, status.code(), status.reasonPhrase(), text);
+    }
+
+    public static void sendResponse(HttpServerRequest req, int statusCode, String statusMessage) {
+        getContextLog().info("< " + statusCode + " " + statusMessage);
+
+        req.response().setStatusCode(statusCode)
+            .setStatusMessage(statusMessage)
+            .end();
+    }
+
+    public static void sendResponse(HttpServerRequest req, int statusCode, String statusMessage, String text) {
+        getContextLog().info("< " + statusCode + " " + statusMessage + "\n" + text);
+
+        req.response().setStatusCode(statusCode)
+                .setStatusMessage(statusMessage)
+                .end(text);
+    }
+
+    static void handleFailure(HttpServerRequest req, Throwable t, Logger log) {
+        log.error("An error during processing of request: " + req, t);
+        sendResponse(req, INTERNAL_SERVER_ERROR);
+    }
+}

--- a/testsuite/mock-oauth-server/src/main/java/io/strimzi/testsuite/oauth/server/Commons.java
+++ b/testsuite/mock-oauth-server/src/main/java/io/strimzi/testsuite/oauth/server/Commons.java
@@ -17,14 +17,14 @@ import static io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERR
 
 public class Commons {
 
-    private static final ThreadLocal<Logger> contextLog = new ThreadLocal<>();
+    private static final ThreadLocal<Logger> CONTEXT_LOG = new ThreadLocal<>();
 
     public static void setContextLog(Logger log) {
-        contextLog.set(log);
+        CONTEXT_LOG.set(log);
     }
 
     public static Logger getContextLog() {
-        Logger log = contextLog.get();
+        Logger log = CONTEXT_LOG.get();
         return log != null ? log : NOPLogger.NOP_LOGGER;
     }
 

--- a/testsuite/mock-oauth-server/src/main/java/io/strimzi/testsuite/oauth/server/Endpoint.java
+++ b/testsuite/mock-oauth-server/src/main/java/io/strimzi/testsuite/oauth/server/Endpoint.java
@@ -11,7 +11,8 @@ public enum Endpoint {
     INTROSPECT,
     USERINFO,
     TOKEN,
-    SERVER;
+    SERVER,
+    CLIENTS;
 
     public static Endpoint fromString(String value) {
         return valueOf(value.toUpperCase(Locale.ROOT));

--- a/testsuite/mock-oauth-server/src/main/java/io/strimzi/testsuite/oauth/server/MockOAuthServerMainVerticle.java
+++ b/testsuite/mock-oauth-server/src/main/java/io/strimzi/testsuite/oauth/server/MockOAuthServerMainVerticle.java
@@ -4,8 +4,11 @@
  */
 package io.strimzi.testsuite.oauth.server;
 
+import com.nimbusds.jose.jwk.KeyUse;
+import com.nimbusds.jose.jwk.RSAKey;
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.Future;
+import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpServer;
 import io.vertx.core.http.HttpServerOptions;
@@ -13,8 +16,18 @@ import io.vertx.core.net.JksOptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAPublicKey;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
 import static io.strimzi.testsuite.oauth.server.Endpoint.INTROSPECT;
 import static io.strimzi.testsuite.oauth.server.Endpoint.JWKS;
@@ -26,7 +39,7 @@ import static io.strimzi.testsuite.oauth.server.Mode.MODE_401;
 import static io.strimzi.testsuite.oauth.server.Mode.MODE_404;
 
 /**
- * A simple remote controllable authorization server for testing various error situations
+ * A simple remote controllable authorization server for testing various error situations.
  * <p>
  * This Verticle sets up two servers on two ports:
  * <ul>
@@ -42,10 +55,11 @@ import static io.strimzi.testsuite.oauth.server.Mode.MODE_404;
  *     <li>/token</li>
  * </ul>
  *
- * The admin server allows configuring for each of these endpoints what an error status it should return.
+ * The admin server allows configuring for each of these endpoints what it should return.
  *
- * Use PUT or POST to any of these endpoints with <tt>?mode=MODE</tt> where MODE is one of:
+ * Use PUT or POST to any of these endpoints prepended by '/admin' (e.g. '/admin/jwks') with <tt>?mode=MODE</tt> where MODE is one of:
  * <ul>
+ *     <li>MODE_200</li>
  *     <li>MODE_400</li>
  *     <li>MODE_401</li>
  *     <li>MODE_403</li>
@@ -54,41 +68,71 @@ import static io.strimzi.testsuite.oauth.server.Mode.MODE_404;
  *     <li>MODE_503</li>
  * </ul>
  *
- *  For example, <tt>POST /jwks?mode=MODE_404</tt> will configure the authorization server to always return status 404
- *  when any request is performed against <tt>/jwks</tt> endpoint.
+ * Some other modes are endpoint specific.
  *
- *  Additionally, the admin server exposes another endpoint:
- *  <ul>
- *      <li>/server</li>
- *  </ul>
+ * For 'jwks' there are two specific modes:
+ * <ul>
+ *     <li>MODE_JWKS_RSA_WITH_SIG_USE</li>
+ *     <li>MODE_JWKS_RSA_WITHOUT_SIG_USE</li>
+ * </ul>
  *
- *  Which is used to control the state of the authorization server itself rather than its specific endpoints.
- *  The following modes are available:
- *  <ul>
- *      <li><tt>MODE_OFF</tt> to unbind the server port 8090</li>
- *      <li><tt>MODE_CERT_ONE_ON</tt> to bind the server using <tt>https</tt> with a valid certificate</li>
- *      <li><tt>MODE_CERT_TWO_ON</tt> to bind the server using <tt>https</tt> with a different certificate</li>
- *      <li><tt>MODE_EXPIRED_CERT_ON</tt> to bind the server using <tt>https</tt> with expired certificate</li>
- *  </ul>
+ * For example, <tt>POST /admin/jwks?mode=MODE_404</tt> will configure the authorization server to always return status 404
+ * when any request is performed against <tt>/jwks</tt> endpoint.
  *
- *  The server is bound on all the network interfaces, but certificates are created for the name <tt>mockoauth</tt>.
- *  Rather than accessing this server using the local hostname or a loopback IP you should add <tt>mockoauth</tt> to your
- *  <tt>/etc/host</tt> and in <tt>.travis.yml</tt>.
+ * The <tt>MODE_200</tt> mode results in the endpoint behaving as a properly functioning OAuth server. For example,
+ * <tt>POST /admin/jwks?mode=MODE_200</tt> will instruct the authorization server to return public keys for signature validation.
+ * Specifically, the behaviour will be the same as if setting it to MODE_JWKS_RSA_WITH_SIG_USE.
+ *
+ * And setting <tt>/admin/token</tt> to <tt>MODE_200</tt> instructs the authorization server that the token endpoint should issue new tokens,
+ * using the <tt>client_credentials</tt> grant type.
+ *
+ * <br><br>
+ * The admin server exposes two additional endpoints:
+ * <ul>
+ *     <li>/admin/server</li>
+ *     <li>/admin/clients</li>
+ * </ul>
+ *
+ * <tt>/admin/server</tt> is used to control the state of the authorization server itself rather than its specific endpoints.
+ * The following modes are available:
+ * <ul>
+ *     <li><tt>MODE_OFF</tt> to unbind the server port 8090</li>
+ *     <li><tt>MODE_CERT_ONE_ON</tt> to bind the server using <tt>https</tt> with a valid certificate</li>
+ *     <li><tt>MODE_CERT_TWO_ON</tt> to bind the server using <tt>https</tt> with a different certificate</li>
+ *     <li><tt>MODE_EXPIRED_CERT_ON</tt> to bind the server using <tt>https</tt> with expired certificate</li>
+ * </ul>
+ *
+ * <tt>/admin/clients</tt> is used to add client definitions. A client has a <tt>clientId</tt> and a <tt>secret</tt>.
+ *
+ * They can be added by posting a JSON document to <tt>/admin/clients</tt> containing the attributes, e.g.:
+ * <pre>
+ * {
+ *     "clientId": "testclient",
+ *     "secret": "testsecret"
+ * }
+ * </pre>
+ *
+ * The server is bound on all the network interfaces, but certificates are created for the name <tt>mockoauth</tt>.
+ * Rather than accessing this server using the local hostname or a loopback IP you should add <tt>mockoauth</tt> to your
+ * <tt>/etc/host</tt> and in <tt>.travis.yml</tt>.
  */
 public class MockOAuthServerMainVerticle extends AbstractVerticle {
 
     private static final Logger log = LoggerFactory.getLogger(MockOAuthServerMainVerticle.class);
 
-    Future<HttpServer> authServer;
+    private Future<HttpServer> authServer;
 
-    Map<Endpoint, Mode> modes = new HashMap<>();
+    private final Map<Endpoint, Mode> modes = new HashMap<>();
 
-    String keystoreOnePath;
-    String keystoreOnePass;
-    String keystoreTwoPath;
-    String keystoreTwoPass;
-    String keystoreExpiredPath;
-    String keystoreExpiredPass;
+    private String keystoreOnePath;
+    private String keystoreOnePass;
+    private String keystoreTwoPath;
+    private String keystoreTwoPass;
+    private String keystoreExpiredPath;
+    private String keystoreExpiredPass;
+
+    private final Map<String, String> clients = new HashMap<>();
+    private RSAKey sigKey;
 
     public void start() {
 
@@ -97,13 +141,14 @@ public class MockOAuthServerMainVerticle extends AbstractVerticle {
         modes.put(INTROSPECT, MODE_401);
         modes.put(USERINFO, MODE_401);
 
-        keystoreOnePath = getEnvVar("KEYSTORE_ONE_PATH", "../docker/certificates/mockoauth.server.keystore.p12");
+        String projectRoot = getProjectRoot();
+        keystoreOnePath = getEnvVar("KEYSTORE_ONE_PATH", projectRoot + "/../docker/certificates/mockoauth.server.keystore.p12");
         keystoreOnePass = getEnvVar("KEYSTORE_ONE_PASSWORD", "changeit");
 
-        keystoreTwoPath = getEnvVar("KEYSTORE_TWO_PATH", "../docker/certificates/mockoauth.server.keystore_2.p12");
+        keystoreTwoPath = getEnvVar("KEYSTORE_TWO_PATH", projectRoot + "/../docker/certificates/mockoauth.server.keystore_2.p12");
         keystoreTwoPass = getEnvVar("KEYSTORE_TWO_PASSWORD", "changeit");
 
-        keystoreExpiredPath = getEnvVar("KEYSTORE_EXPIRED_PATH", "../docker/certificates/mockoauth.server.keystore_expired.p12");
+        keystoreExpiredPath = getEnvVar("KEYSTORE_EXPIRED_PATH", projectRoot + "/../docker/certificates/mockoauth.server.keystore_expired.p12");
         keystoreExpiredPass = getEnvVar("KEYSTORE_EXPIRED_PASSWORD", "changeit");
 
         // Start admin server
@@ -112,7 +157,20 @@ public class MockOAuthServerMainVerticle extends AbstractVerticle {
         ensureAuthServerWithFirstCert();
     }
 
-    void ensureAuthServer(String keystorePath, String keystorePass) {
+    private static String getProjectRoot() {
+        String cwd = System.getProperty("user.dir");
+        Path path = Paths.get(cwd);
+        if (path.endsWith("mock-oauth-server") && Files.exists(path.resolve("../docker"))) {
+            return path.toAbsolutePath().toString();
+        } else if (path.endsWith("strimzi-kafka-oauth") && Files.exists(path.resolve("testsuite/docker")) && Files.exists(path.resolve("testsuite/mock-oauth-server")))  {
+            return path.resolve("testsuite/mock-oauth-server").toAbsolutePath().toString();
+        }
+        return cwd;
+    }
+
+    Future<Void> ensureAuthServer(String keystorePath, String keystorePass, Mode mode) {
+        Promise<Void> result = Promise.promise();
+
         if (authServer == null) {
             JksOptions keyOptions = new JksOptions();
             keyOptions.setPath(keystorePath);
@@ -121,51 +179,65 @@ public class MockOAuthServerMainVerticle extends AbstractVerticle {
             authServer = vertx.createHttpServer(new HttpServerOptions()
                     .setSsl(true)
                     .setKeyStoreOptions(keyOptions)
-                ).requestHandler(new AuthServerRequestHandler(this)).listen(8090);
-
-            if (authServer.failed()) {
-                log.error("Failed to start Mock OAuth Server: ", authServer.cause());
-                authServer = null;
-            }
+                )
+                    .requestHandler(new AuthServerRequestHandler(this))
+                    .listen(8090)
+                    .onSuccess(server -> {
+                        log.info("ensureAuthServer(): AuthServer started successfully");
+                        setServerMode(mode);
+                        result.complete();
+                    })
+                    .onFailure(t -> {
+                        log.error("ensureAuthServer(): Failed to start Mock OAuth Server: ", t);
+                        authServer = null;
+                        result.fail(t);
+                    });
+        } else {
+            result.complete();
         }
+
+        return result.future();
     }
 
-    void ensureAuthServerWithFirstCert() {
-        if (authServer != null) {
-            shutdownAuthServer();
-        }
-        ensureAuthServer(keystoreOnePath, keystoreOnePass);
-        setServerMode(Mode.MODE_CERT_ONE_ON);
+    Future<Void> ensureAuthServerWithFirstCert() {
+        return shutdownAuthServer()
+            .onSuccess(r -> ensureAuthServer(keystoreOnePath, keystoreOnePass, Mode.MODE_CERT_ONE_ON));
     }
 
-    void ensureAuthServerWithSecondCert() {
-        if (authServer != null) {
-            shutdownAuthServer();
-        }
-        ensureAuthServer(keystoreTwoPath, keystoreTwoPass);
-        setServerMode(Mode.MODE_CERT_TWO_ON);
+    Future<Void> ensureAuthServerWithSecondCert() {
+        return shutdownAuthServer()
+            .onSuccess(r -> ensureAuthServer(keystoreTwoPath, keystoreTwoPass, Mode.MODE_CERT_TWO_ON));
     }
 
-    void ensureAuthServerWithExpiredCert() {
-        if (authServer != null) {
-            shutdownAuthServer();
-        }
-        ensureAuthServer(keystoreExpiredPath, keystoreExpiredPass);
-        setServerMode(Mode.MODE_EXPIRED_CERT_ON);
+    Future<Void>  ensureAuthServerWithExpiredCert() {
+        return shutdownAuthServer()
+            .onSuccess(r -> ensureAuthServer(keystoreExpiredPath, keystoreExpiredPass, Mode.MODE_EXPIRED_CERT_ON));
     }
 
-    void shutdownAuthServer() {
+    Future<Void> shutdownAuthServer() {
+        Promise<Void> result = Promise.promise();
+
         if (authServer != null) {
-            authServer.result().close();
-            authServer = null;
+            authServer.result().close()
+                    .onSuccess(v -> {
+                        log.error("shutdownAuthServer(): AuthServer shut down successfully");
+                        authServer = null;
+                        setServerMode(null);
+                        result.complete();
+                    })
+                    .onFailure(t -> {
+                        log.error("shutdownAuthServer(): Failed to shut down Mock OAuth Server: ", t);
+                        result.fail(t);
+                    });
+        } else {
+            result.complete();
         }
-        setServerMode(null);
+
+        return result.future();
     }
 
     private void setServerMode(Mode mode) {
-        if (authServer != null) {
-            setMode(SERVER, mode);
-        }
+        setMode(SERVER, mode);
     }
 
     void setMode(Endpoint e, Mode m) {
@@ -174,6 +246,33 @@ public class MockOAuthServerMainVerticle extends AbstractVerticle {
 
     Mode getMode(Endpoint e) {
         return modes.get(e);
+    }
+
+    synchronized RSAKey getSigKey() throws NoSuchAlgorithmException {
+        if (sigKey != null) {
+            return sigKey;
+        }
+
+        // Generate the RSA key pair
+        KeyPairGenerator gen = KeyPairGenerator.getInstance("RSA");
+        gen.initialize(2048);
+        KeyPair keyPair = gen.generateKeyPair();
+
+        // Convert to JWK format
+        sigKey = new RSAKey.Builder((RSAPublicKey) keyPair.getPublic())
+                .privateKey((RSAPrivateKey) keyPair.getPrivate())
+                .keyID(UUID.randomUUID().toString())
+                .keyUse(KeyUse.SIGNATURE)
+                .build();
+        return sigKey;
+    }
+
+    void createOrUpdateClient(String clientId, String secret) {
+        clients.put(clientId, secret);
+    }
+
+    Map<String, String> getClients() {
+        return Collections.unmodifiableMap(clients);
     }
 
     private static String getEnvVar(String name, String defaultValue) {

--- a/testsuite/mock-oauth-server/src/main/java/io/strimzi/testsuite/oauth/server/Mode.java
+++ b/testsuite/mock-oauth-server/src/main/java/io/strimzi/testsuite/oauth/server/Mode.java
@@ -7,6 +7,7 @@ package io.strimzi.testsuite.oauth.server;
 import java.util.Locale;
 
 enum Mode {
+    MODE_200,
     MODE_400,
     MODE_401,
     MODE_403,
@@ -16,7 +17,9 @@ enum Mode {
     MODE_OFF,
     MODE_CERT_ONE_ON,
     MODE_CERT_TWO_ON,
-    MODE_EXPIRED_CERT_ON;
+    MODE_EXPIRED_CERT_ON,
+    MODE_JWKS_RSA_WITH_SIG_USE,
+    MODE_JWKS_RSA_WITHOUT_SIG_USE;
 
 
     public static Mode fromString(String value) {


### PR DESCRIPTION
Set this option to `true` in order to use all the keys in the JWKS response for token signature validation, regardless of their `use` attribute.
This makes it possible to use authorization servers that don't specify `use` attribute in JWKS keys.

Signed-off-by: Marko Strukelj <marko.strukelj@gmail.com>