### PR TITLE
support client_credentials with client_assertion

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ The authorization configuration for KeycloakRBACAuthorizer is specified as `serv
 Both authentication and authorization configuration specific to Strimzi Kafka OAuth can also be set as ENV vars, or as Java system properties.
 The limitation here is that authentication configuration specified in this manner can not be listener-scoped. 
 
+Note that property-values starting with `env:` are interpreted as references to existing ENV vars.
+
 ### Configuring the Kafka Broker authentication
 
 Note: Strimzi Kafka OAuth can not be used for Kafka Broker to Zookeeper authentication. It only supports Kafka Client to Kafka Broker authentication (including inter-broker communication).
@@ -870,19 +872,46 @@ Strimzi Kafka OAuth supports four ways to configure authentication on the client
 
 #### Client Credentials
 
-The first is to specify the client ID and secret configured on the authorization server specifically for the individual client deployment. This is also called `client credentials grant`.
+The first is to specify Client Credentials. This requires that a client is configured on the authorization server specifically for the individual client deployment. This is also called `client credentials grant`.
 
 This is achieved by specifying the following:
 - `oauth.client.id` (e.g.: "my-client")
+
+together with one of authentication options below 
+
+When client starts to establish the connection with the Kafka Broker it will first obtain an access token from the configured Token Endpoint, authenticating with the configured client ID and configured authentication option using client_credentials grant type.
+
+##### Option 1: Using a Client Secret 
+
+Specify the client secret.
+
 - `oauth.client.secret` (e.g.: "my-client-secret")
 
-When client starts to establish the connection with the Kafka Broker it will first obtain an access token from the configured Token Endpoint, authenticating with the configured client ID and secret using client_credentials grant type.
+##### Option 2: Using a Client Assertion (a.k.a. private_key_jwt)
+
+Specify the client assertion (JWT token) either directly through
+
+- `oauth.client.assertion`
+
+or pointing to a file on the filesystem
+
+- `oauth.client.assertion.location`
+
+the exact type of the token must also be communicated to the token endpoint and defaults to `urn:ietf:params:oauth:client-assertion-type:jwt-bearer`. 
+
+This can be overridden using property
+
+-  `oauth.client.assertion.type` (i.e. use `urn:ietf:params:oauth:client-assertion-type:saml2-bearer` for SAML 2 tokens)
 
 #### Refresh Token
 
-The second way is to manually obtain and set a refresh token:
+The second way is to manually obtain and set a refresh token either directly through
 
 - `oauth.refresh.token`
+
+or pointing to a file on the filesystem
+
+- `oauth.refresh.token.location`
 
 When using this approach you are not limited to OAuth2 client_credentials grant type for obtaining a token.
 You can use a password grant type and authenticate as an individual user, rather than a client application.
@@ -892,9 +921,13 @@ When client starts to establish the connection with the Kafka Broker it will fir
 
 #### Access Token
 
-The third way is to manually obtain and set an access token:
+The third way is to manually obtain and set an access token either directly through:
 
 - `oauth.access.token`
+
+or pointing to a file on the filesystem
+
+- `oauth.access.token.location`
 
 Access tokens are supposed to be short-lived in order to prevent unauthorized access if the token leaks.
 It is up to you, your environment, and how you plan to run your Kafka client application to consider if using long-lived access tokens is appropriate.

--- a/examples/consumer/src/main/java/io/strimzi/examples/consumer/ExampleConsumer.java
+++ b/examples/consumer/src/main/java/io/strimzi/examples/consumer/ExampleConsumer.java
@@ -44,8 +44,9 @@ public class ExampleConsumer {
 
         defaults.setProperty(ClientConfig.OAUTH_TOKEN_ENDPOINT_URI, tokenEndpointUri);
 
-        //  By defaut this client uses preconfigured clientId and secret to authenticate.
-        //  You can set OAUTH_ACCESS_TOKEN or OAUTH_REFRESH_TOKEN to override default authentication.
+        //  By default, this client uses preconfigured clientId and secret to authenticate.
+        //  You can set OAUTH_ACCESS_TOKEN(_LOCATION) or OAUTH_REFRESH_TOKEN(_LOCATION)
+        //  or OAUTH_CLIENT_ASSERTION(_LOCATION) to override default authentication behavior.
         //
         //  If access token is configured, it is passed directly to Kafka broker
         //  If refresh token is configured, it is used in conjunction with clientId and secret
@@ -56,7 +57,12 @@ public class ExampleConsumer {
 
         if (accessToken == null) {
             defaults.setProperty(Config.OAUTH_CLIENT_ID, "kafka-consumer-client");
+
+            // use a secret for client_credentials authentication
             defaults.setProperty(Config.OAUTH_CLIENT_SECRET, "kafka-consumer-client-secret");
+
+            // use private_key_jwt for client_credentials authentication
+            //defaults.setProperty(ClientConfig.OAUTH_CLIENT_ASSERTION, "jwt-signed-by-trusted-key");
         }
 
         // Use 'preferred_username' rather than 'sub' for principal name

--- a/oauth-client/src/main/java/io/strimzi/kafka/oauth/client/ClientConfig.java
+++ b/oauth-client/src/main/java/io/strimzi/kafka/oauth/client/ClientConfig.java
@@ -9,11 +9,16 @@ import io.strimzi.kafka.oauth.common.Config;
 public class ClientConfig extends Config {
 
     public static final String OAUTH_ACCESS_TOKEN = "oauth.access.token";
+    public static final String OAUTH_ACCESS_TOKEN_LOCATION = "oauth.access.token.location";
     public static final String OAUTH_REFRESH_TOKEN = "oauth.refresh.token";
+    public static final String OAUTH_REFRESH_TOKEN_LOCATION = "oauth.refresh.token.location";
     public static final String OAUTH_TOKEN_ENDPOINT_URI = "oauth.token.endpoint.uri";
     public static final String OAUTH_MAX_TOKEN_EXPIRY_SECONDS = "oauth.max.token.expiry.seconds";
     public static final String OAUTH_PASSWORD_GRANT_USERNAME = "oauth.password.grant.username";
     public static final String OAUTH_PASSWORD_GRANT_PASSWORD = "oauth.password.grant.password";
+    public static final String OAUTH_CLIENT_ASSERTION = "oauth.client.assertion";
+    public static final String OAUTH_CLIENT_ASSERTION_LOCATION = "oauth.client.assertion.location";
+    public static final String OAUTH_CLIENT_ASSERTION_TYPE = "oauth.client.assertion.type";
 
     public ClientConfig() {
     }

--- a/oauth-client/src/main/java/io/strimzi/kafka/oauth/client/JaasClientOauthLoginCallbackHandler.java
+++ b/oauth-client/src/main/java/io/strimzi/kafka/oauth/client/JaasClientOauthLoginCallbackHandler.java
@@ -4,14 +4,17 @@
  */
 package io.strimzi.kafka.oauth.client;
 
-import io.strimzi.kafka.oauth.common.ConfigException;
-import io.strimzi.kafka.oauth.common.MetricsHandler;
-import io.strimzi.kafka.oauth.common.Config;
-import io.strimzi.kafka.oauth.common.ConfigUtil;
-import io.strimzi.kafka.oauth.common.PrincipalExtractor;
-import io.strimzi.kafka.oauth.common.TokenInfo;
 import io.strimzi.kafka.oauth.client.metrics.ClientAuthenticationSensorKeyProducer;
 import io.strimzi.kafka.oauth.client.metrics.ClientHttpSensorKeyProducer;
+import io.strimzi.kafka.oauth.common.Config;
+import io.strimzi.kafka.oauth.common.ConfigException;
+import io.strimzi.kafka.oauth.common.ConfigUtil;
+import io.strimzi.kafka.oauth.common.MetricsHandler;
+import io.strimzi.kafka.oauth.common.PrincipalExtractor;
+import io.strimzi.kafka.oauth.common.TokenInfo;
+import io.strimzi.kafka.oauth.common.TokenProvider;
+import io.strimzi.kafka.oauth.common.TokenProvider.FileBasedTokenProvider;
+import io.strimzi.kafka.oauth.common.TokenProvider.StaticTokenProvider;
 import io.strimzi.kafka.oauth.metrics.SensorKeyProducer;
 import io.strimzi.kafka.oauth.services.OAuthMetrics;
 import io.strimzi.kafka.oauth.services.Services;
@@ -40,6 +43,7 @@ import static io.strimzi.kafka.oauth.common.ConfigUtil.getReadTimeout;
 import static io.strimzi.kafka.oauth.common.DeprecationUtil.isAccessTokenJwt;
 import static io.strimzi.kafka.oauth.common.LogUtil.mask;
 import static io.strimzi.kafka.oauth.common.OAuthAuthenticator.loginWithAccessToken;
+import static io.strimzi.kafka.oauth.common.OAuthAuthenticator.loginWithClientAssertion;
 import static io.strimzi.kafka.oauth.common.OAuthAuthenticator.loginWithClientSecret;
 import static io.strimzi.kafka.oauth.common.OAuthAuthenticator.loginWithPassword;
 import static io.strimzi.kafka.oauth.common.OAuthAuthenticator.loginWithRefreshToken;
@@ -50,10 +54,12 @@ public class JaasClientOauthLoginCallbackHandler implements AuthenticateCallback
 
     private ClientConfig config = new ClientConfig();
 
-    private String token;
-    private String refreshToken;
     private String clientId;
     private String clientSecret;
+    private String clientAssertionType;
+    private TokenProvider tokenProvider;
+    private TokenProvider refreshTokenProvider;
+    private TokenProvider clientAssertionProvider;
     private String username;
     private String password;
     private String scope;
@@ -89,8 +95,11 @@ public class JaasClientOauthLoginCallbackHandler implements AuthenticateCallback
             config = new ClientConfig(p);
         }
 
-        token = config.getValue(ClientConfig.OAUTH_ACCESS_TOKEN);
-        if (token == null) {
+        final String token = config.getValue(ClientConfig.OAUTH_ACCESS_TOKEN);
+        final String tokenLocation = config.getValue(ClientConfig.OAUTH_ACCESS_TOKEN_LOCATION);
+        tokenProvider = createProvider(token, tokenLocation);
+
+        if (token == null && tokenLocation == null) {
             String endpoint = config.getValue(ClientConfig.OAUTH_TOKEN_ENDPOINT_URI);
 
             if (endpoint == null) {
@@ -104,10 +113,18 @@ public class JaasClientOauthLoginCallbackHandler implements AuthenticateCallback
             }
         }
 
-        refreshToken = config.getValue(ClientConfig.OAUTH_REFRESH_TOKEN);
+        final String refreshToken = config.getValue(ClientConfig.OAUTH_REFRESH_TOKEN);
+        final String refreshTokenLocation = config.getValue(ClientConfig.OAUTH_REFRESH_TOKEN_LOCATION);
+        refreshTokenProvider = createProvider(refreshToken, refreshTokenLocation);
 
         clientId = config.getValue(Config.OAUTH_CLIENT_ID);
         clientSecret = config.getValue(Config.OAUTH_CLIENT_SECRET);
+
+        final String clientAssertion = config.getValue(ClientConfig.OAUTH_CLIENT_ASSERTION);
+        final String clientAssertionLocation = config.getValue(ClientConfig.OAUTH_CLIENT_ASSERTION_LOCATION);
+        clientAssertionProvider = createProvider(clientAssertion, clientAssertionLocation);
+        clientAssertionType = config.getValue(ClientConfig.OAUTH_CLIENT_ASSERTION_TYPE, "urn:ietf:params:oauth:client-assertion-type:jwt-bearer");
+
         username = config.getValue(ClientConfig.OAUTH_PASSWORD_GRANT_USERNAME);
         password = config.getValue(ClientConfig.OAUTH_PASSWORD_GRANT_PASSWORD);
 
@@ -142,10 +159,15 @@ public class JaasClientOauthLoginCallbackHandler implements AuthenticateCallback
             LOG.debug("Configured JaasClientOauthLoginCallbackHandler:"
                     + "\n    configId: " + configId
                     + "\n    token: " + mask(token)
+                    + "\n    tokenLocation: " + tokenLocation
                     + "\n    refreshToken: " + mask(refreshToken)
+                    + "\n    refreshTokenLocation: " + refreshTokenLocation
                     + "\n    tokenEndpointUri: " + tokenEndpoint
                     + "\n    clientId: " + clientId
                     + "\n    clientSecret: " + mask(clientSecret)
+                    + "\n    clientAssertion: " + mask(clientAssertion)
+                    + "\n    clientAssertionLocation: " + clientAssertionLocation
+                    + "\n    clientAssertionType: " + clientAssertionType
                     + "\n    username: " + username
                     + "\n    password: " + mask(password)
                     + "\n    scope: " + scope
@@ -159,11 +181,20 @@ public class JaasClientOauthLoginCallbackHandler implements AuthenticateCallback
         }
     }
 
+    private TokenProvider createProvider(final String token, final String tokenLocation) {
+        if (tokenLocation != null) {
+            return new FileBasedTokenProvider(tokenLocation);
+        } else if (token != null) {
+            return new StaticTokenProvider(token);
+        }
+        return null;
+    }
+
     private void checkConfiguration() {
-        if (token != null) {
-            if (refreshToken != null) {
-                LOG.warn("Access token is configured ('{}'), refresh token will be ignored ('{}').",
-                        ClientConfig.OAUTH_ACCESS_TOKEN, ClientConfig.OAUTH_REFRESH_TOKEN);
+        if (tokenProvider != null) {
+            if (refreshTokenProvider != null) {
+                LOG.warn("Access token is configured ('{}'), refresh token will be ignored ('{}', '{}').",
+                        ClientConfig.OAUTH_ACCESS_TOKEN, ClientConfig.OAUTH_REFRESH_TOKEN, ClientConfig.OAUTH_REFRESH_TOKEN_LOCATION);
             }
             if (username != null) {
                 LOG.warn("Access token is configured ('{}'), username will be ignored ('{}').",
@@ -173,14 +204,18 @@ public class JaasClientOauthLoginCallbackHandler implements AuthenticateCallback
                 LOG.warn("Access token is configured ('{}'), client id will be ignored ('{}').",
                         ClientConfig.OAUTH_ACCESS_TOKEN, ClientConfig.OAUTH_CLIENT_ID);
             }
-        } else if (refreshToken != null) {
+            if (clientAssertionProvider != null) {
+                LOG.warn("Access token is configured ('{}'), client assertion (location) will be ignored ('{}', '{}').",
+                        ClientConfig.OAUTH_ACCESS_TOKEN, ClientConfig.OAUTH_CLIENT_ASSERTION, ClientConfig.OAUTH_CLIENT_ASSERTION_LOCATION);
+            }
+        } else if (refreshTokenProvider != null) {
             if (username != null) {
                 LOG.warn("Refresh token is configured ('{}'), username will be ignored ('{}').",
                         ClientConfig.OAUTH_REFRESH_TOKEN, ClientConfig.OAUTH_PASSWORD_GRANT_USERNAME);
             }
         }
 
-        if (token == null) {
+        if (tokenProvider == null) {
             if (clientId == null) {
                 throw new ConfigException("No client id specified ('" + ClientConfig.OAUTH_CLIENT_ID + "')");
             }
@@ -190,10 +225,14 @@ public class JaasClientOauthLoginCallbackHandler implements AuthenticateCallback
                         + "') but no password specified ('" + ClientConfig.OAUTH_PASSWORD_GRANT_PASSWORD + "')");
             }
 
-            if (refreshToken == null && clientSecret == null && username == null) {
-                throw new ConfigException("No access token ('" + ClientConfig.OAUTH_ACCESS_TOKEN + "'), refresh token ('"
-                        + ClientConfig.OAUTH_REFRESH_TOKEN + "'), client credentials ('" + ClientConfig.OAUTH_CLIENT_SECRET
-                        + "') or user credentials specified ('" + ClientConfig.OAUTH_PASSWORD_GRANT_USERNAME + "')");
+            if (refreshTokenProvider == null && clientSecret == null && username == null && clientAssertionProvider == null) {
+                throw new ConfigException("No access token or location ('" + ClientConfig.OAUTH_ACCESS_TOKEN
+                        + "', '" + ClientConfig.OAUTH_ACCESS_TOKEN_LOCATION + "'), refresh token or location ('"
+                        + ClientConfig.OAUTH_REFRESH_TOKEN + "', '" + ClientConfig.OAUTH_REFRESH_TOKEN_LOCATION + "'),"
+                        + " client credentials ('" + ClientConfig.OAUTH_CLIENT_SECRET
+                        + "'), user credentials ('" + ClientConfig.OAUTH_PASSWORD_GRANT_USERNAME + "')"
+                        + " or clientAssertion or location ('" + ClientConfig.OAUTH_CLIENT_ASSERTION + "', '"
+                        + ClientConfig.OAUTH_CLIENT_ASSERTION_LOCATION + "') specified");
             }
         }
     }
@@ -239,15 +278,17 @@ public class JaasClientOauthLoginCallbackHandler implements AuthenticateCallback
 
         long requestStartTime = System.currentTimeMillis();
         try {
-            if (token != null) {
+            if (tokenProvider != null) {
                 // we could check if it's a JWT - in that case we could check if it's expired
-                result = loginWithAccessToken(token, isJwt, principalExtractor);
-            } else if (refreshToken != null) {
-                result = loginWithRefreshToken(tokenEndpoint, socketFactory, hostnameVerifier, refreshToken, clientId, clientSecret, isJwt, principalExtractor, scope, audience, connectTimeout, readTimeout, authenticatorMetrics);
+                result = loginWithAccessToken(tokenProvider.token(), isJwt, principalExtractor);
+            } else if (refreshTokenProvider != null) {
+                result = loginWithRefreshToken(tokenEndpoint, socketFactory, hostnameVerifier, refreshTokenProvider.token(), clientId, clientSecret, isJwt, principalExtractor, scope, audience, connectTimeout, readTimeout, authenticatorMetrics);
             } else if (username != null) {
                 result = loginWithPassword(tokenEndpoint, socketFactory, hostnameVerifier, username, password, clientId, clientSecret, isJwt, principalExtractor, scope, audience, connectTimeout, readTimeout, authenticatorMetrics);
             } else if (clientSecret != null) {
                 result = loginWithClientSecret(tokenEndpoint, socketFactory, hostnameVerifier, clientId, clientSecret, isJwt, principalExtractor, scope, audience, connectTimeout, readTimeout, authenticatorMetrics);
+            } else if (clientAssertionProvider != null) {
+                result = loginWithClientAssertion(tokenEndpoint, socketFactory, hostnameVerifier, clientId, clientAssertionProvider.token(), clientAssertionType, isJwt, principalExtractor, scope, audience, connectTimeout, readTimeout, authenticatorMetrics);
             } else {
                 throw new IllegalStateException("Invalid oauth client configuration - no credentials");
             }

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/Config.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/Config.java
@@ -120,7 +120,10 @@ public class Config {
 
         if (result != null && result.startsWith("env:")) {
             // try reference to environment variable
-            result = System.getenv(result.substring(4));
+            final String envResult = System.getenv(result.substring(4));
+            if (envResult != null) {
+                result = envResult;
+            }
         }
 
         return result != null ? result : fallback;

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/Config.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/Config.java
@@ -85,6 +85,10 @@ public class Config {
      *   key.toUpperCase().replace('-', '_').replace('.', '_');
      *
      * If not, it checks if env variable with name equal to key exists.
+     *
+     * if the value contains the 'env:' prefix the rest of the value is treated as a reference to an env variable
+     * and the value is dereferenced to the value of the environment variable
+     *
      * Ultimately, it checks the defaults passed at Config object construction time.
      *
      * If no configuration is found for key, it returns the fallback value.
@@ -97,26 +101,26 @@ public class Config {
 
         // try system properties first
         String result = System.getProperty(key, null);
-        if (result != null) {
-            return result;
+
+        if (result == null) {
+            // try env properties
+            result = System.getenv(toEnvName(key));
         }
 
-        // try env properties
-        result = System.getenv(toEnvName(key));
-        if (result != null) {
-            return result;
+        if (result == null) {
+            // try env property by key name (without converting with toEnvName())
+            result = System.getenv(key);
         }
 
-        // try env property by key name (without converting with toEnvName())
-        result = System.getenv(key);
-        if (result != null) {
-            return result;
-        }
-
-        // try default properties and if all else fails return fallback value
-        if (defaults != null) {
+        if (result == null && defaults != null) {
+            // try default properties and if all else fails return fallback value
             Object val = defaults.get(key);
             result = val != null ? String.valueOf(val) : null;
+        }
+
+        if (result != null && result.startsWith("env:")) {
+            // try reference to environment variable
+            result = System.getenv(result.substring(4));
         }
 
         return result != null ? result : fallback;

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/OAuthAuthenticator.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/OAuthAuthenticator.java
@@ -91,6 +91,46 @@ public class OAuthAuthenticator {
         return post(tokenEndpointUrl, socketFactory, hostnameVerifier, authorization, body.toString(), isJwt, principalExtractor, connectTimeout, readTimeout, metrics);
     }
 
+    @SuppressWarnings("checkstyle:ParameterNumber")
+    public static TokenInfo loginWithClientAssertion(URI tokenEndpointUrl, SSLSocketFactory socketFactory,
+                                                     HostnameVerifier hostnameVerifier,
+                                                     String clientId, String clientAssertion, String clientAssertionType, boolean isJwt,
+                                                     PrincipalExtractor principalExtractor, String scope, String audience) throws IOException {
+
+        return loginWithClientAssertion(tokenEndpointUrl, socketFactory, hostnameVerifier,
+                clientId, clientAssertion, clientAssertionType, isJwt, principalExtractor, scope, audience, HttpUtil.DEFAULT_CONNECT_TIMEOUT, HttpUtil.DEFAULT_READ_TIMEOUT, null);
+    }
+
+    @SuppressWarnings("checkstyle:ParameterNumber")
+    public static TokenInfo loginWithClientAssertion(URI tokenEndpointUrl, SSLSocketFactory socketFactory,
+                                                  HostnameVerifier hostnameVerifier,
+                                                  String clientId, String clientAssertion, String clientAssertionType, boolean isJwt,
+                                                  PrincipalExtractor principalExtractor, String scope, String audience,
+                                                  int connectTimeout, int readTimeout, MetricsHandler metrics) throws IOException {
+        if (log.isDebugEnabled()) {
+            log.debug("loginWithClientAssertion() - tokenEndpointUrl: {}, clientId: {}, clientAssertion: {}, clientAssertionType: {}, scope: {}, audience: {}, connectTimeout: {}, readTimeout: {}",
+                    tokenEndpointUrl, clientId, mask(clientAssertion), clientAssertionType, scope, audience, connectTimeout, readTimeout);
+        }
+
+        if (clientId == null) {
+            throw new IllegalArgumentException("No clientId specified");
+        }
+
+        StringBuilder body = new StringBuilder("grant_type=client_credentials")
+                .append("&client_id=").append(urlencode(clientId))
+                .append("&client_assertion=").append(urlencode(clientAssertion))
+                .append("&client_assertion_type=").append(urlencode(clientAssertionType));
+
+        if (scope != null) {
+            body.append("&scope=").append(urlencode(scope));
+        }
+        if (audience != null) {
+            body.append("&audience=").append(urlencode(audience));
+        }
+
+        return post(tokenEndpointUrl, socketFactory, hostnameVerifier, null, body.toString(), isJwt, principalExtractor, connectTimeout, readTimeout, metrics);
+    }
+
     public static TokenInfo loginWithPassword(URI tokenEndpointUrl, SSLSocketFactory socketFactory,
                                               HostnameVerifier hostnameVerifier,
                                               String username, String password,

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/TokenProvider.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/TokenProvider.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017-2019, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.kafka.oauth.common;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public interface TokenProvider {
+
+    String token();
+
+    class StaticTokenProvider implements TokenProvider {
+        private final String token;
+
+        public StaticTokenProvider(final String token) {
+            this.token = token;
+        }
+
+        @Override
+        public String token() {
+            return token;
+        }
+    }
+
+    class FileBasedTokenProvider implements TokenProvider {
+        private final Path filePath;
+
+        public FileBasedTokenProvider(final String tokenFilePath) {
+            this.filePath = Paths.get(tokenFilePath);
+            if (!filePath.toFile().exists()) {
+                throw new IllegalArgumentException("file '" + filePath + "' does not exist!");
+            }
+            if (!filePath.toFile().isFile()) {
+                throw new IllegalArgumentException("'" + filePath + "' does not point to a file!");
+            }
+        }
+
+        @Override
+        public String token() {
+            try {
+                return new String(Files.readAllBytes(filePath), StandardCharsets.UTF_8);
+            } catch (IOException e) {
+                throw new IllegalStateException(e);
+            }
+        }
+    }
+}

--- a/oauth-common/src/test/java/io/strimzi/kafka/oauth/common/HttpUtilTimeoutTest.java
+++ b/oauth-common/src/test/java/io/strimzi/kafka/oauth/common/HttpUtilTimeoutTest.java
@@ -17,6 +17,7 @@ import java.net.Socket;
 import java.net.SocketTimeoutException;
 import java.net.URI;
 import java.util.Collections;
+import java.util.Locale;
 import java.util.concurrent.CompletableFuture;
 
 public class HttpUtilTimeoutTest {
@@ -60,7 +61,7 @@ public class HttpUtilTimeoutTest {
                 Assert.fail("Should fail with SocketTimeoutException");
             } catch (SocketTimeoutException e) {
                 long diff = System.currentTimeMillis() - start;
-                Assert.assertTrue("Unexpected error: " + e, e.toString().contains("connect timed out"));
+                Assert.assertTrue("Unexpected error: " + e, e.toString().toLowerCase(Locale.ENGLISH).contains("connect timed out"));
                 Assert.assertTrue("Unexpected diff: " + diff, diff >= timeout * 1000 && diff < timeout * 1000 + 1000);
             } catch (IOException e) {
                 if (e.getCause() instanceof ConnectException) {
@@ -78,7 +79,7 @@ public class HttpUtilTimeoutTest {
                 Assert.fail("Should fail with SocketTimeoutException");
             } catch (SocketTimeoutException e) {
                 long diff = System.currentTimeMillis() - start;
-                Assert.assertTrue("Unexpected error: " + e, e.toString().contains("Read timed out"));
+                Assert.assertTrue("Unexpected error: " + e, e.toString().toLowerCase(Locale.ENGLISH).contains("read timed out"));
                 Assert.assertTrue("Unexpected diff: " + diff, diff >= timeout * 1000 && diff < timeout * 1000 + 1000);
             }
 
@@ -90,7 +91,7 @@ public class HttpUtilTimeoutTest {
                 Assert.fail("Should fail with SocketTimeoutException");
             } catch (SocketTimeoutException e) {
                 long diff = System.currentTimeMillis() - start;
-                Assert.assertTrue("Unexpected error: " + e, e.toString().contains("connect timed out"));
+                Assert.assertTrue("Unexpected error: " + e, e.toString().toLowerCase(Locale.ENGLISH).contains("connect timed out"));
                 Assert.assertTrue("Unexpected diff: " + diff, diff >= timeout * 1000 && diff < timeout * 1000 + 1000);
             } catch (IOException e) {
                 if (e.getCause() instanceof ConnectException) {
@@ -108,7 +109,7 @@ public class HttpUtilTimeoutTest {
                 Assert.fail("Should fail with SocketTimeoutException");
             } catch (SocketTimeoutException e) {
                 long diff = System.currentTimeMillis() - start;
-                Assert.assertTrue("Unexpected error: " + e, e.toString().contains("Read timed out"));
+                Assert.assertTrue("Unexpected error: " + e, e.toString().toLowerCase(Locale.ENGLISH).contains("read timed out"));
                 Assert.assertTrue("Unexpected diff: " + diff, diff >= timeout * 1000 && diff < timeout * 1000 + 1000);
             }
 
@@ -128,7 +129,7 @@ public class HttpUtilTimeoutTest {
                 long diff = System.currentTimeMillis() - start;
 
                 Assert.assertTrue("Wrong exception: " + e + " caused by " + cause, cause instanceof SocketTimeoutException);
-                Assert.assertTrue("Unexpected error: " + cause, cause.toString().contains("connect timed out"));
+                Assert.assertTrue("Unexpected error: " + cause, cause.toString().toLowerCase(Locale.ENGLISH).contains("connect timed out"));
                 Assert.assertTrue("Unexpected diff: " + diff, diff >= timeout * 1000 && diff < timeout * 1000 + 1000);
             }
 

--- a/oauth-common/src/test/java/io/strimzi/kafka/oauth/common/TokenProviderTest.java
+++ b/oauth-common/src/test/java/io/strimzi/kafka/oauth/common/TokenProviderTest.java
@@ -49,12 +49,13 @@ public class TokenProviderTest {
 
     @Test
     public void testFileBasedTokenProvider_fileIsDir() {
+        String tempDir = new File(System.getProperty("java.io.tmpdir")).getAbsolutePath();
         try {
-            final TokenProvider fileBasedTokenProvider = new TokenProvider.FileBasedTokenProvider(System.getProperty("java.io.tmpdir"));
+            final TokenProvider fileBasedTokenProvider = new TokenProvider.FileBasedTokenProvider(tempDir);
             Assert.fail("failed to test for file existence");
 
         } catch (IllegalArgumentException e) {
-            Assert.assertEquals("'/tmp' does not point to a file!", e.getMessage());
+            Assert.assertEquals("'" + tempDir + "' does not point to a file!", e.getMessage());
         }
     }
 

--- a/oauth-common/src/test/java/io/strimzi/kafka/oauth/common/TokenProviderTest.java
+++ b/oauth-common/src/test/java/io/strimzi/kafka/oauth/common/TokenProviderTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2017-2022, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.kafka.oauth.common;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+
+public class TokenProviderTest {
+
+    @Test
+    public void testStaticTokenProvider() {
+
+        final TokenProvider staticTokenProvider = new TokenProvider.StaticTokenProvider("test-token");
+
+        Assert.assertEquals(staticTokenProvider.token(), "test-token");
+    }
+
+    @Test
+    public void testFileBasedTokenProvider() throws IOException {
+        final File tempFile = File.createTempFile("test-token-", ".jwt");
+        Files.write(tempFile.toPath(), "some-test-value".getBytes(StandardCharsets.UTF_8));
+
+        final TokenProvider fileBasedTokenProvider = new TokenProvider.FileBasedTokenProvider(tempFile.getPath());
+
+        final String tokenValueFromFile = fileBasedTokenProvider.token();
+        final boolean delete = tempFile.delete();
+
+        Assert.assertEquals("some-test-value", tokenValueFromFile);
+        Assert.assertTrue(delete);
+    }
+
+    @Test
+    public void testFileBasedTokenProvider_fileDoesNotExist() {
+        try {
+            final TokenProvider fileBasedTokenProvider = new TokenProvider.FileBasedTokenProvider("/invalid-file-path");
+            Assert.fail("failed to test for file type");
+
+        } catch (IllegalArgumentException e) {
+            Assert.assertEquals("file '/invalid-file-path' does not exist!", e.getMessage());
+        }
+    }
+
+    @Test
+    public void testFileBasedTokenProvider_fileIsDir() {
+        try {
+            final TokenProvider fileBasedTokenProvider = new TokenProvider.FileBasedTokenProvider(System.getProperty("java.io.tmpdir"));
+            Assert.fail("failed to test for file existence");
+
+        } catch (IllegalArgumentException e) {
+            Assert.assertEquals("'/tmp' does not point to a file!", e.getMessage());
+        }
+    }
+
+    @Test
+    public void testFileBasedTokenProvider_fileRemoved() throws IOException {
+        final File tempFile = File.createTempFile("test-token-", ".jwt");
+        Files.write(tempFile.toPath(), "some-test-value".getBytes(StandardCharsets.UTF_8));
+
+        final TokenProvider fileBasedTokenProvider = new TokenProvider.FileBasedTokenProvider(tempFile.getPath());
+
+        final boolean delete = tempFile.delete();
+        Assert.assertTrue(delete);
+
+        try {
+            fileBasedTokenProvider.token();
+            Assert.fail("this should not be possible");
+
+        } catch (IllegalStateException e) {
+            Assert.assertTrue(e.getCause() instanceof IOException);
+        }
+    }
+}

--- a/testsuite/mock-oauth-server/src/main/java/io/strimzi/testsuite/oauth/server/AdminServerRequestHandler.java
+++ b/testsuite/mock-oauth-server/src/main/java/io/strimzi/testsuite/oauth/server/AdminServerRequestHandler.java
@@ -219,9 +219,14 @@ public class AdminServerRequestHandler implements Handler<HttpServerRequest> {
                     }
 
                     String secret = json.getString("secret");
+                    String clientAssertion = json.getString("clientAssertion");
                     if (secret == null) {
-                        sendResponse(req, BAD_REQUEST, "Required attribute 'secret' is null or missing.");
-                        return;
+                        if (clientAssertion == null) {
+                            sendResponse(req, BAD_REQUEST, "Required attribute 'secret' is null or missing.");
+                            return;
+                        } else {
+                            secret = clientAssertion;
+                        }
                     }
 
                     verticle.createOrUpdateClient(clientId, secret);

--- a/testsuite/mock-oauth-server/src/main/java/io/strimzi/testsuite/oauth/server/AuthServerRequestHandler.java
+++ b/testsuite/mock-oauth-server/src/main/java/io/strimzi/testsuite/oauth/server/AuthServerRequestHandler.java
@@ -151,8 +151,16 @@ public class AuthServerRequestHandler implements Handler<HttpServerRequest> {
 
             String username = null;
 
-            // clientId should always be passed via Authorization header - with or without a password
+            // clientId should be passed via Authorization header
             String clientId = authorizeClient(authorization);
+
+            // or via the body together with its assertion
+            if (clientId == null) {
+                final String clientIdFromForm = form.get("client_id");
+                final String clientAssertion = form.get("client_assertion");
+                final String clientAssertionType = form.get("client_assertion_type");
+                clientId = authorizeClientUsingAssertion(clientIdFromForm, clientAssertion, clientAssertionType);
+            }
 
             // if password auth rather than client_credentials, also make sure the username and password are a match
             if (clientId != null && "password".equals(grantType)) {
@@ -309,6 +317,16 @@ public class AuthServerRequestHandler implements Handler<HttpServerRequest> {
             return null;
         }
         return idSecret[0];
+    }
+
+    private String authorizeClientUsingAssertion(final String clientId, final String clientAssertion, final String clientAssertionType) {
+        if (clientId == null || clientAssertion == null || clientAssertionType == null) {
+            return null;
+        }
+        if (!clientAssertion.equals(verticle.getClients().get(clientId))) {
+            return null;
+        }
+        return clientId;
     }
 
     private String authorizeUser(String username, String password) {

--- a/testsuite/mockoauth-tests/src/test/java/io/strimzi/testsuite/oauth/MockOAuthTests.java
+++ b/testsuite/mockoauth-tests/src/test/java/io/strimzi/testsuite/oauth/MockOAuthTests.java
@@ -7,6 +7,7 @@ package io.strimzi.testsuite.oauth;
 import io.strimzi.testsuite.oauth.common.TestContainersLogCollector;
 import io.strimzi.testsuite.oauth.common.TestContainersWatcher;
 import io.strimzi.testsuite.oauth.metrics.MetricsTest;
+import io.strimzi.testsuite.oauth.mockoauth.ClientAssertionAuthTest;
 import io.strimzi.testsuite.oauth.mockoauth.JaasClientConfigTest;
 import io.strimzi.testsuite.oauth.mockoauth.PasswordAuthTest;
 
@@ -50,6 +51,9 @@ public class MockOAuthTests {
 
             logStart("PasswordAuthTest :: Password Grant Tests");
             new PasswordAuthTest().doTest();
+
+            logStart("ClientAssertionAuthTest :: Client Assertion Tests");
+            new ClientAssertionAuthTest().doTest();
 
         } catch (Throwable e) {
             log.error("Exception has occured: ", e);

--- a/testsuite/mockoauth-tests/src/test/java/io/strimzi/testsuite/oauth/mockoauth/ClientAssertionAuthTest.java
+++ b/testsuite/mockoauth-tests/src/test/java/io/strimzi/testsuite/oauth/mockoauth/ClientAssertionAuthTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2017-2022, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.testsuite.oauth.mockoauth;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.strimzi.kafka.oauth.common.HttpException;
+import io.strimzi.kafka.oauth.common.HttpUtil;
+import io.strimzi.kafka.oauth.common.OAuthAuthenticator;
+import io.strimzi.kafka.oauth.common.SSLUtil;
+import io.strimzi.kafka.oauth.common.TokenInfo;
+import io.strimzi.kafka.oauth.common.TokenIntrospection;
+import org.junit.Assert;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.net.ssl.SSLSocketFactory;
+import java.net.URI;
+
+import static io.strimzi.testsuite.oauth.mockoauth.Common.WWW_FORM_CONTENT_TYPE;
+import static io.strimzi.testsuite.oauth.mockoauth.Common.changeAuthServerMode;
+import static io.strimzi.testsuite.oauth.mockoauth.Common.createOAuthClient;
+import static io.strimzi.testsuite.oauth.mockoauth.Common.createOAuthClientWithAssertion;
+
+public class ClientAssertionAuthTest {
+
+    private static final Logger log = LoggerFactory.getLogger(ClientAssertionAuthTest.class);
+
+    public void doTest() throws Exception {
+
+        changeAuthServerMode("token", "MODE_200");
+        changeAuthServerMode("introspect", "MODE_200");
+
+        // create a client for resource server
+        String clientSrv = "appserver";
+        String clientSrvSecret = "appserver-secret";
+        createOAuthClient(clientSrv, clientSrvSecret);
+
+        // create a client client2
+        String client2 = "client2";
+        String client2Assertion = "client2-assertion";
+        createOAuthClientWithAssertion(client2, client2Assertion);
+
+        String projectRoot = Common.getProjectRoot();
+        SSLSocketFactory sslFactory = SSLUtil.createSSLFactory(
+                projectRoot + "/../docker/certificates/ca-truststore.p12", null, "changeit", null, null);
+
+        try {
+            // Use client_credentials to authenticate with wrong client_assertion
+            TokenInfo tokenInfo = OAuthAuthenticator.loginWithClientAssertion(
+                    URI.create("https://mockoauth:8090/token"),
+                    sslFactory,
+                    null,
+                    client2,
+                    "bad-client-assertion",
+                    "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+                    true,
+                    null,
+                    null,
+                    null);
+
+            Assert.fail("Should have failed with 401");
+        } catch (HttpException e) {
+            Assert.assertEquals("Expected status 401", 401, e.getStatus());
+        }
+
+        // Use client_credentials to authenticate with correct client_assertion
+        TokenInfo tokenInfo = OAuthAuthenticator.loginWithClientAssertion(
+                URI.create("https://mockoauth:8090/token"),
+                sslFactory,
+                null,
+                client2,
+                client2Assertion,
+                "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+                true,
+                null,
+                null,
+                null);
+
+        String token = tokenInfo.token();
+        Assert.assertNotNull(token);
+
+        TokenIntrospection.debugLogJWT(log, token);
+
+        // introspect the token using the introspection endpoint
+        ObjectNode json = HttpUtil.post(URI.create("https://mockoauth:8090/introspect"), sslFactory, null,
+                "Basic " + OAuthAuthenticator.base64encode(clientSrv + ':' + clientSrvSecret), WWW_FORM_CONTENT_TYPE, "token=" + token, ObjectNode.class);
+
+        log.info("Got introspection endpoint response: " + json);
+        Assert.assertTrue("Token active", json.get("active").asBoolean());
+        Assert.assertEquals("Introspection endpoint response contains `client_id`", client2, json.get("client_id") != null ? json.get("client_id").asText() : null);
+        Assert.assertNull("Introspection endpoint response does not contain `username`", json.get("username"));
+    }
+}

--- a/testsuite/mockoauth-tests/src/test/java/io/strimzi/testsuite/oauth/mockoauth/Common.java
+++ b/testsuite/mockoauth-tests/src/test/java/io/strimzi/testsuite/oauth/mockoauth/Common.java
@@ -228,6 +228,13 @@ public class Common {
                 "{\"clientId\": \"" + clientId + "\", \"secret\": \"" + secret + "\"}", String.class);
     }
 
+    public static void createOAuthClientWithAssertion(String clientId, String clientAssertion) throws IOException {
+        HttpUtil.post(URI.create("http://mockoauth:8091/admin/clients"),
+                null,
+                "application/json",
+                "{\"clientId\": \"" + clientId + "\", \"clientAssertion\": \"" + clientAssertion + "\"}", String.class);
+    }
+
     public static void createOAuthUser(String username, String password) throws IOException {
         HttpUtil.post(URI.create("http://mockoauth:8091/admin/users"),
                 null,

--- a/testsuite/mockoauth-tests/src/test/java/io/strimzi/testsuite/oauth/mockoauth/PasswordAuthTest.java
+++ b/testsuite/mockoauth-tests/src/test/java/io/strimzi/testsuite/oauth/mockoauth/PasswordAuthTest.java
@@ -48,7 +48,6 @@ public class PasswordAuthTest {
         String user1Pass = "user1-password";
         createOAuthUser(user1, user1Pass);
 
-        // authenticate user against token endpoint with the wrong password
         String projectRoot = Common.getProjectRoot();
         SSLSocketFactory sslFactory = SSLUtil.createSSLFactory(
                 projectRoot + "/../docker/certificates/ca-truststore.p12", null, "changeit", null, null);
@@ -136,6 +135,5 @@ public class PasswordAuthTest {
         Assert.assertTrue("Token active", json.get("active").asBoolean());
         Assert.assertEquals("Introspection endpoint response contains `client_id`", client1, json.get("client_id") != null ? json.get("client_id").asText() : null);
         Assert.assertNull("Introspection endpoint response does not contain `username`", json.get("username"));
-
     }
 }


### PR DESCRIPTION
PR for issue #164 

All builds and tests are working.

I added the following abilities:

1. support for client assertion (private_key_jwt) based authentication on the token endpoint as per https://www.rfc-editor.org/rfc/rfc7523#section-2.2
2. support for acquiring token, refresh token, client assertion (token) from filesystem on-demand (to support refreshment by an external process such as Azure AD Workload Identity). 
3. support for acquiring config values based on references to environment variables (to support pointing to externally injected environment variables such as those from Azure AD Workload Identity)

I was not yet able to test the changing token in real scenario as part of a re-authentication request. So the fact that a re-authentication re-triggers JaasClientOauthLoginCallbackHandler.handle is an untested assumption at this point.