### PR TITLE
Prevent UnsupportedCallbackException from counting towards validation error metrics

### DIFF
--- a/oauth-server/src/main/java/io/strimzi/kafka/oauth/server/JaasServerOauthValidatorCallbackHandler.java
+++ b/oauth-server/src/main/java/io/strimzi/kafka/oauth/server/JaasServerOauthValidatorCallbackHandler.java
@@ -528,6 +528,9 @@ public class JaasServerOauthValidatorCallbackHandler implements AuthenticateCall
             delegatedHandle(callbacks);
 
             addValidationMetricSuccessTime(requestStartTime);
+        } catch (UnsupportedCallbackException e) {
+            // we only support OAuthBearerValidatorCallback, not OAuthBearerExtensionsValidatorCallback
+            throw e;
         } catch (Throwable t) {
             addValidationMetricErrorTime(t, requestStartTime);
             throw t;


### PR DESCRIPTION
Unsupported call with OAuthBearerExtensionsValidatorCallback should not increase error count metrics.

Signed-off-by: Marko Strukelj <marko.strukelj@gmail.com>