### PR TITLE
Minimise initial grants requests for 'same token, different session' case

### DIFF
--- a/README.md
+++ b/README.md
@@ -700,6 +700,17 @@ since they are not yet available. The following option enables reattempting the 
 receive the `AuthorizationException`. The default value is '0', meaning 'no retries'. Provide the value greater than '0' to set the number of repeated attempts:
 - `strimzi.authorization.http.retries` (e.g.: "1" - if initial fetching of grants for the session fails, immediately retry one more time)
 
+A single client typically uses a single unique access token for the concurrent sessions to the Kafka broker.
+As a result, the number of active tokens on the broker is generally less than the number of active sessions (connections).
+ However, keep in mind that this is replicated across all Kafka brokers in the cluster, as clients maintain active sessions to multiple brokers.
+
+New sessions will, by default, request the latest grants from the Keycloak in order for any changes in permissions to be reflected immediately.
+You can change this, and reuse the grants for the token, if they have previously been fetched due to the same token already having been used
+for another session on the broker. This can noticeably reduce the load from brokers to the Keycloak and can also help alleviate 'glitchiness' issues
+addressed by `strimzi.authorization.grants.retries`. However, as a result, the grants initially used for the new session may be out-of-sync with
+Keycloak for up to `strimzi.authorization.grants.refresh.period.seconds`.
+- `strimzi.authorization.reuse.grants` (e.g.: "true" - if enabled, then grants fetched for another session may be used)
+
 You may also want to configure some other things. You may want to set a logical cluster name so you can target it with authorization rules:
 - `strimzi.authorization.kafka.cluster.name` (e.g.: "dev-cluster" - a logical name of the cluster which can be targeted with authorization services resource definitions, and permission policies)
 

--- a/README.md
+++ b/README.md
@@ -707,7 +707,7 @@ As a result, the number of active tokens on the broker is generally less than th
 New sessions will, by default, request the latest grants from the Keycloak in order for any changes in permissions to be reflected immediately.
 You can change this, and reuse the grants for the token, if they have previously been fetched due to the same token already having been used
 for another session on the broker. This can noticeably reduce the load from brokers to the Keycloak and can also help alleviate 'glitchiness' issues
-addressed by `strimzi.authorization.grants.retries`. However, as a result, the grants initially used for the new session may be out-of-sync with
+addressed by `strimzi.authorization.http.retries`. However, as a result, the grants initially used for the new session may be out-of-sync with
 Keycloak for up to `strimzi.authorization.grants.refresh.period.seconds`.
 - `strimzi.authorization.reuse.grants` (e.g.: "true" - if enabled, then grants fetched for another session may be used)
 

--- a/README.md
+++ b/README.md
@@ -702,7 +702,7 @@ receive the `AuthorizationException`. The default value is '0', meaning 'no retr
 
 A single client typically uses a single unique access token for the concurrent sessions to the Kafka broker.
 As a result, the number of active tokens on the broker is generally less than the number of active sessions (connections).
- However, keep in mind that this is replicated across all Kafka brokers in the cluster, as clients maintain active sessions to multiple brokers.
+However, keep in mind that this is replicated across all Kafka brokers in the cluster, as clients maintain active sessions to multiple brokers.
 
 New sessions will, by default, request the latest grants from the Keycloak in order for any changes in permissions to be reflected immediately.
 You can change this, and reuse the grants for the token, if they have previously been fetched due to the same token already having been used

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/services/Sessions.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/services/Sessions.java
@@ -72,4 +72,23 @@ public class Sessions {
             }
         }
     }
+
+    /**
+     * Iterate over sessions, and find the first element matching the filter.
+     *
+     * @param filter A filter to apply
+     * @return The first matching session
+     */
+    public BearerTokenWithPayload findFirst(Predicate<BearerTokenWithPayload> filter) {
+        // In order to prevent the possible ConcurrentModificationException in the middle of using an iterator
+        // we first make a local copy, then iterate over the copy
+        ArrayList<BearerTokenWithPayload> values = new ArrayList<>(activeSessions.keySet());
+
+        for (BearerTokenWithPayload token: values) {
+            if (filter.test(token)) {
+                return token;
+            }
+        }
+        return null;
+    }
 }

