### PR TITLE
Keycloak authorizer 'grants fetch retry' feature + tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -693,9 +693,12 @@ The refresh job works by enumerating the active tokens and requesting the latest
 It does that by using a thread pool. You can control the size of the thread pool (how much parallelism you want), the default value is 5:
 - `strimzi.authorization.grants.refresh.pool.size` (e.g.: "10" - the maximum of 10 parallel fetches of grants at a time)
 
-A single client connection typically has a unique access token even though you could use the same access token for multiple connections. 
-Thus, the number of active tokens is generally proportional to the number of client connections.
-Also keep in mind that this is replicated across all Kafka brokers in the cluster, as they all have to be configured the same way.
+Sometimes the deployment environment is such that there is a reverse proxy in front of the Keycloak, or some service like a network traffic analyzer, or flood protection server.
+Or, the network may be glitchy resulting in intermittent connection problems. By default, any error while getting the initial grants for the new session,
+will result in `AuthorizationException` returned to the Kafka client application. Upon client retrying some operation, the grants will be fetched again,
+since not yet available. The following option enables reattempting the fetching of grants immediately so that if subsequent fetch is successful the client doesn't 
+receive the `AuthorizationException`. Provide the value greater than '0' to set the number of repeated attempts:
+- `strimzi.authorization.grants.retries` (e.g.: "1" - if initial fetching of grants for the session fails, immediately retry one more time)
 
 You may also want to configure some other things. You may want to set a logical cluster name so you can target it with authorization rules:
 - `strimzi.authorization.kafka.cluster.name` (e.g.: "dev-cluster" - a logical name of the cluster which can be targeted with authorization services resource definitions, and permission policies)

--- a/README.md
+++ b/README.md
@@ -698,7 +698,7 @@ Or, the network may be glitchy resulting in intermittent connection problems. By
 will result in `AuthorizationException` returned to the Kafka client application. When the client retries some operation, the grants will be fetched again,
 since they are not yet available. The following option enables reattempting the fetching of grants immediately so that if subsequent fetch is successful the client doesn't 
 receive the `AuthorizationException`. The default value is '0', meaning 'no retries'. Provide the value greater than '0' to set the number of repeated attempts:
-- `strimzi.authorization.grants.retries` (e.g.: "1" - if initial fetching of grants for the session fails, immediately retry one more time)
+- `strimzi.authorization.http.retries` (e.g.: "1" - if initial fetching of grants for the session fails, immediately retry one more time)
 
 You may also want to configure some other things. You may want to set a logical cluster name so you can target it with authorization rules:
 - `strimzi.authorization.kafka.cluster.name` (e.g.: "dev-cluster" - a logical name of the cluster which can be targeted with authorization services resource definitions, and permission policies)

--- a/README.md
+++ b/README.md
@@ -695,8 +695,8 @@ It does that by using a thread pool. You can control the size of the thread pool
 
 Sometimes the deployment environment is such that there is a reverse proxy in front of the Keycloak, or some service like a network traffic analyzer, or flood protection server.
 Or, the network may be glitchy resulting in intermittent connection problems. By default, any error while getting the initial grants for the new session,
-will result in `AuthorizationException` returned to the Kafka client application. Upon client retrying some operation, the grants will be fetched again,
-since not yet available. The following option enables reattempting the fetching of grants immediately so that if subsequent fetch is successful the client doesn't 
+will result in `AuthorizationException` returned to the Kafka client application. When the client retries some operation, the grants will be fetched again,
+since they are not yet available. The following option enables reattempting the fetching of grants immediately so that if subsequent fetch is successful the client doesn't 
 receive the `AuthorizationException`. Provide the value greater than '0' to set the number of repeated attempts:
 - `strimzi.authorization.grants.retries` (e.g.: "1" - if initial fetching of grants for the session fails, immediately retry one more time)
 

--- a/README.md
+++ b/README.md
@@ -697,7 +697,7 @@ Sometimes the deployment environment is such that there is a reverse proxy in fr
 Or, the network may be glitchy resulting in intermittent connection problems. By default, any error while getting the initial grants for the new session,
 will result in `AuthorizationException` returned to the Kafka client application. When the client retries some operation, the grants will be fetched again,
 since they are not yet available. The following option enables reattempting the fetching of grants immediately so that if subsequent fetch is successful the client doesn't 
