### PR TITLE
Update jackson dep versions to 2.12.6*

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,8 +81,8 @@
         <sonatype.nexus.staging>1.6.3</sonatype.nexus.staging>
 
         <kafka.version>3.2.0</kafka.version>
-        <jackson.version>2.10.5</jackson.version>
-        <jackson.databind.version>2.10.5.1</jackson.databind.version>
+        <jackson.version>2.12.6</jackson.version>
+        <jackson.databind.version>2.12.6.1</jackson.databind.version>
         <jsonpath.version>2.6.0</jsonpath.version>
         <junit.version>4.13.1</junit.version>
         <slf4j.version>1.7.26</slf4j.version>


### PR DESCRIPTION
I'm not sure what the policy for upgrading this here is normally, but this upgrades to match the versions specified in Apache Kafka 3.2.0:

https://github.com/apache/kafka/blob/3.2.0/gradle/dependencies.gradle#L69..L70

Signed-off-by: Gerard Ryan <gryan@redhat.com>