--- a/oauth-keycloak-authorizer/src/main/java/io/strimzi/kafka/oauth/server/authorizer/AuthzConfig.java
+++ b/oauth-keycloak-authorizer/src/main/java/io/strimzi/kafka/oauth/server/authorizer/AuthzConfig.java
@@ -29,6 +29,7 @@ public class AuthzConfig extends Config {
     public static final String STRIMZI_AUTHORIZATION_CONNECT_TIMEOUT_SECONDS = "strimzi.authorization.connect.timeout.seconds";
     public static final String STRIMZI_AUTHORIZATION_READ_TIMEOUT_SECONDS = "strimzi.authorization.read.timeout.seconds";
     public static final String STRIMZI_AUTHORIZATION_ENABLE_METRICS = "strimzi.authorization.enable.metrics";
+    public static final String STRIMZI_AUTHORIZATION_REUSE_GRANTS = "strimzi.authorization.reuse.grants";
 
     AuthzConfig() {}
 

--- a/oauth-keycloak-authorizer/src/main/java/io/strimzi/kafka/oauth/server/authorizer/KeycloakRBACAuthorizer.java
+++ b/oauth-keycloak-authorizer/src/main/java/io/strimzi/kafka/oauth/server/authorizer/KeycloakRBACAuthorizer.java
@@ -182,6 +182,8 @@ public class KeycloakRBACAuthorizer extends AclAuthorizer {
 
     private int httpRetries;
 
+    private boolean reuseGrants;
+
     // Turning it to false will not enforce access token expiry time (only for debugging purposes during development)
     private final boolean denyWhenTokenInvalid = true;
 
@@ -191,7 +193,7 @@ public class KeycloakRBACAuthorizer extends AclAuthorizer {
     private boolean enableMetrics;
     private SensorKeyProducer authzSensorKeyProducer;
     private SensorKeyProducer grantsSensorKeyProducer;
-
+    private final Semaphores<JsonNode> semaphores = new Semaphores<>();
     public KeycloakRBACAuthorizer() {
         super();
     }
@@ -245,6 +247,8 @@ public class KeycloakRBACAuthorizer extends AclAuthorizer {
             setupRefreshGrantsJob(grantsRefreshPeriodSeconds);
         }
 
+        reuseGrants = config.getValueAsBoolean(AuthzConfig.STRIMZI_AUTHORIZATION_REUSE_GRANTS, false);
+
         configureHttpRetries(config);
 
         configureMetrics(configs, config);
@@ -267,6 +271,7 @@ public class KeycloakRBACAuthorizer extends AclAuthorizer {
                     + "\n    grantsRefreshPeriodSeconds: " + grantsRefreshPeriodSeconds
                     + "\n    grantsRefreshPoolSize: " + grantsRefreshPoolSize
                     + "\n    httpRetries: " + httpRetries
+                    + "\n    reuseGrants: " + reuseGrants
                     + "\n    connectTimeoutSeconds: " + connectTimeoutSeconds
                     + "\n    readTimeoutSeconds: " + readTimeoutSeconds
                     + "\n    enableMetrics: " + enableMetrics
@@ -329,7 +334,7 @@ public class KeycloakRBACAuthorizer extends AclAuthorizer {
     /**
      * This method extracts the key=value configuration entries relevant for KeycloakRBACAuthorizer from
      * Kafka properties configuration file (server.properties) and wraps them with AuthzConfig instance.
-     *
+     * <p>
      * Any new config options have to be added here in order to become visible, otherwise they will be ignored.
      *
      * @param configs Kafka configs map
@@ -344,6 +349,7 @@ public class KeycloakRBACAuthorizer extends AclAuthorizer {
             AuthzConfig.STRIMZI_AUTHORIZATION_GRANTS_REFRESH_PERIOD_SECONDS,
             AuthzConfig.STRIMZI_AUTHORIZATION_GRANTS_REFRESH_POOL_SIZE,
             AuthzConfig.STRIMZI_AUTHORIZATION_HTTP_RETRIES,
+            AuthzConfig.STRIMZI_AUTHORIZATION_REUSE_GRANTS,
             AuthzConfig.STRIMZI_AUTHORIZATION_DELEGATE_TO_KAFKA_ACL,
             AuthzConfig.STRIMZI_AUTHORIZATION_KAFKA_CLUSTER_NAME,
             AuthzConfig.STRIMZI_AUTHORIZATION_CLIENT_ID,
@@ -406,10 +412,10 @@ public class KeycloakRBACAuthorizer extends AclAuthorizer {
 
     /**
      * The method that makes the authorization decision.
-     *
+     * <p>
      * We assume authorize() is thread-safe in a sense that there will not be two concurrent threads
      * calling it at the same time for the same session.
-     *
+     * <p>
      * Should that not be the case, the side effect could be to make more calls to token endpoint than necessary.
      * Other than that it should not affect proper functioning of this authorizer.
      *
@@ -549,11 +555,60 @@ public class KeycloakRBACAuthorizer extends AclAuthorizer {
         return false;
     }
 
+
+
     private JsonNode handleFetchingGrants(BearerTokenWithPayload token) {
         // Fetch authorization grants
-        JsonNode grants = null;
+        Semaphores<JsonNode>.SemaphoreFuture<JsonNode> future = semaphores.acquireSemaphore(token.value());
 
+        // Try to acquire semaphore for fetching grants
+        if (future.tryAcquire()) {
+            // If acquired
+            try {
+                JsonNode grants = null;
+                if (reuseGrants) {
+                    // If reuseGrants is enabled, first try to get the grants from one of the existing sessions having the same access token
+                    grants = lookupGrantsInExistingSessions(token);
+                }
+                if (grants == null) {
+                    // If grants not available it is on us to fetch (others may be waiting)
+                    grants = fetchAndStoreGrants(token);
+                } else {
+                    log.debug("Found existing grants for the token on another session");
+                }
+
+                future.complete(grants);
+                return grants;
+
+            } catch (Throwable t) {
+                future.completeExceptionally(t);
+                throw t;
+            } finally {
+                semaphores.releaseSemaphore(token.value());
+            }
+
+        } else {
+            try {
+                log.debug("Waiting on another thread to get grants");
+                return future.get();
+            } catch (ExecutionException e) {
+                Throwable cause = e.getCause();
+                if (cause instanceof ServiceException) {
+                    throw (ServiceException) cause;
+                } else {
+                    throw new ServiceException("ExecutionException waiting for grants result: ", e);
+                }
+            } catch (InterruptedException e) {
+                throw new ServiceException("InterruptedException waiting for grants result: ", e);
+            }
+        }
+    }
+
+    private JsonNode fetchAndStoreGrants(BearerTokenWithPayload token) {
+        // If no grants found, fetch grants from server
+        JsonNode grants = null;
         try {
+            log.debug("Fetching grants from Keycloak");
             grants = fetchAuthorizationGrants(token.value());
             if (grants == null) {
                 log.debug("Received null grants for token: {}", mask(token.value()));
@@ -567,11 +622,19 @@ public class KeycloakRBACAuthorizer extends AclAuthorizer {
             }
         }
         if (grants != null) {
-            // Store authz grants in the token so they are available for subsequent requests
+            // Store authz grants in the token, so they are available for subsequent requests
             log.debug("Saving non-null grants for token: {}", mask(token.value()));
             token.setPayload(grants);
         }
         return grants;
+    }
+
+    private static JsonNode lookupGrantsInExistingSessions(BearerTokenWithPayload token) {
+        Sessions sessions = Services.getInstance().getSessions();
+        BearerTokenWithPayload existing = sessions.findFirst(t ->
+            t.value().equals(token.value()) && t.getPayload() != null
+        );
+        return existing != null ? (JsonNode) existing.getPayload() : null;
     }
 
     static List<ScopesSpec.AuthzScope> validateScopes(List<String> scopes) {
@@ -649,11 +712,11 @@ public class KeycloakRBACAuthorizer extends AclAuthorizer {
     /**
      * Method that performs the POST request to fetch grants for the token.
      * In case of a connection failure or a non-200 status response this method immediately retries the request if so configured.
-     *
+     * <p>
      * Status 401 does not trigger a retry since it is used to signal an invalid token.
      * Status 403 does not trigger a retry either since it signals no permissions.
      *
-     * @param token
+     * @param token The raw access token
      * @return Grants JSON response
      */
     private JsonNode fetchAuthorizationGrants(String token) {

--- a/oauth-keycloak-authorizer/src/main/java/io/strimzi/kafka/oauth/server/authorizer/Semaphores.java
+++ b/oauth-keycloak-authorizer/src/main/java/io/strimzi/kafka/oauth/server/authorizer/Semaphores.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017-2019, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.kafka.oauth.server.authorizer;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+class Semaphores<T> {
+
+    private final ConcurrentHashMap<String, SemaphoreFuture<T>> futures = new ConcurrentHashMap<>();
+
+    SemaphoreFuture<T> acquireSemaphore(String key) {
+        return futures.computeIfAbsent(key, v -> new SemaphoreFuture<>());
+    }
+
+    void releaseSemaphore(String key) {
+        futures.remove(key);
+    }
+
+    class SemaphoreFuture<S> extends CompletableFuture<S> {
+
+        private final AtomicBoolean semaphore = new AtomicBoolean(true);
+
+        private SemaphoreFuture() {}
+
+        public boolean tryAcquire() {
+            return semaphore.getAndSet(false);
+        }
+    }
+}

--- a/oauth-server/src/main/java/io/strimzi/kafka/oauth/server/JaasServerOauthValidatorCallbackHandler.java
+++ b/oauth-server/src/main/java/io/strimzi/kafka/oauth/server/JaasServerOauthValidatorCallbackHandler.java
@@ -656,7 +656,7 @@ public class JaasServerOauthValidatorCallbackHandler implements AuthenticateCall
     static class BearerTokenWithPayloadImpl implements BearerTokenWithPayload {
 
         private final TokenInfo ti;
-        private Object payload;
+        private volatile Object payload;
 
         BearerTokenWithPayloadImpl(TokenInfo ti) {
             if (ti == null) {
@@ -666,12 +666,12 @@ public class JaasServerOauthValidatorCallbackHandler implements AuthenticateCall
         }
 
         @Override
-        public Object getPayload() {
+        public synchronized Object getPayload() {
             return payload;
         }
 
         @Override
-        public void setPayload(Object value) {
+        public synchronized void setPayload(Object value) {
             payload = value;
         }
 

--- a/testsuite/keycloak-authz-tests/docker-compose.yml
+++ b/testsuite/keycloak-authz-tests/docker-compose.yml
@@ -115,6 +115,8 @@ services:
       - KAFKA_STRIMZI_AUTHORIZATION_GRANTS_REFRESH_PERIOD_SECONDS=10
       # If a grants fetch fails, immediately perform one retry
       - KAFKA_STRIMZI_AUTHORIZATION_HTTP_RETRIES=1
+      # Use grants fetched for another session if available
+      - KAFKA_STRIMZI_AUTHORIZATION_REUSE_GRANTS=true
 
       - KAFKA_STRIMZI_AUTHORIZATION_ENABLE_METRICS=true
 

--- a/testsuite/keycloak-authz-tests/src/test/java/io/strimzi/testsuite/oauth/authz/ConfigurationTest.java
+++ b/testsuite/keycloak-authz-tests/src/test/java/io/strimzi/testsuite/oauth/authz/ConfigurationTest.java
@@ -34,6 +34,9 @@ public class ConfigurationTest {
 
         value = getLoggerAttribute(lines, "httpRetries");
         Assert.assertEquals("'httpRetries' should be 1", "1", value);
+
+        value = getLoggerAttribute(lines, "reuseGrants");
+        Assert.assertEquals("'reuseGrants' should be true", "true", value);
     }
 
     private static String getLoggerAttribute(List<String> lines, String name) {

--- a/testsuite/keycloak-authz-tests/src/test/java/io/strimzi/testsuite/oauth/authz/FloodTest.java
+++ b/testsuite/keycloak-authz-tests/src/test/java/io/strimzi/testsuite/oauth/authz/FloodTest.java
@@ -142,19 +142,9 @@ public class FloodTest extends Common {
         return lines.size();
     }
 
-    private void checkExistingGrantsLogCountDiff(int previousCount) {
-        int current = currentFoundExistingGrantsLogCount();
-        Assert.assertTrue("Expected many new 'Found existing' messages in the log (" + current + " vs. " + previousCount + ")", current - previousCount > 40);
-    }
-
     private int currentSemaphoreBlockLogCount() {
         List<String> lines = getContainerLogsForString(kafkaContainer, "Waiting on another thread to get grants");
         return lines.size();
-    }
-
-    private void checkSemaphoreBlockLogCountDiff(int previousCount) {
-        int current = currentSemaphoreBlockLogCount();
-        Assert.assertEquals("Expected some new 'Waiting on another thread' messages in the log", current - previousCount > 0);
     }
 
     private void sendSingleMessage(String clientId, String secret, String topic) throws ExecutionException, InterruptedException {

--- a/testsuite/keycloak-authz-tests/src/test/java/io/strimzi/testsuite/oauth/authz/KeycloakAuthorizationTests.java
+++ b/testsuite/keycloak-authz-tests/src/test/java/io/strimzi/testsuite/oauth/authz/KeycloakAuthorizationTests.java
@@ -63,8 +63,9 @@ public class KeycloakAuthorizationTests {
             logStart("KeycloakAuthorizationTest :: MetricsTest");
             MetricsTest.doTest();
 
+            // This test assumes that it is the first producing and consuming test
             logStart("KeycloakAuthorizationTest :: MultiSaslTests");
-            MultiSaslTest.doTest();
+            new MultiSaslTest(kafkaContainer).doTest();
 
             logStart("KeycloakAuthorizationTest :: JwtValidationAuthzTest");
             new BasicTest(JWT_LISTENER, false).doTest();
@@ -79,13 +80,13 @@ public class KeycloakAuthorizationTests {
             new OAuthOverPlainTest(INTROSPECTPLAIN_LISTENER, true).doTest();
 
             logStart("KeycloakAuthorizationTest :: OAuthOverPLain + FloodTest");
-            new FloodTest(JWTPLAIN_LISTENER, true).doTest();
+            new FloodTest(kafkaContainer, JWTPLAIN_LISTENER, true).doTest();
 
             logStart("KeycloakAuthorizationTest :: JWT FloodTest");
-            new FloodTest(JWT_LISTENER, false).doTest();
+            new FloodTest(kafkaContainer, JWT_LISTENER, false).doTest();
 
             logStart("KeycloakAuthorizationTest :: Introspection FloodTest");
-            new FloodTest(INTROSPECT_LISTENER, false).doTest();
+            new FloodTest(kafkaContainer, INTROSPECT_LISTENER, false).doTest();
 
             // This test has to be the last one - it changes the team-a-client, and team-b-client permissions in Keycloak
             logStart("KeycloakAuthorizationTest :: JwtValidationAuthzTest + RefreshGrants");


### PR DESCRIPTION
If grants for the token exist in another session, reuse them, rather than fetch them again. Also introduce per-access-token semaphore to prevent parallel fetching of grants for the same token.

Add `strimzi.authorization.reuse.grants` config option to enable this optimisation.

Signed-off-by: Marko Strukelj <marko.strukelj@gmail.com>