-receive the `AuthorizationException`. Provide the value greater than '0' to set the number of repeated attempts:
+receive the `AuthorizationException`. The default value is '0', meaning 'no retries'. Provide the value greater than '0' to set the number of repeated attempts:
 - `strimzi.authorization.grants.retries` (e.g.: "1" - if initial fetching of grants for the session fails, immediately retry one more time)
 
 You may also want to configure some other things. You may want to set a logical cluster name so you can target it with authorization rules:

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/OAuthAuthenticator.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/OAuthAuthenticator.java
@@ -77,6 +77,9 @@ public class OAuthAuthenticator {
         if (clientId == null) {
             throw new IllegalArgumentException("No clientId specified");
         }
+        if (clientSecret == null) {
+            clientSecret = "";
+        }
 
         String authorization = "Basic " + base64encode(clientId + ':' + clientSecret);
 
@@ -130,6 +133,9 @@ public class OAuthAuthenticator {
         }
         if (clientId == null) {
             throw new IllegalArgumentException("No clientId specified");
+        }
+        if (clientSecret == null) {
+            clientSecret = "";
         }
 
         String authorization = "Basic " + base64encode(clientId + ':' + clientSecret);

--- a/oauth-common/src/test/java/io/strimzi/kafka/oauth/common/HttpUtilTimeoutTest.java
+++ b/oauth-common/src/test/java/io/strimzi/kafka/oauth/common/HttpUtilTimeoutTest.java
@@ -60,7 +60,7 @@ public class HttpUtilTimeoutTest {
                 Assert.fail("Should fail with SocketTimeoutException");
             } catch (SocketTimeoutException e) {
                 long diff = System.currentTimeMillis() - start;
-                Assert.assertTrue("Unexpected error: " + e, e.toString().contains("connect timed out"));
+                Assert.assertTrue("Unexpected error: " + e, e.toString().contains("onnect timed out"));
                 Assert.assertTrue("Unexpected diff: " + diff, diff >= timeout * 1000 && diff < timeout * 1000 + 1000);
             } catch (IOException e) {
                 if (e.getCause() instanceof ConnectException) {

--- a/oauth-keycloak-authorizer/src/main/java/io/strimzi/kafka/oauth/server/authorizer/AuthzConfig.java
+++ b/oauth-keycloak-authorizer/src/main/java/io/strimzi/kafka/oauth/server/authorizer/AuthzConfig.java
@@ -18,7 +18,7 @@ public class AuthzConfig extends Config {
 
     public static final String STRIMZI_AUTHORIZATION_GRANTS_REFRESH_PERIOD_SECONDS = "strimzi.authorization.grants.refresh.period.seconds";
     public static final String STRIMZI_AUTHORIZATION_GRANTS_REFRESH_POOL_SIZE = "strimzi.authorization.grants.refresh.pool.size";
-
+    public static final String STRIMZI_AUTHORIZATION_GRANTS_RETRIES = "strimzi.authorization.grants.retries";
     public static final String STRIMZI_AUTHORIZATION_SSL_TRUSTSTORE_LOCATION = "strimzi.authorization.ssl.truststore.location";
     public static final String STRIMZI_AUTHORIZATION_SSL_TRUSTSTORE_CERTIFICATES = "strimzi.authorization.ssl.truststore.certificates";
     public static final String STRIMZI_AUTHORIZATION_SSL_TRUSTSTORE_PASSWORD = "strimzi.authorization.ssl.truststore.password";

--- a/oauth-keycloak-authorizer/src/main/java/io/strimzi/kafka/oauth/server/authorizer/AuthzConfig.java
+++ b/oauth-keycloak-authorizer/src/main/java/io/strimzi/kafka/oauth/server/authorizer/AuthzConfig.java
@@ -18,7 +18,7 @@ public class AuthzConfig extends Config {
 
     public static final String STRIMZI_AUTHORIZATION_GRANTS_REFRESH_PERIOD_SECONDS = "strimzi.authorization.grants.refresh.period.seconds";
     public static final String STRIMZI_AUTHORIZATION_GRANTS_REFRESH_POOL_SIZE = "strimzi.authorization.grants.refresh.pool.size";
-    public static final String STRIMZI_AUTHORIZATION_GRANTS_RETRIES = "strimzi.authorization.grants.retries";
+    public static final String STRIMZI_AUTHORIZATION_HTTP_RETRIES = "strimzi.authorization.http.retries";
     public static final String STRIMZI_AUTHORIZATION_SSL_TRUSTSTORE_LOCATION = "strimzi.authorization.ssl.truststore.location";
     public static final String STRIMZI_AUTHORIZATION_SSL_TRUSTSTORE_CERTIFICATES = "strimzi.authorization.ssl.truststore.certificates";
     public static final String STRIMZI_AUTHORIZATION_SSL_TRUSTSTORE_PASSWORD = "strimzi.authorization.ssl.truststore.password";

--- a/oauth-keycloak-authorizer/src/main/java/io/strimzi/kafka/oauth/server/authorizer/KeycloakRBACAuthorizer.java
+++ b/oauth-keycloak-authorizer/src/main/java/io/strimzi/kafka/oauth/server/authorizer/KeycloakRBACAuthorizer.java
@@ -650,7 +650,7 @@ public class KeycloakRBACAuthorizer extends AclAuthorizer {
 
             try {
                 if (t != null) {
-                    log.warn("Failed to fetch grants. Will retry (attempt no. " + i + ")", t);
+                    log.info("Failed to fetch grants. Will retry (attempt no. " + i + ")", t);
                 }
                 response = fetchAuthorizationGrantsOnce(token);
                 break;

--- a/oauth-keycloak-authorizer/src/main/java/io/strimzi/kafka/oauth/server/authorizer/KeycloakRBACAuthorizer.java
+++ b/oauth-keycloak-authorizer/src/main/java/io/strimzi/kafka/oauth/server/authorizer/KeycloakRBACAuthorizer.java
@@ -262,6 +262,9 @@ public class KeycloakRBACAuthorizer extends AclAuthorizer {
         }
 
         grantsRetries = config.getValueAsInt(AuthzConfig.STRIMZI_AUTHORIZATION_GRANTS_RETRIES, 0);
+        if (grantsRetries < 0) {
+            throw new ConfigException("Invalid value of 'strimzi.authorization.grants.retries': " + grantsRetries + ". Has to be >= 0.");
+        }
 
         configureMetrics(configs, config);
 

--- a/testsuite/keycloak-authz-tests/docker-compose.yml
+++ b/testsuite/keycloak-authz-tests/docker-compose.yml
@@ -113,6 +113,10 @@ services:
       - KAFKA_STRIMZI_AUTHORIZATION_GRANTS_REFRESH_POOL_SIZE=4
       #   any change to permissions will be reflected within 10 seconds
       - KAFKA_STRIMZI_AUTHORIZATION_GRANTS_REFRESH_PERIOD_SECONDS=10
+      # If a grants fetch fails, immediately perform one retry
+      - KAFKA_STRIMZI_AUTHORIZATION_GRANTS_RETRIES=1
+
+      - KAFKA_STRIMZI_AUTHORIZATION_ENABLE_METRICS=true
 
       - KAFKA_SUPER_USERS=User:admin;User:service-account-kafka
 

--- a/testsuite/keycloak-authz-tests/docker-compose.yml
+++ b/testsuite/keycloak-authz-tests/docker-compose.yml
@@ -114,7 +114,7 @@ services:
       #   any change to permissions will be reflected within 10 seconds
       - KAFKA_STRIMZI_AUTHORIZATION_GRANTS_REFRESH_PERIOD_SECONDS=10
       # If a grants fetch fails, immediately perform one retry
-      - KAFKA_STRIMZI_AUTHORIZATION_GRANTS_RETRIES=1
+      - KAFKA_STRIMZI_AUTHORIZATION_HTTP_RETRIES=1
 
       - KAFKA_STRIMZI_AUTHORIZATION_ENABLE_METRICS=true
 

--- a/testsuite/keycloak-authz-tests/src/test/java/io/strimzi/testsuite/oauth/authz/ConfigurationTest.java
+++ b/testsuite/keycloak-authz-tests/src/test/java/io/strimzi/testsuite/oauth/authz/ConfigurationTest.java
@@ -32,8 +32,8 @@ public class ConfigurationTest {
         value = getLoggerAttribute(lines, "enableMetrics");
         Assert.assertEquals("'enableMetrics' should be true", "true", value);
 
-        value = getLoggerAttribute(lines, "grantsRetries");
-        Assert.assertEquals("'grantsRetries' should be 1", "1", value);
+        value = getLoggerAttribute(lines, "httpRetries");
+        Assert.assertEquals("'httpRetries' should be 1", "1", value);
     }
 
     private static String getLoggerAttribute(List<String> lines, String name) {

--- a/testsuite/keycloak-authz-tests/src/test/java/io/strimzi/testsuite/oauth/authz/ConfigurationTest.java
+++ b/testsuite/keycloak-authz-tests/src/test/java/io/strimzi/testsuite/oauth/authz/ConfigurationTest.java
@@ -28,6 +28,12 @@ public class ConfigurationTest {
 
         value = getLoggerAttribute(lines, "readTimeoutSeconds");
         Assert.assertEquals("'readTimeoutSeconds' should be 45", "45", value);
+
+        value = getLoggerAttribute(lines, "enableMetrics");
+        Assert.assertEquals("'enableMetrics' should be true", "true", value);
+
+        value = getLoggerAttribute(lines, "grantsRetries");
+        Assert.assertEquals("'grantsRetries' should be 1", "1", value);
     }
 
     private static String getLoggerAttribute(List<String> lines, String name) {

--- a/testsuite/keycloak-authz-tests/src/test/java/io/strimzi/testsuite/oauth/authz/MetricsTest.java
+++ b/testsuite/keycloak-authz-tests/src/test/java/io/strimzi/testsuite/oauth/authz/MetricsTest.java
@@ -19,6 +19,7 @@ public class MetricsTest {
         final String authHostPort = "keycloak:8080";
         final String realm = "kafka-authz";
         final String jwksPath = "/auth/realms/" + realm + "/protocol/openid-connect/certs";
+        final String tokenPath = "/auth/realms/" + realm + "/protocol/openid-connect/token";
 
         TestMetrics metrics = getPrometheusMetrics(URI.create("http://kafka:9404/metrics"));
         BigDecimal value = metrics.getValueSum("strimzi_oauth_http_requests_count", "kind", "jwks", "host", authHostPort, "path", jwksPath, "outcome", "success");
@@ -40,5 +41,8 @@ public class MetricsTest {
 
         value = metrics.getValueSum("strimzi_oauth_validation_requests_totaltimems", "kind", "jwks", "mechanism", "OAUTHBEARER", "outcome", "success");
         Assert.assertTrue("strimzi_oauth_validation_requests_totaltimems for jwks > 0.0", value.doubleValue() > 0.0);
+
+        value = metrics.getValueSum("strimzi_oauth_http_requests_count", "kind", "keycloak-authorization", "host", authHostPort, "path", tokenPath, "outcome", "error");
+        Assert.assertTrue("strimzi_oauth_http_requests_count for keycloak-authorization > 0.0", value.doubleValue() > 0.0);
     }
 }

--- a/testsuite/mock-oauth-server/src/main/java/io/strimzi/testsuite/oauth/server/AtomicCoin.java
+++ b/testsuite/mock-oauth-server/src/main/java/io/strimzi/testsuite/oauth/server/AtomicCoin.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017-2022, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.testsuite.oauth.server;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+public class AtomicCoin {
+
+    private AtomicLong counter;
+
+    public AtomicCoin() {
+        counter = new AtomicLong();
+    }
+
+    public AtomicCoin(boolean faceUp) {
+        counter = new AtomicLong(faceUp ? 1 : 0);
+    }
+
+    public boolean flip() {
+        return counter.incrementAndGet() % 2 == 1;
+    }
+
+    public boolean isFaceUp() {
+        return counter.get() % 2 == 1;
+    }
+}

--- a/testsuite/mock-oauth-server/src/main/java/io/strimzi/testsuite/oauth/server/Endpoint.java
+++ b/testsuite/mock-oauth-server/src/main/java/io/strimzi/testsuite/oauth/server/Endpoint.java
@@ -14,7 +14,9 @@ public enum Endpoint {
     SERVER,
     CLIENTS,
     USERS,
-    REVOCATIONS;
+    REVOCATIONS,
+    GRANTS,
+    FAILING_GRANTS;
 
     public static Endpoint fromString(String value) {
         return valueOf(value.toUpperCase(Locale.ROOT));

--- a/testsuite/mock-oauth-server/src/main/java/io/strimzi/testsuite/oauth/server/MockOAuthServerMainVerticle.java
+++ b/testsuite/mock-oauth-server/src/main/java/io/strimzi/testsuite/oauth/server/MockOAuthServerMainVerticle.java
@@ -31,11 +31,14 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
+import static io.strimzi.testsuite.oauth.server.Endpoint.FAILING_GRANTS;
+import static io.strimzi.testsuite.oauth.server.Endpoint.GRANTS;
 import static io.strimzi.testsuite.oauth.server.Endpoint.INTROSPECT;
 import static io.strimzi.testsuite.oauth.server.Endpoint.JWKS;
 import static io.strimzi.testsuite.oauth.server.Endpoint.SERVER;
 import static io.strimzi.testsuite.oauth.server.Endpoint.TOKEN;
 import static io.strimzi.testsuite.oauth.server.Endpoint.USERINFO;
+import static io.strimzi.testsuite.oauth.server.Mode.MODE_200;
 import static io.strimzi.testsuite.oauth.server.Mode.MODE_400;
 import static io.strimzi.testsuite.oauth.server.Mode.MODE_401;
 import static io.strimzi.testsuite.oauth.server.Mode.MODE_404;
@@ -144,6 +147,9 @@ public class MockOAuthServerMainVerticle extends AbstractVerticle {
         modes.put(TOKEN, MODE_400);
         modes.put(INTROSPECT, MODE_401);
         modes.put(USERINFO, MODE_401);
+        modes.put(GRANTS, MODE_200);
+        modes.put(FAILING_GRANTS, MODE_400);
+
 
         String projectRoot = getProjectRoot();
         keystoreOnePath = getEnvVar("KEYSTORE_ONE_PATH", projectRoot + "/../docker/certificates/mockoauth.server.keystore.p12");

--- a/testsuite/mockoauth-tests/docker-compose.yml
+++ b/testsuite/mockoauth-tests/docker-compose.yml
@@ -80,7 +80,7 @@ services:
       - OAUTH_SSL_TRUSTSTORE_LOCATION=/opt/kafka/config/strimzi/certs/ca-truststore.p12
       - OAUTH_SSL_TRUSTSTORE_PASSWORD=changeit
       - OAUTH_SSL_TRUSTSTORE_TYPE=pkcs12
-      - OAUTH_CONNECT_TIMEOUT=10
+      - OAUTH_CONNECT_TIMEOUT_SECONDS=10
       - OAUTH_ENABLE_METRICS=true
 
   zookeeper:

--- a/testsuite/mockoauth-tests/pom.xml
+++ b/testsuite/mockoauth-tests/pom.xml
@@ -39,6 +39,18 @@
             <artifactId>common</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.strimzi</groupId>
+            <artifactId>kafka-oauth-keycloak-authorizer</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka_2.13</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
         </dependency>

--- a/testsuite/mockoauth-tests/src/test/java/io/strimzi/testsuite/oauth/MockOAuthTests.java
+++ b/testsuite/mockoauth-tests/src/test/java/io/strimzi/testsuite/oauth/MockOAuthTests.java
@@ -8,6 +8,7 @@ import io.strimzi.testsuite.oauth.common.TestContainersLogCollector;
 import io.strimzi.testsuite.oauth.common.TestContainersWatcher;
 import io.strimzi.testsuite.oauth.metrics.MetricsTest;
 import io.strimzi.testsuite.oauth.mockoauth.JaasClientConfigTest;
+import io.strimzi.testsuite.oauth.mockoauth.KeycloakAuthorizerTest;
 import io.strimzi.testsuite.oauth.mockoauth.PasswordAuthTest;
 
 import org.junit.ClassRule;
@@ -41,6 +42,9 @@ public class MockOAuthTests {
     public void runTests() throws Exception {
         try {
             System.setProperty("oauth.read.timeout.seconds", "600");
+
+            logStart("KeycloakAuthorizerTest :: Grants Retries Tests");
+            new KeycloakAuthorizerTest().doTest();
 
             logStart("MetricsTest :: Basic Metrics Tests");
             new MetricsTest().doTest();

--- a/testsuite/mockoauth-tests/src/test/java/io/strimzi/testsuite/oauth/mockoauth/KeycloakAuthorizerTest.java
+++ b/testsuite/mockoauth-tests/src/test/java/io/strimzi/testsuite/oauth/mockoauth/KeycloakAuthorizerTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2017-2019, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.testsuite.oauth.mockoauth;
+
+import io.strimzi.kafka.oauth.common.OAuthAuthenticator;
+import io.strimzi.kafka.oauth.common.PrincipalExtractor;
+import io.strimzi.kafka.oauth.common.SSLUtil;
+import io.strimzi.kafka.oauth.common.TokenInfo;
+import io.strimzi.kafka.oauth.server.OAuthKafkaPrincipal;
+import io.strimzi.kafka.oauth.server.authorizer.KeycloakRBACAuthorizer;
+import org.apache.kafka.common.acl.AclOperation;
+import org.apache.kafka.common.resource.PatternType;
+import org.apache.kafka.common.resource.ResourcePattern;
+import org.apache.kafka.common.resource.ResourceType;
+import org.apache.kafka.common.security.auth.KafkaPrincipal;
+import org.apache.kafka.common.security.auth.SecurityProtocol;
+import org.apache.kafka.server.authorizer.Action;
+import org.apache.kafka.server.authorizer.AuthorizableRequestContext;
+import org.apache.kafka.server.authorizer.AuthorizationResult;
+import org.junit.Assert;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+import static io.strimzi.testsuite.oauth.mockoauth.Common.changeAuthServerMode;
+import static io.strimzi.testsuite.oauth.mockoauth.Common.createOAuthClient;
+import static io.strimzi.testsuite.oauth.mockoauth.Common.createOAuthUser;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class KeycloakAuthorizerTest {
+
+    public void doTest() throws IOException {
+
+        // create a client for resource server
+        String clientSrv = "kafka";
+        String clientSrvSecret = "kafka-secret";
+        createOAuthClient(clientSrv, clientSrvSecret);
+
+        // create a client for user's client agent
+        String clientCli = "kafka-cli";
+        createOAuthClient(clientCli, "");
+
+        // create a user alice
+        String userAlice = "alice";
+        String userAlicePass = "alice-password";
+        createOAuthUser(userAlice, userAlicePass);
+
+        String truststorePath = "../docker/target/kafka/certs/ca-truststore.p12";
+        String truststorePass = "changeit";
+        String tokenEndpoint = "https://mockoauth:8090/token";
+
+        changeAuthServerMode("token", "MODE_200");
+
+        HashMap<String, String> props = new HashMap<>();
+        props.put("strimzi.authorization.ssl.truststore.location", truststorePath);
+        props.put("strimzi.authorization.ssl.truststore.password", truststorePass);
+        props.put("strimzi.authorization.ssl.truststore.type", "pkcs12");
+
+        props.put("strimzi.authorization.enable.metrics", "true");
+        props.put("strimzi.authorization.token.endpoint.uri", "https://mockoauth:8090/failing_grants");
+        props.put("strimzi.authorization.client.id", clientSrv);
+        props.put("strimzi.authorization.client.secret", clientSrvSecret);
+        props.put("strimzi.authorization.kafka.cluster.name", "my-cluster");
+        props.put("strimzi.authorization.delegate.to.kafka.acl", "false");
+        props.put("strimzi.authorization.read.timeout.seconds", "45");
+        props.put("strimzi.authorization.connect.timeout.seconds", "10");
+        props.put("strimzi.authorization.grants.refresh.pool.size", "2");
+        props.put("strimzi.authorization.grants.refresh.period.seconds", "60");
+        props.put("strimzi.authorization.grants.retries", "1");
+        props.put("super.users", "User:admin;User:service-account-kafka");
+        props.put("principal.builder.class", "io.strimzi.kafka.oauth.server.OAuthKafkaPrincipalBuilder");
+
+        KeycloakRBACAuthorizer authorizer = new KeycloakRBACAuthorizer();
+        authorizer.configure(props);
+
+
+        SecurityProtocol protocol = SecurityProtocol.SASL_PLAINTEXT;
+        TokenInfo tokenInfo = OAuthAuthenticator.loginWithPassword(
+                URI.create(tokenEndpoint),
+                SSLUtil.createSSLFactory(truststorePath, null, truststorePass, null, null),
+                null,
+                userAlice,
+                userAlicePass,
+                clientCli,
+                null,
+                true,
+                new PrincipalExtractor(),
+                "all",
+                null,
+                60,
+                60);
+
+        KafkaPrincipal principal = new OAuthKafkaPrincipal(KafkaPrincipal.USER_TYPE, "alice", new Common.MockBearerTokenWithPayload(tokenInfo));
+
+
+        AuthorizableRequestContext ctx = mock(AuthorizableRequestContext.class);
+        when(ctx.listenerName()).thenReturn("JWT");
+        when(ctx.securityProtocol()).thenReturn(protocol);
+        when(ctx.principal()).thenReturn(principal);
+        when(ctx.clientId()).thenReturn(clientCli);
+
+
+        List<Action> actions = new ArrayList<>();
+        actions.add(new Action(
+                AclOperation.CREATE,
+                new ResourcePattern(ResourceType.TOPIC, "my-topic", PatternType.LITERAL),
+                1, true, true));
+
+
+        List<AuthorizationResult> result = authorizer.authorize(ctx, actions);
+        Assert.assertNotNull("Authorizer has to return non-null", result);
+        Assert.assertTrue("Authorizer has to return as many results as it received inputs", result.size() == actions.size());
+        Assert.assertEquals("Authorizer should return ALLOWED", AuthorizationResult.ALLOWED, result.get(0));
+    }
+}

--- a/testsuite/mockoauth-tests/src/test/java/io/strimzi/testsuite/oauth/mockoauth/KeycloakAuthorizerTest.java
+++ b/testsuite/mockoauth-tests/src/test/java/io/strimzi/testsuite/oauth/mockoauth/KeycloakAuthorizerTest.java
@@ -72,7 +72,7 @@ public class KeycloakAuthorizerTest {
         props.put("strimzi.authorization.connect.timeout.seconds", "10");
         props.put("strimzi.authorization.grants.refresh.pool.size", "2");
         props.put("strimzi.authorization.grants.refresh.period.seconds", "60");
-        props.put("strimzi.authorization.grants.retries", "1");
+        props.put("strimzi.authorization.http.retries", "1");
         props.put("super.users", "User:admin;User:service-account-kafka");
         props.put("principal.builder.class", "io.strimzi.kafka.oauth.server.OAuthKafkaPrincipalBuilder");
 


### PR DESCRIPTION
Introduced `strimzi.authorization.http.retries` broker option that signifies how many retries to attempt immediately in the same thread if the grants HTTP request fails. Status errors 401 and 403 don't trigger a re-attempt, all other failures do.

This feature is useful in the environment where network is glitchy or a reverse proxy in front of the Keycloak server produces intermittent failures. Such an environment may be a given and the application developers may have no other option but to work within such constraints.

Signed-off-by: Marko Strukelj <marko.strukelj@gmail.com>