### PR TITLE
Add support for Java 17

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ jobs:
         packages:
         - maven
 jdk:
-- openjdk8
 - openjdk11
 cache:
   directories:

--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -18,14 +18,16 @@ exitIfError() {
   [ "$EXIT" != "0" ] && exit $EXIT
 }
 
+arch=$(uname -m)
+
 # The first segment of the version number is '1' for releases < 9; then '9', '10', '11', ...
 JAVA_MAJOR_VERSION=$(java -version 2>&1 | sed -E -n 's/.* version "([0-9]*).*$/\1/p')
 if [ ${JAVA_MAJOR_VERSION} -gt 1 ] ; then
   export JAVA_VERSION=${JAVA_MAJOR_VERSION}
 fi
 
-if [ ${JAVA_MAJOR_VERSION} -eq 1 ] ; then
-  # some parts of the workflow should be done only once on the main build which is currently Java 8
+if [ "$arch" == 'x86_64' ] ; then
+  # some parts of the workflow should be done only once on the main build which is currently Java 11
   export MAIN_BUILD="TRUE"
 fi
 
@@ -40,8 +42,6 @@ else
 fi
 
 mvn spotbugs:check
-
-arch=$(uname -m)
 
 # Also test examples build on different architectures (exclude ppc64le until fixed)
 if [ "$arch" != 'ppc64le' ]; then

--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -26,7 +26,7 @@ if [ ${JAVA_MAJOR_VERSION} -gt 1 ] ; then
   export JAVA_VERSION=${JAVA_MAJOR_VERSION}
 fi
 
-if [ "$arch" == 'x86_64' ] ; then
+if [ "$arch" == 'x86_64' ] || [ "$arch" == 'arm64' ] ; then
   # some parts of the workflow should be done only once on the main build which is currently Java 11
   export MAIN_BUILD="TRUE"
 fi
@@ -82,20 +82,24 @@ if [ "${MAIN_BUILD}" == "TRUE" ] ; then
     EXIT=$?
     exitIfError
 
-    clearDockerEnv
-    mvn -e -V -B clean install -f testsuite -Pkafka-3_1_2
-    EXIT=$?
-    exitIfError
+    if [ $JAVA_VERSION -le 11 ]; then
+      clearDockerEnv
+      mvn -e -V -B clean install -f testsuite -Pkafka-3_1_2
+      EXIT=$?
+      exitIfError
 
-    clearDockerEnv
-    mvn -e -V -B clean install -f testsuite -Pkafka-3_0_0
-    EXIT=$?
-    exitIfError
+      clearDockerEnv
+      mvn -e -V -B clean install -f testsuite -Pkafka-3_0_0
+      EXIT=$?
+      exitIfError
 
-    clearDockerEnv
-    mvn -e -V -B clean install -f testsuite -Pkafka-2_8_1
-    EXIT=$?
-    exitIfError
+      clearDockerEnv
+      mvn -e -V -B clean install -f testsuite -Pkafka-2_8_1
+      EXIT=$?
+      exitIfError
+    else
+      echo "Skipped test profiles: kafka-3_1_2, kafka-3_0_0 and kafka-2_8_1"
+    fi
 
     set -e
   fi

--- a/examples/consumer/src/main/java/io/strimzi/examples/consumer/ExampleConsumer.java
+++ b/examples/consumer/src/main/java/io/strimzi/examples/consumer/ExampleConsumer.java
@@ -22,9 +22,17 @@ import java.time.Duration;
 import java.util.Arrays;
 import java.util.Properties;
 
+/**
+ * An example consumer implementation
+ */
 @SuppressFBWarnings("THROWS_METHOD_THROWS_RUNTIMEEXCEPTION")
 public class ExampleConsumer {
 
+    /**
+     * A main method
+     *
+     * @param args No arguments expected
+     */
     public static void main(String[] args) {
 
         String topic = "a_Topic1";

--- a/examples/producer/src/main/java/io/strimzi/examples/producer/ExampleConcurrentProducer.java
+++ b/examples/producer/src/main/java/io/strimzi/examples/producer/ExampleConcurrentProducer.java
@@ -25,11 +25,19 @@ import java.util.Properties;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
+/**
+ * An example asynchronous (multi-threaded) producer implementation where multiple execution threads are managed by KafkaProducer
+ */
 @SuppressFBWarnings("THROWS_METHOD_THROWS_RUNTIMEEXCEPTION")
 public class ExampleConcurrentProducer {
 
     private static Logger log = LoggerFactory.getLogger(ExampleConcurrentProducer.class);
 
+    /**
+     * A main method
+     *
+     * @param args No arguments expected
+     */
     public static void main(String[] args) {
 
         String topic = "a_Topic1";

--- a/examples/producer/src/main/java/io/strimzi/examples/producer/ExampleProducer.java
+++ b/examples/producer/src/main/java/io/strimzi/examples/producer/ExampleProducer.java
@@ -19,9 +19,17 @@ import org.apache.kafka.common.serialization.StringSerializer;
 import java.util.Properties;
 import java.util.concurrent.ExecutionException;
 
+/**
+ * An example synchronous (single-threaded) producer implementation
+ */
 @SuppressFBWarnings("THROWS_METHOD_THROWS_RUNTIMEEXCEPTION")
 public class ExampleProducer {
 
+    /**
+     * A main method
+     *
+     * @param args No arguments expected
+     */
     public static void main(String[] args) {
 
         String topic = "a_Topic1";

--- a/oauth-client/src/main/java/io/strimzi/kafka/oauth/client/ClientConfig.java
+++ b/oauth-client/src/main/java/io/strimzi/kafka/oauth/client/ClientConfig.java
@@ -6,18 +6,52 @@ package io.strimzi.kafka.oauth.client;
 
 import io.strimzi.kafka.oauth.common.Config;
 
+/**
+ * A {@link Config} object used for client configuration
+ */
 public class ClientConfig extends Config {
 
+    /**
+     * "oauth.access.token"
+     */
     public static final String OAUTH_ACCESS_TOKEN = "oauth.access.token";
+
+    /**
+     * "oauth.refresh.token"
+     */
     public static final String OAUTH_REFRESH_TOKEN = "oauth.refresh.token";
+
+    /**
+     * "oauth.token.endpoint.uri"
+     */
     public static final String OAUTH_TOKEN_ENDPOINT_URI = "oauth.token.endpoint.uri";
+
+    /**
+     * "oauth.max.token.expiry.seconds"
+     */
     public static final String OAUTH_MAX_TOKEN_EXPIRY_SECONDS = "oauth.max.token.expiry.seconds";
+
+    /**
+     * "oauth.password.grant.username"
+     */
     public static final String OAUTH_PASSWORD_GRANT_USERNAME = "oauth.password.grant.username";
+
+    /**
+     * "oauth.password.grant.password"
+     */
     public static final String OAUTH_PASSWORD_GRANT_PASSWORD = "oauth.password.grant.password";
 
+    /**
+     * Create a new instance
+     */
     public ClientConfig() {
     }
 
+    /**
+     * Create a new instance
+     *
+     * @param p Properties object containing the configuration
+     */
     public ClientConfig(java.util.Properties p) {
         super(p);
     }

--- a/oauth-client/src/main/java/io/strimzi/kafka/oauth/client/JaasClientOauthLoginCallbackHandler.java
+++ b/oauth-client/src/main/java/io/strimzi/kafka/oauth/client/JaasClientOauthLoginCallbackHandler.java
@@ -44,6 +44,9 @@ import static io.strimzi.kafka.oauth.common.OAuthAuthenticator.loginWithClientSe
 import static io.strimzi.kafka.oauth.common.OAuthAuthenticator.loginWithPassword;
 import static io.strimzi.kafka.oauth.common.OAuthAuthenticator.loginWithRefreshToken;
 
+/**
+ * A login callback handler class for use with the KafkaProducer, KafkaConsumer, KafkaAdmin clients.
+ */
 public class JaasClientOauthLoginCallbackHandler implements AuthenticateCallbackHandler {
 
     private static final Logger LOG = LoggerFactory.getLogger(JaasClientOauthLoginCallbackHandler.class);

--- a/oauth-client/src/main/java/io/strimzi/kafka/oauth/client/metrics/ClientAuthenticationSensorKeyProducer.java
+++ b/oauth-client/src/main/java/io/strimzi/kafka/oauth/client/metrics/ClientAuthenticationSensorKeyProducer.java
@@ -11,11 +11,20 @@ import io.strimzi.kafka.oauth.metrics.SensorKeyProducer;
 import java.net.URI;
 import java.util.Map;
 
+/**
+ * A {@link SensorKeyProducer} used for client authentication metrics
+ */
 public class ClientAuthenticationSensorKeyProducer implements SensorKeyProducer {
 
     private final String contextId;
     private final URI uri;
 
+    /**
+     * Create a new instance
+     *
+     * @param contextId Context id (e.g. a config id or a label)
+     * @param uri A token endpoint url
+     */
     public ClientAuthenticationSensorKeyProducer(String contextId, URI uri) {
         if (contextId == null) {
             throw new IllegalArgumentException("contextId == null");
@@ -24,6 +33,11 @@ public class ClientAuthenticationSensorKeyProducer implements SensorKeyProducer 
         this.uri = uri;
     }
 
+    /**
+     * Generate a <code>SensorKey</code> for metrics about successful client authentication requests
+     *
+     * @return A sensor key
+     */
     @Override
     public SensorKey successKey() {
         Map<String, String> attrs = MetricsUtil.getSensorKeyAttrs(contextId, uri, "client-auth");
@@ -31,6 +45,12 @@ public class ClientAuthenticationSensorKeyProducer implements SensorKeyProducer 
         return SensorKey.of("authentication_requests", attrs);
     }
 
+    /**
+     * Generate a <code>SensorKey</code> for metrics about failed client authentication requests
+     *
+     * @param e The Throwable object to go with the failure
+     * @return A sensor key
+     */
     @Override
     public SensorKey errorKey(Throwable e) {
         Map<String, String> attrs = MetricsUtil.getSensorKeyAttrs(contextId, uri, "client-auth");

--- a/oauth-client/src/main/java/io/strimzi/kafka/oauth/client/metrics/ClientHttpSensorKeyProducer.java
+++ b/oauth-client/src/main/java/io/strimzi/kafka/oauth/client/metrics/ClientHttpSensorKeyProducer.java
@@ -7,16 +7,31 @@ package io.strimzi.kafka.oauth.client.metrics;
 import io.strimzi.kafka.oauth.metrics.AbstractSensorKeyProducer;
 import io.strimzi.kafka.oauth.metrics.MetricsUtil;
 import io.strimzi.kafka.oauth.metrics.SensorKey;
+import io.strimzi.kafka.oauth.metrics.SensorKeyProducer;
 
 import java.net.URI;
 import java.util.Map;
 
+/**
+ * A {@link SensorKeyProducer} used for token endpoint HTTP metrics when accessed by a client
+ */
 public class ClientHttpSensorKeyProducer extends AbstractSensorKeyProducer {
 
+    /**
+     * Create a new instance
+     *
+     * @param contextId Context id (e.g. a config id or a label)
+     * @param uri A token endpoint url
+     */
     public ClientHttpSensorKeyProducer(String contextId, URI uri) {
         super(contextId, uri);
     }
 
+    /**
+     * Generate a <code>SensorKey</code> for metrics about successful HTTP requests
+     *
+     * @return A sensor key
+     */
     @Override
     public SensorKey successKey() {
         Map<String, String> attrs = MetricsUtil.getSensorKeyAttrs(contextId, uri, "client-auth");
@@ -24,6 +39,12 @@ public class ClientHttpSensorKeyProducer extends AbstractSensorKeyProducer {
         return SensorKey.of("http_requests", attrs);
     }
 
+    /**
+     * Generate a <code>SensorKey</code> for metrics about failed HTTP requests
+     *
+     * @param e The Throwable object to go with the failure
+     * @return A sensor key
+     */
     @Override
     public SensorKey errorKey(Throwable e) {
         Map<String, String> attrs = MetricsUtil.getSensorKeyAttrs(contextId, uri, "client-auth");

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/Config.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/Config.java
@@ -12,29 +12,73 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.stream.Collectors;
 
+/**
+ * Configuration handling class
+ */
 public class Config {
 
+    /** The name of 'oauth.client.id' config option  */
     public static final String OAUTH_CLIENT_ID = "oauth.client.id";
+
+    /** The name of 'oauth.client.secret' config option  */
     public static final String OAUTH_CLIENT_SECRET = "oauth.client.secret";
+
+    /** The name of 'oauth.scope' config option  */
     public static final String OAUTH_SCOPE = "oauth.scope";
+
+    /** The name of 'oauth.audience' config option  */
     public static final String OAUTH_AUDIENCE = "oauth.audience";
+
+    /** The name of 'oauth.username.claim' config option  */
     public static final String OAUTH_USERNAME_CLAIM = "oauth.username.claim";
+
+    /** The name of 'oauth.fallback.username.claim' config option  */
     public static final String OAUTH_FALLBACK_USERNAME_CLAIM = "oauth.fallback.username.claim";
+
+    /** The name of 'oauth.fallback.username.prefix' config option  */
     public static final String OAUTH_FALLBACK_USERNAME_PREFIX = "oauth.fallback.username.prefix";
+
+    /** The name of 'oauth.ssl.truststore.location' config option  */
     public static final String OAUTH_SSL_TRUSTSTORE_LOCATION = "oauth.ssl.truststore.location";
+
+    /** The name of 'oauth.ssl.truststore.certificates' config option  */
     public static final String OAUTH_SSL_TRUSTSTORE_CERTIFICATES = "oauth.ssl.truststore.certificates";
+
+    /** The name of 'oauth.ssl.truststore.password' config option  */
+
     public static final String OAUTH_SSL_TRUSTSTORE_PASSWORD = "oauth.ssl.truststore.password";
+
+    /** The name of 'oauth.ssl.truststore.type' config option  */
     public static final String OAUTH_SSL_TRUSTSTORE_TYPE = "oauth.ssl.truststore.type";
+
+    /** The name of 'oauth.ssl.secure.random.implementation' config option  */
     public static final String OAUTH_SSL_SECURE_RANDOM_IMPLEMENTATION = "oauth.ssl.secure.random.implementation";
+
+    /** The name of 'oauth.ssl.endpoint.identification.algorithm' config option  */
     public static final String OAUTH_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM = "oauth.ssl.endpoint.identification.algorithm";
+
+    /** The name of 'oauth.access.token.is.jwt' config option */
     public static final String OAUTH_ACCESS_TOKEN_IS_JWT = "oauth.access.token.is.jwt";
+
+    /** The name of 'oauth.connect.timeout.seconds' config option  */
     public static final String OAUTH_CONNECT_TIMEOUT_SECONDS = "oauth.connect.timeout.seconds";
+
+    /** The name of 'oauth.read.timeout.seconds' config option  */
     public static final String OAUTH_READ_TIMEOUT_SECONDS = "oauth.read.timeout.seconds";
+
+    /** The name of 'oauth.http.retries' config option  */
     public static final String OAUTH_HTTP_RETRIES = "oauth.http.retries";
+
+    /** The name of 'oauth.http.retry.pause.millis' config option  */
     public static final String OAUTH_HTTP_RETRY_PAUSE_MILLIS = "oauth.http.retry.pause.millis";
+
+    /** The name of 'oauth.config.id' config option  */
     public static final String OAUTH_CONFIG_ID = "oauth.config.id";
+
+    /** The name of 'oauth.enable.metrics' config option  */
     public static final String OAUTH_ENABLE_METRICS = "oauth.enable.metrics";
 
+    /** The name of 'oauth.tokens.not.jwt' config option  */
     @Deprecated
     public static final String OAUTH_TOKENS_NOT_JWT = "oauth.tokens.not.jwt";
 
@@ -191,6 +235,12 @@ public class Config {
         }
     }
 
+    /**
+     * Helper method the test if some boolean config option is set to 'true' or 'false'
+     *
+     * @param result The configured value of the option as String
+     * @return The boolean value of the option
+     */
     public static boolean isTrue(String result) {
         String val = result.toLowerCase(Locale.ENGLISH);
         if (val.equals("true") || val.equals("yes") || val.equals("y") || val.equals("1")) {
@@ -209,7 +259,7 @@ public class Config {
      *
      * @param key   A key of a property which should be converted to environment variable name
      *
-     * @return  A name whihc should be used for environment variable
+     * @return  A name which should be used for environment variable
      */
     public static String toEnvName(String key) {
         return key.toUpperCase(Locale.ENGLISH).replace('-', '_').replace('.', '_');

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/ConfigException.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/ConfigException.java
@@ -4,12 +4,26 @@
  */
 package io.strimzi.kafka.oauth.common;
 
+/**
+ * The exception used to signal a configuration error
+ */
 public class ConfigException extends RuntimeException {
 
+    /**
+     * Create a new instance with the specified error message
+     *
+     * @param message The error message
+     */
     public ConfigException(String message) {
         super(message);
     }
 
+    /**
+     * Create a new instance with the specified error message, and a cause
+     *
+     * @param message The error message
+     * @param cause The exception cause
+     */
     public ConfigException(String message, Throwable cause) {
         super(message, cause);
     }

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/ConfigProperties.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/ConfigProperties.java
@@ -6,11 +6,22 @@ package io.strimzi.kafka.oauth.common;
 
 import java.util.Properties;
 
+/**
+ * A helper class to apply configuration override mechanism to a <code>java.util.Properties</code> object.
+ *
+ * See {@link Config#getValue(String, String)}.
+ */
 public class ConfigProperties {
 
     private final Properties defaults;
     private final Config config;
 
+    /**
+     * Construct a new instance for existing <code>java.util.Properties</code> object
+     *
+     * @param defaults A <code>java.util.Properties</code> object that serves as the source of keys, and the final fallback
+     *                 source for values if no override is found for a config option
+     */
     public ConfigProperties(Properties defaults) {
         Properties p = new Properties();
         p.putAll(defaults);
@@ -18,6 +29,13 @@ public class ConfigProperties {
         config = new Config(defaults);
     }
 
+    /**
+     * Apply the config override mechanism to all the keys in <code>java.util.Properties</code> object used to initialise
+     * this <code>ConfigProperties</code> storing the resolved configuration values to the passed destination object.
+     *
+     * @param destination The destination <code>java.util.Properties</code> object
+     * @return The passed destination object
+     */
     public Properties resolveTo(Properties destination) {
         for (Object key: defaults.keySet()) {
             destination.setProperty(key.toString(), config.getValue(key.toString()));
@@ -25,6 +43,13 @@ public class ConfigProperties {
         return destination;
     }
 
+    /**
+     * Apply the config override mechanism to all the keys in the passed <code>java.util.Properties</code> object using it
+     * as the final fallback for value resolution. The resolved config values are set as System properties.
+     *
+     * @param defaults A <code>java.util.Properties</code> object that serves as the source of keys, and the final fallback
+     *                 source for values if no override is found for a config option
+     */
     public static void resolveAndExportToSystemProperties(Properties defaults) {
         Properties p = new ConfigProperties(defaults).resolveTo(new Properties());
         for (Object key: p.keySet()) {
@@ -32,6 +57,15 @@ public class ConfigProperties {
         }
     }
 
+    /**
+     * Apply the config override mechanism to all the keys in <code>java.util.Properties</code> object passed as defaults,
+     * storing the resolved configuration values into a new <code>java.util.Properties</code> object that is returned as a result.
+     *
+     * @param defaults A <code>java.util.Properties</code> object that serves as the source of keys, and the final fallback
+     *                 source for values if no override is found for a config option
+     *
+     * @return New <code>java.util.Properties</code> object with resolved configuration values
+     */
     public static Properties resolve(Properties defaults) {
         return new ConfigProperties(defaults).resolveTo(new Properties());
     }

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/ConfigUtil.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/ConfigUtil.java
@@ -11,10 +11,19 @@ import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLSocketFactory;
 import java.util.Properties;
 
+/**
+ * The helper class with methods used in multiple places.
+ */
 public class ConfigUtil {
 
     private static final Logger log = LoggerFactory.getLogger(ConfigUtil.class);
 
+    /**
+     * Create the <code>javax.net.ssl.SSLSocketFactory</code> from configuration in the passed <code>Config</code> object.
+     *
+     * @param config The Config object containing the configuration
+     * @return The <code>javax.net.ssl.SSLSocketFactory</code> based on the passed configuration
+     */
     public static SSLSocketFactory createSSLFactory(Config config) {
         String truststore = config.getValue(Config.OAUTH_SSL_TRUSTSTORE_LOCATION);
         String truststoreData = config.getValue(Config.OAUTH_SSL_TRUSTSTORE_CERTIFICATES);
@@ -25,6 +34,12 @@ public class ConfigUtil {
         return SSLUtil.createSSLFactory(truststore, truststoreData, password, type, rnd);
     }
 
+    /**
+     * Create the HostnameVerifier from configuration in the passed <code>Config</code> object.
+     *
+     * @param config The Config object containing the configuration
+     * @return The <code>javax.net.ssl.HostnameVerifier</code> based on the passed configuration
+     */
     public static HostnameVerifier createHostnameVerifier(Config config) {
         String hostCheck = config.getValue(Config.OAUTH_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM, "HTTPS");
 
@@ -32,20 +47,47 @@ public class ConfigUtil {
         return "".equals(hostCheck) ? SSLUtil.createAnyHostHostnameVerifier() : null;
     }
 
+    /**
+     * Helper method that puts the key-value pair into the passed <code>java.util.Properties</code> only if
+     * the value is not null.
+     *
+     * @param p Destination Properties object
+     * @param key The key
+     * @param value The value
+     */
     public static void putIfNotNull(Properties p, String key, Object value) {
         if (value != null) {
             p.put(key, value);
         }
     }
 
+    /**
+     * Resolve the value of the <code>Config.OAUTH_CONNECT_TIMEOUT_SECONDS</code> configuration
+     *
+     * @param config the Config object
+     * @return Configured value as int
+     */
     public static int getConnectTimeout(Config config) {
         return getTimeout(config, Config.OAUTH_CONNECT_TIMEOUT_SECONDS);
     }
 
+    /**
+     * Resolve the value of the <code>Config.OAUTH_READ_TIMEOUT_SECONDS</code> configuration
+     *
+     * @param config the Config object
+     * @return Configured value as int
+     */
     public static int getReadTimeout(Config config) {
         return getTimeout(config, Config.OAUTH_READ_TIMEOUT_SECONDS);
     }
 
+    /**
+     * Resolve the configuration value for the key as a timeout in seconds with the default value of 60
+     *
+     * @param c the Config object
+     * @param key the configuration key
+     * @return Configured value as int
+     */
     public static int getTimeout(Config c, String key) {
         int timeout = c.getValueAsInt(key, 60);
         if (timeout <= 0) {
@@ -55,6 +97,15 @@ public class ConfigUtil {
         return timeout;
     }
 
+    /**
+     * Resolve the configuration value for the key as a timeout in seconds with the default value of 60.
+     * If the key is not present, fallback to using a secondary key.
+     *
+     * @param c the Config object
+     * @param key the configuration key
+     * @param fallbackKey the fallback key
+     * @return Configured value as int
+     */
     public static int getTimeoutConfigWithFallbackLookup(Config c, String key, String fallbackKey) {
         String result = c.getValue(key);
         if (result == null) {
@@ -63,6 +114,15 @@ public class ConfigUtil {
         return getTimeout(c, key);
     }
 
+    /**
+     * Resolve the configuration value for the key as a string.
+     * If the key is not present, fallback to using a secondary key.
+     *
+     * @param c the Config object
+     * @param key the configuration key
+     * @param fallbackKey the fallback key
+     * @return Configured value as String
+     */
     public static String getConfigWithFallbackLookup(Config c, String key, String fallbackKey) {
         String result = c.getValue(key);
         if (result == null) {

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/DeprecationUtil.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/DeprecationUtil.java
@@ -6,8 +6,20 @@ package io.strimzi.kafka.oauth.common;
 
 import org.slf4j.Logger;
 
+/**
+ * Helper class with methods to handle deprecated config options
+ */
 public class DeprecationUtil {
 
+    /**
+     * Get 'oauth.access.token.is.jwt' config option with fallback to the deprecated 'oauth.tokens.not.jwt'
+     *
+     * @param config a Config instance
+     * @param log Logger to use to log warnings
+     * @param errorPrefix Error message prefix that becomes part of ConfigException#getMessage() if both current,
+     *                    and deprecated keys are configured
+     * @return The value of the config option as a boolean
+     */
     @SuppressWarnings("deprecation")
     public static boolean isAccessTokenJwt(Config config, Logger log, String errorPrefix) {
         String legacy = config.getValue(Config.OAUTH_TOKENS_NOT_JWT);

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/HttpException.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/HttpException.java
@@ -6,13 +6,41 @@ package io.strimzi.kafka.oauth.common;
 
 import java.net.URI;
 
+/**
+ * An exception that signals an error status while performing a HTTP request.
+ * When this exception is encountered it means the client successfully established the connection with the server,
+ * established any secure (https) session, and received an HTTP response from the server.
+ */
 public class HttpException extends RuntimeException {
 
+    /**
+     * HTTP method
+     */
     private final String method;
+
+    /**
+     * Target URL
+     */
     private final URI uri;
+
+    /**
+     * HTTP Response status
+     */
     private final int status;
+
+    /**
+     * An HTTP response body
+     */
     private final String response;
 
+    /**
+     * Create a new instance
+     *
+     * @param method An HTTP method used
+     * @param uri A target url
+     * @param status The HTTP response status code
+     * @param response The HTTP response body
+     */
     public HttpException(String method, URI uri, int status, String response) {
         super(method + " request to " + uri + " failed with status " + status + ": " + response);
 
@@ -22,18 +50,38 @@ public class HttpException extends RuntimeException {
         this.response = response;
     }
 
+    /**
+     * Get the HTTP method
+     *
+     * @return The HTTP method
+     */
     public String getMethod() {
         return method;
     }
 
+    /**
+     * Get the target url
+     *
+     * @return A URI object for the url
+     */
     public URI getUri() {
         return uri;
     }
 
+    /**
+     * Get the HTTP status
+     *
+     * @return A status code as int
+     */
     public int getStatus() {
         return status;
     }
 
+    /**
+     * Get the HTTP response body
+     *
+     * @return A response body
+     */
     public String getResponse() {
         return response;
     }

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/HttpUtil.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/HttpUtil.java
@@ -109,74 +109,313 @@ public class HttpUtil {
         throw new ExecutionException(msg, exception);
     }
 
+    /**
+     * Perform HTTP GET request and return the response in the specified type.
+     *
+     * @param uri The target url
+     * @param authorization The Authorization header value
+     * @param responseType The type to which to convert the response (String or one of the Jackson Mapper types)
+     * @return The response as specified by the <code>responseType</code>.
+     * @param <T> Generic type of the <code>responseType</code>
+     * @throws IOException A connection, timeout, or network exception that occurs while performing the request
+     * @throws HttpException A runtime exception when an HTTP response status signals a failed request
+     */
     public static <T> T get(URI uri, String authorization, Class<T> responseType) throws IOException {
         return request(uri, null, null, authorization, null, null, responseType);
     }
 
+    /**
+     * Perform HTTP GET request and return the response in the specified type.
+     *
+     * @param uri The target url
+     * @param socketFactory Socket factory to use with https:// url
+     * @param authorization The Authorization header value
+     * @param responseType The type to which to convert the response (String or one of the Jackson Mapper types)
+     * @return The response as specified by the <code>responseType</code>.
+     * @param <T> Generic type of the <code>responseType</code>
+     * @throws IOException A connection, timeout, or network exception that occurs while performing the request
+     * @throws HttpException A runtime exception when an HTTP response status signals a failed request
+     */
     public static <T> T get(URI uri, SSLSocketFactory socketFactory, String authorization, Class<T> responseType) throws IOException {
         return request(uri, socketFactory, null, authorization, null, null, responseType);
     }
 
+    /**
+     * Perform HTTP GET request and return the response in the specified type.
+     *
+     * @param uri The target url
+     * @param socketFactory Socket factory to use with https:// url
+     * @param hostnameVerifier HostnameVerifier to use with https:// url
+     * @param authorization The Authorization header value
+     * @param responseType The type to which to convert the response (String or one of the Jackson Mapper types)
+     * @return The response as specified by the <code>responseType</code>.
+     * @param <T> Generic type of the <code>responseType</code>
+     * @throws IOException A connection, timeout, or network exception that occurs while performing the request
+     * @throws HttpException A runtime exception when an HTTP response status signals a failed request
+     */
     public static <T> T get(URI uri, SSLSocketFactory socketFactory, HostnameVerifier hostnameVerifier, String authorization, Class<T> responseType) throws IOException {
         return request(uri, socketFactory, hostnameVerifier, authorization, null, null, responseType);
     }
 
+    /**
+     * Perform HTTP GET request and return the response in the specified type.
+     *
+     * @param uri The target url
+     * @param socketFactory Socket factory to use with https:// url
+     * @param hostnameVerifier HostnameVerifier to use with https:// url
+     * @param authorization The Authorization header value
+     * @param responseType The type to which to convert the response (String or one of the Jackson Mapper types)
+     * @param connectTimeout Connect timeout in seconds
+     * @param readTimeout Read timeout in seconds
+     * @return The response as specified by the <code>responseType</code>.
+     * @param <T> Generic type of the <code>responseType</code>
+     * @throws IOException A connection, timeout, or network exception that occurs while performing the request
+     * @throws HttpException A runtime exception when an HTTP response status signals a failed request
+     */
     public static <T> T get(URI uri, SSLSocketFactory socketFactory, HostnameVerifier hostnameVerifier, String authorization, Class<T> responseType, int connectTimeout, int readTimeout) throws IOException {
         return request(uri, "GET", socketFactory, hostnameVerifier, authorization, null, null, responseType, connectTimeout, readTimeout);
     }
 
+    /**
+     * Perform HTTP POST request and return the response in the specified type.
+     *
+     * @param uri The target url
+     * @param authorization The Authorization header value
+     * @param contentType MIME type of the request body
+     * @param body The request body
+     * @param responseType The type to which to convert the response (String or one of the Jackson Mapper types)
+     * @return The response as specified by the <code>responseType</code>.
+     * @param <T> Generic type of the <code>responseType</code>
+     * @throws IOException A connection, timeout, or network exception that occurs while performing the request
+     * @throws HttpException A runtime exception when an HTTP response status signals a failed request
+     */
     public static <T> T post(URI uri, String authorization, String contentType, String body, Class<T> responseType) throws IOException {
         return request(uri, null, null, authorization, contentType, body, responseType);
     }
 
+    /**
+     * Perform HTTP POST request and return the response in the specified type.
+     *
+     * @param uri The target url
+     * @param socketFactory Socket factory to use with https:// url
+     * @param authorization The Authorization header value
+     * @param contentType MIME type of the request body
+     * @param body The request body
+     * @param responseType The type to which to convert the response (String or one of the Jackson Mapper types)
+     * @return The response as specified by the <code>responseType</code>.
+     * @param <T> Generic type of the <code>responseType</code>
+     * @throws IOException A connection, timeout, or network exception that occurs while performing the request
+     * @throws HttpException A runtime exception when an HTTP response status signals a failed request
+     */
     public static <T> T post(URI uri, SSLSocketFactory socketFactory, String authorization, String contentType, String body, Class<T> responseType) throws IOException {
         return request(uri, socketFactory, null, authorization, contentType, body, responseType);
     }
 
+    /**
+     * Perform HTTP POST request and return the response in the specified type.
+     *
+     * @param uri The target url
+     * @param socketFactory Socket factory to use with https:// url
+     * @param verifier HostnameVerifier to use with https:// url
+     * @param authorization The Authorization header value
+     * @param contentType MIME type of the request body
+     * @param body The request body
+     * @param responseType The type to which to convert the response (String or one of the Jackson Mapper types)
+     * @return The response as specified by the <code>responseType</code>.
+     * @param <T> Generic type of the <code>responseType</code>
+     * @throws IOException A connection, timeout, or network exception that occurs while performing the request
+     * @throws HttpException A runtime exception when an HTTP response status signals a failed request
+     */
     public static <T> T post(URI uri, SSLSocketFactory socketFactory, HostnameVerifier verifier, String authorization, String contentType, String body, Class<T> responseType) throws IOException {
         return request(uri, socketFactory, verifier, authorization, contentType, body, responseType);
     }
 
+    /**
+     * Perform HTTP POST request and return the response in the specified type.
+     *
+     * @param uri The target url
+     * @param socketFactory Socket factory to use with https:// url
+     * @param verifier HostnameVerifier to use with https:// url
+     * @param authorization The Authorization header value
+     * @param contentType MIME type of the request body
+     * @param body The request body
+     * @param responseType The type to which to convert the response (String or one of the Jackson Mapper types)
+     * @param connectTimeout Connect timeout in seconds
+     * @param readTimeout Read timeout in seconds
+     * @return The response as specified by the <code>responseType</code>.
+     * @param <T> Generic type of the <code>responseType</code>
+     * @throws IOException A connection, timeout, or network exception that occurs while performing the request
+     * @throws HttpException A runtime exception when an HTTP response status signals a failed request
+     */
     public static <T> T post(URI uri, SSLSocketFactory socketFactory, HostnameVerifier verifier, String authorization, String contentType, String body, Class<T> responseType, int connectTimeout, int readTimeout) throws IOException {
         return request(uri, "POST", socketFactory, verifier, authorization, contentType, body, responseType, connectTimeout, readTimeout);
     }
 
+    /**
+     * Perform HTTP PUT request
+     *
+     * @param uri The target url
+     * @param authorization The Authorization header value
+     * @param contentType MIME type of the request body
+     * @param body The request body
+     * @throws IOException A connection, timeout, or network exception that occurs while performing the request
+     * @throws HttpException A runtime exception when an HTTP response status signals a failed request
+     */
     public static void put(URI uri, String authorization, String contentType, String body) throws IOException {
         request(uri, null, null, authorization, contentType, body, null);
     }
 
+    /**
+     * Perform HTTP PUT request
+     *
+     * @param uri The target url
+     * @param socketFactory Socket factory to use with https:// url
+     * @param authorization The Authorization header value
+     * @param contentType MIME type of the request body
+     * @param body The request body
+     * @throws IOException A connection, timeout, or network exception that occurs while performing the request
+     * @throws HttpException A runtime exception when an HTTP response status signals a failed request
+     */
     public static void put(URI uri, SSLSocketFactory socketFactory, String authorization, String contentType, String body) throws IOException {
         request(uri, socketFactory, null, authorization, contentType, body, null);
     }
 
+    /**
+     * Perform HTTP PUT request
+     *
+     * @param uri The target url
+     * @param socketFactory Socket factory to use with https:// url
+     * @param verifier HostnameVerifier to use with https:// url
+     * @param authorization The Authorization header value
+     * @param contentType MIME type of the request body
+     * @param body The request body
+     * @throws IOException A connection, timeout, or network exception that occurs while performing the request
+     * @throws HttpException A runtime exception when an HTTP response status signals a failed request
+     */
     public static void put(URI uri, SSLSocketFactory socketFactory, HostnameVerifier verifier, String authorization, String contentType, String body) throws IOException {
         request(uri, socketFactory, verifier, authorization, contentType, body, null);
     }
 
+    /**
+     * Perform HTTP PUT request
+     *
+     * @param uri The target url
+     * @param socketFactory Socket factory to use with https:// url
+     * @param verifier HostnameVerifier to use with https:// url
+     * @param authorization The Authorization header value
+     * @param contentType MIME type of the request body
+     * @param body The request body
+     * @param connectTimeout Connect timeout in seconds
+     * @param readTimeout Read timeout in seconds
+     * @throws IOException A connection, timeout, or network exception that occurs while performing the request
+     * @throws HttpException A runtime exception when an HTTP response status signals a failed request
+     */
     public static void put(URI uri, SSLSocketFactory socketFactory, HostnameVerifier verifier, String authorization, String contentType, String body, int connectTimeout, int readTimeout) throws IOException {
         request(uri, "PUT", socketFactory, verifier, authorization, contentType, body, null, connectTimeout, readTimeout);
     }
 
+    /**
+     * Perform HTTP DELETE request using the default connect and read timeouts (60 seconds).
+     *
+     * @param uri The target url
+     * @param authorization The Authorization header value
+     * @throws IOException A connection, timeout, or network exception that occurs while performing the request
+     * @throws HttpException A runtime exception when an HTTP response status signals a failed request
+     */
     public static void delete(URI uri, String authorization) throws IOException {
         request(uri, "DELETE", null, null, authorization, null, null, null, DEFAULT_CONNECT_TIMEOUT, DEFAULT_READ_TIMEOUT);
     }
 
+    /**
+     * Perform HTTP DELETE request using the default connect and read timeouts (60 seconds).
+     *
+     * @param uri The target url
+     * @param socketFactory Socket factory to use with https:// url
+     * @param verifier HostnameVerifier to use with https:// url
+     * @param authorization The Authorization header value
+     * @throws IOException A connection, timeout, or network exception that occurs while performing the request
+     * @throws HttpException A runtime exception when an HTTP response status signals a failed request
+     */
     public static void delete(URI uri, SSLSocketFactory socketFactory, HostnameVerifier verifier, String authorization) throws IOException {
         request(uri, "DELETE", socketFactory, verifier, authorization, null, null, null, DEFAULT_CONNECT_TIMEOUT, DEFAULT_READ_TIMEOUT);
     }
 
+    /**
+     * Perform HTTP DELETE request
+     *
+     * @param uri The target url
+     * @param socketFactory Socket factory to use with https:// url
+     * @param verifier HostnameVerifier to use with https:// url
+     * @param authorization The Authorization header value
+     * @param connectTimeout Connect timeout in seconds
+     * @param readTimeout Read timeout in seconds
+     * @throws IOException A connection, timeout, or network exception that occurs while performing the request
+     * @throws HttpException A runtime exception when an HTTP response status signals a failed request
+     */
     public static void delete(URI uri, SSLSocketFactory socketFactory, HostnameVerifier verifier, String authorization, int connectTimeout, int readTimeout) throws IOException {
         request(uri, "DELETE", socketFactory, verifier, authorization, null, null, null, connectTimeout, readTimeout);
     }
 
+    /**
+     * Perform an HTTP request, auto-detecting a method, and using the default connect and read timeouts (60 seconds)..
+     * If body is null the HTTP method GET is used.
+     * If responseType is null the HTTP method PUT is used.
+     * Otherwise, the HTTP method POST is used.
+     *
+     * @param uri The target url
+     * @param socketFactory Socket factory to use with https:// url
+     * @param hostnameVerifier HostnameVerifier to use with https:// url
+     * @param authorization The Authorization header value
+     * @param contentType MIME type of the request body
+     * @param body The request body
+     * @param responseType The type to which to convert the response (String or one of the Jackson Mapper types)
+     * @return The response as specified by the <code>responseType</code>.
+     * @param <T> Generic type of the <code>responseType</code>
+     * @throws IOException A connection, timeout, or network exception that occurs while performing the request
+     * @throws HttpException A runtime exception when an HTTP response status signals a failed request
+     */
     public static <T> T request(URI uri, SSLSocketFactory socketFactory, HostnameVerifier hostnameVerifier, String authorization, String contentType, String body, Class<T> responseType) throws IOException {
         return request(uri, null, socketFactory, hostnameVerifier, authorization, contentType, body, responseType, DEFAULT_CONNECT_TIMEOUT, DEFAULT_READ_TIMEOUT);
     }
 
+    /**
+     * Perform an HTTP request using the default connect and read timeouts (60 seconds).
+     *
+     * @param uri The target url
+     * @param method The HTTP request method
+     * @param socketFactory Socket factory to use with https:// url
+     * @param hostnameVerifier HostnameVerifier to use with https:// url
+     * @param authorization The Authorization header value
+     * @param contentType MIME type of the request body
+     * @param body The request body
+     * @param responseType The type to which to convert the response (String or one of the Jackson Mapper types)
+     * @return The response as specified by the <code>responseType</code>.
+     * @param <T> Generic type of the <code>responseType</code>
+     * @throws IOException A connection, timeout, or network exception that occurs while performing the request
+     * @throws HttpException A runtime exception when an HTTP response status signals a failed request
+     */
     public static <T> T request(URI uri, String method, SSLSocketFactory socketFactory, HostnameVerifier hostnameVerifier, String authorization, String contentType, String body, Class<T> responseType) throws IOException {
         return request(uri, method, socketFactory, hostnameVerifier, authorization, contentType, body, responseType, DEFAULT_CONNECT_TIMEOUT, DEFAULT_READ_TIMEOUT);
     }
 
+    /**
+     * Perform an HTTP request using the default connect and read timeouts (60 seconds).
+     *
+     * @param uri The target url
+     * @param method The HTTP request method
+     * @param socketFactory Socket factory to use with https:// url
+     * @param hostnameVerifier HostnameVerifier to use with https:// url
+     * @param authorization The Authorization header value
+     * @param contentType MIME type of the request body
+     * @param body The request body
+     * @param responseType The type to which to convert the response (String or one of the Jackson Mapper types)
+     * @param connectTimeout Connect timeout in seconds
+     * @param readTimeout Read timeout in seconds
+     * @return The response as specified by the <code>responseType</code>.
+     * @param <T> Generic type of the <code>responseType</code>
+     * @throws IOException A connection, timeout, or network exception that occurs while performing the request
+     * @throws HttpException A runtime exception when an HTTP response status signals a failed request
+     */
     // Suppressed because of Spotbugs Java 11 bug - https://github.com/spotbugs/spotbugs/issues/756
     @SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE")
     public static <T> T request(URI uri, String method, SSLSocketFactory socketFactory, HostnameVerifier hostnameVerifier, String authorization,

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/IOUtil.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/IOUtil.java
@@ -12,10 +12,20 @@ import java.nio.charset.StandardCharsets;
 import java.util.Random;
 import java.util.zip.CRC32;
 
+/**
+ * A helper class that contains commonly used methods for I/O operations
+ */
 public class IOUtil {
 
     private static final Random RANDOM = new Random();
 
+    /**
+     * Copy the content of specified InputStream into the specified OutputStream
+     *
+     * @param input The input stream to read from
+     * @param output The output stream to write to
+     * @throws IOException an exception if the copy operation fails
+     */
     public static void copy(InputStream input, OutputStream output) throws IOException {
         byte[] buf = new byte[4096];
 
@@ -31,10 +41,21 @@ public class IOUtil {
         }
     }
 
+    /**
+     * Generate a random 8 character string of hexadecimal digits
+     *
+     * @return a hexadecimal String of length 8
+     */
     public static String randomHexString() {
         return randomHexString(8);
     }
 
+    /**
+     * Generate a random string of hexadecimal digits of the specified length
+     *
+     * @param length The length of the resulting string
+     * @return a hexadecimal String of the specified length
+     */
     public static String randomHexString(int length) {
         StringBuilder sb = new StringBuilder();
         for (int i = 0; i < length; i++) {
@@ -43,6 +64,12 @@ public class IOUtil {
         return sb.toString();
     }
 
+    /**
+     * Convert a byte array into a hexadecimal string
+     *
+     * @param bytes A byte array
+     * @return a hexadecimal string
+     */
     public static String asHexString(byte[] bytes) {
         StringBuilder sb = new StringBuilder(2 * bytes.length);
         for (byte b : bytes) {
@@ -55,6 +82,12 @@ public class IOUtil {
         return sb.toString();
     }
 
+    /**
+     * Generate a predictable (deterministic) hash string of length 8 for an array of objects
+     *
+     * @param args The objects to take as input for the calculation
+     * @return a hash string of length 8
+     */
     public static String hashForObjects(Object... args) {
         StringBuilder sb = new StringBuilder();
         for (Object o: args) {
@@ -70,9 +103,16 @@ public class IOUtil {
         }
     }
 
+    /**
+     * Calculate a CRC32 for the specified String
+     *
+     * @param content The input string
+     * @return CRC32 as long value
+     */
     public static long crc32(String content) {
         CRC32 crc = new CRC32();
-        crc.update(content.getBytes(StandardCharsets.UTF_8));
+        byte[] bytes = content.getBytes(StandardCharsets.UTF_8);
+        crc.update(bytes, 0, bytes.length);
         return crc.getValue();
     }
 }

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/JSONUtil.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/JSONUtil.java
@@ -18,14 +18,34 @@ import java.util.List;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+/**
+ * Helper methods to work with JSON
+ */
 public class JSONUtil {
 
+    /**
+     * A Jackson Databind <code>ObjectMapper</code> singleton
+     */
     public static final ObjectMapper MAPPER = new ObjectMapper();
 
+    /**
+     * Create a new ObjectNode
+     *
+     * @return A new ObjectNode
+     */
     public static ObjectNode newObjectNode() {
         return new ObjectNode(MAPPER.getNodeFactory());
     }
 
+    /**
+     * Parse JSON from <code>InputStream</code> into a specified type
+     *
+     * @param is An <code>InputStream</code> to read JSON from
+     * @param clazz A class representing the type to return (e.g. <code>JsonNode</code>, <code>ObjectNode</code>, <code>ArrayNode</code>, <code>String</code>)
+     * @return Parsed JSON as an object
+     * @param <T> Generic type representing a return type
+     * @throws IOException If an error occurs while reading or parsing the input
+     */
     public static <T> T readJSON(InputStream is, Class<T> clazz) throws IOException {
         if (clazz == String.class) {
             // just read and convert to UTF-8 String
@@ -36,12 +56,21 @@ public class JSONUtil {
         return MAPPER.readValue(is, clazz);
     }
 
+    /**
+     * Parse JSON from String into a specified type
+     *
+     * @param jsonString JSON as a String
+     * @param clazz A class representing the type to return (e.g. <code>JsonNode</code>, <code>ObjectNode</code>, <code>ArrayNode</code>, <code>String</code>)
+     * @return Parsed JSON as an object
+     * @param <T> Generic type representing a return type
+     * @throws IOException If an error occurs while reading or parsing the input
+     */
     public static <T> T readJSON(String jsonString, Class<T> clazz) throws IOException {
         return MAPPER.readValue(jsonString, clazz);
     }
 
     /**
-     * Convert object to JsonNode
+     * Convert object to <code>JsonNode</code>
      *
      * @param value Json-serializable object
      * @return Object as JsonNode
@@ -90,10 +119,10 @@ public class JSONUtil {
 
     /**
      * This method takes a JsonNode representing an array, or a string, and converts it into a List of String items.
-     *
+     * <p>
      * If the passed node is a TextNode, the text is parsed into a list of items by using ' ' (space) as a delimiter.
      * The resulting list can contain empty strings if two delimiters are present next to one another.
-     *
+     * <p>
      * If the JsonNode is neither an ArrayNode, nor a TextNode an IllegalArgumentException is thrown.
      *
      * @param arrayOrString A JsonNode to convert into a list of String
@@ -105,10 +134,10 @@ public class JSONUtil {
 
     /**
      * This method takes a JsonNode representing an array, or a string, and converts it into a List of String items.
-     *
+     * <p>
      * The {@code delimiter} parameter is only used if the passed node is a TextNode. It is used to parse the node content
      * as a list of strings. The resulting list can contain empty strings if two delimiters are present next to one another.
-     *
+     * <p>
      * If the JsonNode is neither an ArrayNode, nor a TextNode an IllegalArgumentException is thrown.
      *
      * @param arrayOrString A JsonNode to convert into a list of String

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/LogUtil.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/LogUtil.java
@@ -4,6 +4,9 @@
  */
 package io.strimzi.kafka.oauth.common;
 
+/**
+ * The helper class with logging helper methods used in multiple places
+ */
 public class LogUtil {
 
     /**

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/NimbusPayloadTransformer.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/NimbusPayloadTransformer.java
@@ -8,8 +8,17 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.nimbusds.jose.Payload;
 import com.nimbusds.jose.PayloadTransformer;
 
+/**
+ * An interface to convert from Nimbus Jose JWT <code>Payload</code> object to Jackson Databind <code>JsonNode</code> object
+ */
 public class NimbusPayloadTransformer implements PayloadTransformer<JsonNode> {
 
+    /**
+     * Convert a <code>Payload</code> object to <code>JsonNode</code>
+     *
+     * @param payload The payload object
+     * @return The <code>JsonNode</code>
+     */
     @Override
     public JsonNode transform(Payload payload) {
         return JSONUtil.asJson(payload.toJSONObject());

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/PrincipalExtractor.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/PrincipalExtractor.java
@@ -8,20 +8,43 @@ import com.fasterxml.jackson.databind.JsonNode;
 
 import static io.strimzi.kafka.oauth.common.JSONUtil.getClaimFromJWT;
 
+/**
+ * An object with logic for extracting a principal name (i.e. a user id) from a JWT token.
+ *
+ * First a claim configured as <code>usernameClaim</code> is looked up.
+ * If not found the claim configured as <code>fallbackUsernameClaim</code> is looked up. If that one is found and if
+ * the <code>fallbackUsernamePrefix</code> is configured prefix the found value with the prefix, otherwise not.
+ */
 public class PrincipalExtractor {
 
     private String usernameClaim;
     private String fallbackUsernameClaim;
     private String fallbackUsernamePrefix;
 
+    /**
+     * Create a new instance
+     */
     public PrincipalExtractor() {}
 
+    /**
+     * Create a new instance
+     *
+     * @param usernameClaim Attribute name for an attribute containing the user id to lookup first
+     * @param fallbackUsernameClaim Attribute name for an attribute containg the user id to lookup as a fallback
+     * @param fallbackUsernamePrefix A prefix to prepend to the value of the fallback attribute value if set
+     */
     public PrincipalExtractor(String usernameClaim, String fallbackUsernameClaim, String fallbackUsernamePrefix) {
         this.usernameClaim = usernameClaim;
         this.fallbackUsernameClaim = fallbackUsernameClaim;
         this.fallbackUsernamePrefix = fallbackUsernamePrefix;
     }
 
+    /**
+     * Get the principal name
+     *
+     * @param json JWT token as a <code>JsonNode</code> object
+     * @return Principal name
+     */
     public String getPrincipal(JsonNode json) {
         String result;
 
@@ -42,6 +65,12 @@ public class PrincipalExtractor {
         return null;
     }
 
+    /**
+     * Get the value of <code>sub</code> claim
+     *
+     * @param json JWT token as a <code>JsonNode</code> object
+     * @return The value of <code>sub</code> attribute
+     */
     public String getSub(JsonNode json) {
         return getClaimFromJWT(json, "sub");
     }
@@ -51,6 +80,11 @@ public class PrincipalExtractor {
         return "PrincipalExtractor {usernameClaim: " + usernameClaim  + ", fallbackUsernameClaim: " + fallbackUsernameClaim + ", fallbackUsernamePrefix: " + fallbackUsernamePrefix + "}";
     }
 
+    /**
+     * Return true if any of the configuration options is configured
+     *
+     * @return True if any of the constructor parameters is set
+     */
     public boolean isConfigured() {
         return usernameClaim != null || fallbackUsernameClaim != null || fallbackUsernamePrefix != null;
     }

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/SSLUtil.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/SSLUtil.java
@@ -27,8 +27,21 @@ import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.util.Locale;
 
+/**
+ * A class containing helper methods that deal with SSL / TLS
+ */
 public class SSLUtil {
 
+    /**
+     * Create a new SSL Factory from given configuration arguments
+     *
+     * @param truststore A path to truststore file (used by default)
+     * @param truststoreData A PEM string containing a chain of X.509 certificates. Used if <code>type</code> is set to <code>pem</code>
+     * @param password A password for the truststore file (optional)
+     * @param type A truststore type (e.g. PKCS12, JKS, or PEM) (optional)
+     * @param rnd A random number generator to use (optional)
+     * @return A new SSLSocketFactory instance
+     */
     @SuppressFBWarnings(value = "REC_CATCH_EXCEPTION",
             justification = "Avoid enumerating all checked exceptions in try-with-resources")
     public static SSLSocketFactory createSSLFactory(String truststore, String truststoreData, String password, String type, String rnd) {
@@ -100,6 +113,11 @@ public class SSLUtil {
         throw new IllegalStateException("No X509TrustManager on default factory");
     }
 
+    /**
+     * Create a new instance of HostnameVerifier that accepts any hostname
+     *
+     * @return A new HostnameVerifier instance
+     */
     public static HostnameVerifier createAnyHostHostnameVerifier() {
         return (hostname, session) -> true;
     }

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/TimeUtil.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/TimeUtil.java
@@ -8,8 +8,17 @@ import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 
+/**
+ * A helper class containing time functions
+ */
 public class TimeUtil {
 
+    /**
+     * Format time in millis as ISO DateTime UTC
+     *
+     * @param timeMillis time to format
+     * @return Time as a String
+     */
     public static String formatIsoDateTimeUTC(long timeMillis) {
         return LocalDateTime.ofEpochSecond(timeMillis / 1000, 0, ZoneOffset.UTC)
                 .format(DateTimeFormatter.ISO_DATE_TIME);

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/TokenInfo.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/TokenInfo.java
@@ -21,12 +21,33 @@ import java.util.Set;
  */
 public class TokenInfo {
 
+    /**
+     * "scope"
+     */
     public static final String SCOPE = "scope";
+    /**
+     * "iat"
+     */
     public static final String IAT = "iat";
+    /**
+     * "exp"
+     */
     public static final String EXP = "exp";
+    /**
+     * "iss"
+     */
     public static final String ISS = "iss";
+    /**
+     * "typ"
+     */
     public static final String TYP = "typ";
+    /**
+     * "token_type"
+     */
     public static final String TOKEN_TYPE = "token_type";
+    /**
+     * "aud"
+     */
     public static final String AUD = "aud";
 
     private final String token;
@@ -94,10 +115,20 @@ public class TokenInfo {
         scopes = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(parsedScopes)));
     }
 
+    /**
+     * Get raw access token
+     *
+     * @return Access token as String
+     */
     public String token() {
         return token;
     }
 
+    /**
+     * Get scopes for this token
+     *
+     * @return A Set of scopes as strings
+     */
     @SuppressFBWarnings("EI_EXPOSE_REP")
     // See https://spotbugs.readthedocs.io/en/stable/bugDescriptions.html#ei-may-expose-internal-representation-by-returning-reference-to-mutable-object-ei-expose-rep
     public Set<String> scope() {
@@ -105,14 +136,29 @@ public class TokenInfo {
         return scopes;
     }
 
+    /**
+     * Get token expiry time in ISO millis time
+     *
+     * @return Long value representing time
+     */
     public long expiresAtMs() {
         return expiresAt;
     }
 
+    /**
+     * Get a principal (user id) for this token
+     *
+     * @return User id as String
+     */
     public String principal() {
         return principal;
     }
 
+    /**
+     * Get groups for this token
+     *
+     * @return Set of groups as strings
+     */
     @SuppressFBWarnings("EI_EXPOSE_REP")
     // See https://spotbugs.readthedocs.io/en/stable/bugDescriptions.html#ei-may-expose-internal-representation-by-returning-reference-to-mutable-object-ei-expose-rep
     public Set<String> groups() {
@@ -120,6 +166,11 @@ public class TokenInfo {
         return groups;
     }
 
+    /**
+     * Get token creation time ISO millis
+     *
+     * @return Long value representing time
+     */
     public long issuedAtMs() {
         return issuedAt;
     }

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/TokenIntrospection.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/TokenIntrospection.java
@@ -16,10 +16,20 @@ import java.time.format.DateTimeFormatter;
 import static io.strimzi.kafka.oauth.common.LogUtil.mask;
 import static io.strimzi.kafka.oauth.common.TokenInfo.EXP;
 
+/**
+ * A class with methods for introspecting a JWT token
+ */
 public class TokenIntrospection {
 
     private static final NimbusPayloadTransformer TRANSFORMER = new NimbusPayloadTransformer();
 
+    /**
+     * Parse a raw access token, and extract the basic information from it, including user id by using a given {@link PrincipalExtractor}.
+     *
+     * @param token A raw token
+     * @param principalExtractor PrincipalExtractor instance
+     * @return Extracted token information as TokenInfo object
+     */
     public static TokenInfo introspectAccessToken(String token, PrincipalExtractor principalExtractor) {
         JWSObject jws;
         try {
@@ -46,6 +56,12 @@ public class TokenIntrospection {
         }
     }
 
+    /**
+     * Debug log the given raw token by parsing it as JWT and logging its payload section
+     *
+     * @param log Logger to use
+     * @param token A raw token
+     */
     public static void debugLogJWT(Logger log, String token) {
         JWSObject jws;
         try {

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/jsonpath/JsonPathQueryException.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/jsonpath/JsonPathQueryException.java
@@ -5,10 +5,16 @@
 package io.strimzi.kafka.oauth.jsonpath;
 
 /**
- * The exception signalling a syntactic or semantic error during JsonPathQuery or JsonPathFilterQuery parsing
+ * A runtime exception signalling a syntactic or semantic error during JsonPathQuery or JsonPathFilterQuery parsing
  */
 public class JsonPathQueryException extends RuntimeException {
 
+    /**
+     * Create a new instance
+     *
+     * @param message Error message
+     * @param cause The original exception
+     */
     public JsonPathQueryException(String message, Throwable cause) {
         super(message, cause);
     }

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/metrics/AbstractSensorKeyProducer.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/metrics/AbstractSensorKeyProducer.java
@@ -6,11 +6,20 @@ package io.strimzi.kafka.oauth.metrics;
 
 import java.net.URI;
 
+/**
+ * A SensorKeyProducer with logic shared by all SensorKeyProducers
+ */
 public abstract class AbstractSensorKeyProducer implements SensorKeyProducer {
 
     protected final String contextId;
     protected final URI uri;
 
+    /**
+     * The constructor, that requires contexId, and an uri on the authorization server associated with the sensor keys.
+     *
+     * @param contextId A configId or some other label that identifies the specific configuration or environment
+     * @param uri The uri on the authorization server the metrics are associated with
+     */
     public AbstractSensorKeyProducer(String contextId, URI uri) {
 
         if (contextId == null) {

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/metrics/IntrospectHttpSensorKeyProducer.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/metrics/IntrospectHttpSensorKeyProducer.java
@@ -7,12 +7,26 @@ package io.strimzi.kafka.oauth.metrics;
 import java.net.URI;
 import java.util.Map;
 
+/**
+ * A {@link SensorKeyProducer} used for introspect endpoint HTTP metrics
+ */
 public class IntrospectHttpSensorKeyProducer extends AbstractSensorKeyProducer {
 
+    /**
+     * Create a new instance
+     *
+     * @param contextId Context id (e.g. a config id or a label)
+     * @param uri An introspection endpoint url
+     */
     public IntrospectHttpSensorKeyProducer(String contextId, URI uri) {
         super(contextId, uri);
     }
 
+    /**
+     * Generate a <code>SensorKey</code> for metrics about successful HTTP requests
+     *
+     * @return A sensor key
+     */
     @Override
     public SensorKey successKey() {
         Map<String, String> attrs = MetricsUtil.getSensorKeyAttrs(contextId, uri, "introspect");
@@ -20,6 +34,12 @@ public class IntrospectHttpSensorKeyProducer extends AbstractSensorKeyProducer {
         return SensorKey.of("http_requests", attrs);
     }
 
+    /**
+     * Generate a <code>SensorKey</code> for metrics about failed HTTP requests
+     *
+     * @param e The Throwable object to go with the failure
+     * @return A sensor key
+     */
     @Override
     public SensorKey errorKey(Throwable e) {
         Map<String, String> attrs = MetricsUtil.getSensorKeyAttrs(contextId, uri, "introspect");

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/metrics/IntrospectValidationSensorKeyProducer.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/metrics/IntrospectValidationSensorKeyProducer.java
@@ -7,10 +7,20 @@ package io.strimzi.kafka.oauth.metrics;
 import java.net.URI;
 import java.util.Map;
 
+/**
+ * A {@link SensorKeyProducer} used for token validation metrics for a listener using an introspection endpoint
+ */
 public class IntrospectValidationSensorKeyProducer extends AbstractSensorKeyProducer {
 
     private final String saslMechanism;
 
+    /**
+     * Create a new instance
+     *
+     * @param contextId Context id (e.g. a config id or a label)
+     * @param saslMechanism a mechanism through which the validator is used (e.g. OAUTHBEARER, PLAIN)
+     * @param uri An introspection endpoint url
+     */
     public IntrospectValidationSensorKeyProducer(String contextId, String saslMechanism, URI uri) {
         super(contextId, uri);
 
@@ -20,6 +30,11 @@ public class IntrospectValidationSensorKeyProducer extends AbstractSensorKeyProd
         this.saslMechanism = saslMechanism;
     }
 
+    /**
+     * Generate a <code>SensorKey</code> for metrics about successful token validation requests
+     *
+     * @return A sensor key
+     */
     @Override
     public SensorKey successKey() {
         Map<String, String> attrs = MetricsUtil.getSensorKeyAttrs(contextId, saslMechanism, uri, "introspect");
@@ -27,6 +42,12 @@ public class IntrospectValidationSensorKeyProducer extends AbstractSensorKeyProd
         return SensorKey.of("validation_requests", attrs);
     }
 
+    /**
+     * Generate a <code>SensorKey</code> for metrics about failed token validation requests
+     *
+     * @param e The Throwable object to go with the failure
+     * @return A sensor key
+     */
     @Override
     public SensorKey errorKey(Throwable e) {
         Map<String, String> attrs = MetricsUtil.getSensorKeyAttrs(contextId, saslMechanism, uri, "introspect");

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/metrics/JwksHttpSensorKeyProducer.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/metrics/JwksHttpSensorKeyProducer.java
@@ -7,12 +7,26 @@ package io.strimzi.kafka.oauth.metrics;
 import java.net.URI;
 import java.util.Map;
 
+/**
+ * A {@link SensorKeyProducer} used for JWKS endpoint HTTP metrics
+ */
 public class JwksHttpSensorKeyProducer extends AbstractSensorKeyProducer {
 
+    /**
+     * Create a new instance
+     *
+     * @param contextId Context id (e.g. a config id or a label)
+     * @param uri A JWKS endpoint url
+     */
     public JwksHttpSensorKeyProducer(String contextId, URI uri) {
         super(contextId, uri);
     }
 
+    /**
+     * Generate a <code>SensorKey</code> for metrics about successful HTTP requests
+     *
+     * @return A sensor key
+     */
     @Override
     public SensorKey successKey() {
         Map<String, String> attrs = MetricsUtil.getSensorKeyAttrs(contextId, uri, "jwks");
@@ -20,6 +34,12 @@ public class JwksHttpSensorKeyProducer extends AbstractSensorKeyProducer {
         return SensorKey.of("http_requests", attrs);
     }
 
+    /**
+     * Generate a <code>SensorKey</code> for metrics about failed HTTP requests
+     *
+     * @param e The Throwable object to go with the failure
+     * @return A sensor key
+     */
     @Override
     public SensorKey errorKey(Throwable e) {
         Map<String, String> attrs = MetricsUtil.getSensorKeyAttrs(contextId, uri, "jwks");

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/metrics/JwksValidationSensorKeyProducer.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/metrics/JwksValidationSensorKeyProducer.java
@@ -7,10 +7,20 @@ package io.strimzi.kafka.oauth.metrics;
 import java.net.URI;
 import java.util.Map;
 
+/**
+ * A {@link SensorKeyProducer} used for token validation metrics for a listener using a JWKS endpoint
+ */
 public class JwksValidationSensorKeyProducer extends AbstractSensorKeyProducer {
 
     private final String saslMechanism;
 
+    /**
+     * Create a new instance
+     *
+     * @param contextId Context id (e.g. a config id or a label)
+     * @param saslMechanism a mechanism through which the validator is used (e.g. OAUTHBEARER, PLAIN)
+     * @param uri A jwks endpoint url
+     */
     public JwksValidationSensorKeyProducer(String contextId, String saslMechanism, URI uri) {
         super(contextId, uri);
 
@@ -20,6 +30,11 @@ public class JwksValidationSensorKeyProducer extends AbstractSensorKeyProducer {
         this.saslMechanism = saslMechanism;
     }
 
+    /**
+     * Generate a <code>SensorKey</code> for metrics about successful token validation requests
+     *
+     * @return A sensor key
+     */
     @Override
     public SensorKey successKey() {
         Map<String, String> attrs = MetricsUtil.getSensorKeyAttrs(contextId, saslMechanism, uri, "jwks");
@@ -27,6 +42,12 @@ public class JwksValidationSensorKeyProducer extends AbstractSensorKeyProducer {
         return SensorKey.of("validation_requests", attrs);
     }
 
+    /**
+     * Generate a <code>SensorKey</code> for metrics about failed token validation requests
+     *
+     * @param e The Throwable object to go with the failure
+     * @return A sensor key
+     */
     @Override
     public SensorKey errorKey(Throwable e) {
         Map<String, String> attrs = MetricsUtil.getSensorKeyAttrs(contextId, saslMechanism, uri, "jwks");

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/metrics/MetricsUtil.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/metrics/MetricsUtil.java
@@ -19,12 +19,31 @@ import java.util.Map;
  */
 public class MetricsUtil {
 
+    /**
+     * Get the attributes for the sensor key using passed info.
+     *
+     * @param contextId a contextId
+     * @param mechanism a SASL authentication mechanism used
+     * @param uri a URI associated with the sensor
+     * @param kind a 'kind' for the sensor
+     *
+     * @return The map of attributes for the SensorKey
+     */
     public static Map<String, String> getSensorKeyAttrs(String contextId, String mechanism, URI uri, String kind) {
         Map<String, String> attrs = getSensorKeyAttrs(contextId, uri, kind);
         attrs.put("mechanism", mechanism);
         return attrs;
     }
 
+    /**
+     * Get the attributes for the sensor key using passed info
+     *
+     * @param contextId a contextId
+     * @param uri a URI associated with the sensor
+     * @param kind a 'kind' for the sensor
+     *
+     * @return The map of attributes for the SensorKey
+     */
     public static Map<String, String> getSensorKeyAttrs(String contextId, URI uri, String kind) {
         HashMap<String, String> attrs = new LinkedHashMap<>();
         attrs.put("context", contextId);
@@ -34,12 +53,25 @@ public class MetricsUtil {
         return attrs;
     }
 
+    /**
+     * Add http success attributes to the passed map of attributes
+     *
+     * @param attrs A target attributes map
+     * @return The passed attributes map
+     */
     public static Map<String, String> addHttpSuccessAttrs(Map<String, String> attrs) {
         attrs.put("outcome", "success");
         attrs.put("status", "200");
         return attrs;
     }
 
+    /**
+     * Add http error attributes to the passed map of attributes
+     *
+     * @param attrs A target attributes map
+     * @param ex The exception that occurred
+     * @return The passed attributes map
+     */
     public static Map<String, String> addHttpErrorAttrs(Map<String, String> attrs, Throwable ex) {
         String errorType = "other";
         String status = null;
@@ -64,6 +96,12 @@ public class MetricsUtil {
         return attrs;
     }
 
+    /**
+     * Resolve the raw path of the passed url
+     *
+     * @param uri a URI object
+     * @return The path component of the URI
+     */
     public static String pathAttr(URI uri) {
         if (uri == null) {
             return "";
@@ -71,6 +109,14 @@ public class MetricsUtil {
         return uri.getRawPath();
     }
 
+    /**
+     * Extract the hostname:port from the passed url
+     * For 'http' protocol use port 80 as the default.
+     * For 'https' protocol use port 443 as the default.
+     *
+     * @param uri the URI object
+     * @return The hostname:port
+     */
     public static String hostAttr(URI uri) {
         if (uri == null) {
             return "";

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/metrics/UserInfoHttpSensorKeyProducer.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/metrics/UserInfoHttpSensorKeyProducer.java
@@ -7,12 +7,26 @@ package io.strimzi.kafka.oauth.metrics;
 import java.net.URI;
 import java.util.Map;
 
+/**
+ * A {@link SensorKeyProducer} used for user info endpoint HTTP metrics
+ */
 public class UserInfoHttpSensorKeyProducer extends AbstractSensorKeyProducer {
 
+    /**
+     * Create a new instance
+     *
+     * @param contextId Context id (e.g. a config id or a label)
+     * @param uri A user info endpoint url
+     */
     public UserInfoHttpSensorKeyProducer(String contextId, URI uri) {
         super(contextId, uri);
     }
 
+    /**
+     * Generate a <code>SensorKey</code> for metrics about successful HTTP requests
+     *
+     * @return A sensor key
+     */
     @Override
     public SensorKey successKey() {
         Map<String, String> attrs = MetricsUtil.getSensorKeyAttrs(contextId, uri, "userinfo");
@@ -20,6 +34,12 @@ public class UserInfoHttpSensorKeyProducer extends AbstractSensorKeyProducer {
         return SensorKey.of("http_requests", attrs);
     }
 
+    /**
+     * Generate a <code>SensorKey</code> for metrics about failed HTTP requests
+     *
+     * @param e The Throwable object to go with the failure
+     * @return A sensor key
+     */
     @Override
     public SensorKey errorKey(Throwable e) {
         Map<String, String> attrs = MetricsUtil.getSensorKeyAttrs(contextId, uri, "userinfo");

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/services/ConfigurationKey.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/services/ConfigurationKey.java
@@ -43,10 +43,20 @@ public class ConfigurationKey {
         this.validatorKey = validatorKey;
     }
 
+    /**
+     * Get the config id
+     *
+     * @return The config id
+     */
     public String getConfigId() {
         return configId;
     }
 
+    /**
+     * Get the validator key
+     *
+     * @return The validator key
+     */
     public ValidatorKey getValidatorKey() {
         return validatorKey;
     }

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/services/CurrentTime.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/services/CurrentTime.java
@@ -4,18 +4,36 @@
  */
 package io.strimzi.kafka.oauth.services;
 
+/**
+ * The source of time used in several places instead of <code>java.lang.System.currentTime</code>.
+ *
+ * It allows overriding the source of time for tests.
+ */
 public class CurrentTime {
 
     private static CurrentTimeProvider current = CurrentTimeProvider.DEFAULT;
 
+    /**
+     * Set the current time provider
+     * @param timeProvider the <code>CurrentTimeProvider</code> instance
+     */
     public static void setCurrentTimeProvider(CurrentTimeProvider timeProvider) {
         current = timeProvider;
     }
 
+    /**
+     * Get the currently set <code>CurrentTimeProvider</code>
+     * @return The current <code>CurrentTimeProvider</code>
+     */
     public static CurrentTimeProvider getCurrentTimeProvider() {
         return current;
     }
 
+    /**
+     * Get current time in millis
+     *
+     * @return Current time in millis provided by current <code>CurrentTimeProvider</code>
+     */
     public static long currentTime() {
         return current.currentTime();
     }

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/services/CurrentTimeProvider.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/services/CurrentTimeProvider.java
@@ -4,9 +4,20 @@
  */
 package io.strimzi.kafka.oauth.services;
 
+/**
+ * The source of current time in millis as an alternative to calling <code>java.lang.System.currentTimeMillis()</code>
+ */
 public interface CurrentTimeProvider {
 
+    /**
+     * The default <code>CurrentTimeProvider</code> singleton which simply invokes <code>java.lang.System.currentTimeMillis()</code>
+     */
     CurrentTimeProvider DEFAULT = System::currentTimeMillis;
 
+    /**
+     * Get the current time in millis
+     *
+     * @return Current time in millis
+     */
     long currentTime();
 }

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/services/Principals.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/services/Principals.java
@@ -11,14 +11,30 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.WeakHashMap;
 
+/**
+ * An in-memory cache of 'sessions' and their associated principals.
+ * Used to transfer the principal information between SASL authentication layer and PrincipalBuilder layer.
+ */
 public class Principals {
 
     private final Map<SaslServer, KafkaPrincipal> activeServers = Collections.synchronizedMap(new WeakHashMap<>());
 
+    /**
+     * Put a new principal into the cache
+     *
+     * @param srv a SaslServer instance
+     * @param principal a KafkaPrincipal
+     */
     public void putPrincipal(SaslServer srv, KafkaPrincipal principal) {
         activeServers.put(srv, principal);
     }
 
+    /**
+     * Get the new principal from the cache
+     *
+     * @param srv a SaslServer principal
+     * @return an associated KafkaPrincipal
+     */
     public KafkaPrincipal getPrincipal(SaslServer srv) {
         return activeServers.get(srv);
     }

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/services/ServiceException.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/services/ServiceException.java
@@ -4,12 +4,26 @@
  */
 package io.strimzi.kafka.oauth.services;
 
+/**
+ * An exception used to report a background job failure
+ */
 public class ServiceException extends RuntimeException {
 
+    /**
+     * Create a new instance
+     *
+     * @param message An error message
+     */
     public ServiceException(String message) {
         super(message);
     }
 
+    /**
+     * Create a new instance
+     *
+     * @param message An error message
+     * @param cause A cause exception
+     */
     public ServiceException(String message, Throwable cause) {
         super(message, cause);
     }

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/services/Services.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/services/Services.java
@@ -28,12 +28,22 @@ public class Services {
 
     private volatile OAuthMetrics metrics;
 
+    /**
+     * Configure a new <code>Services</code> instance. A new instance will only be created if one has not been configured before.
+     *
+     * @param configs Global configuration
+     */
     public static synchronized void configure(Map<String, ?> configs) {
         if (services == null) {
             services = new Services(configs);
         }
     }
 
+    /**
+     * Get a configured singleton instance
+     *
+     * @return Services object
+     */
     public static Services getInstance() {
         if (services == null) {
             throw new IllegalStateException("Services object has not been properly initialised");
@@ -45,26 +55,56 @@ public class Services {
         this.configs = configs;
     }
 
+    /**
+     * Get {@link Validators} singleton
+     *
+     * @return Validators instance
+     */
     public Validators getValidators() {
         return validators;
     }
 
+    /**
+     * Check if Services singleton has been configured
+     *
+     * @return True if configured
+     */
     public static boolean isAvailable() {
         return services != null;
     }
 
+    /**
+     * Get {@link Sessions} singleton
+     *
+     * @return Sessions instance
+     */
     public Sessions getSessions() {
         return sessions;
     }
 
+    /**
+     * Get {@link Principals} singleton
+     *
+     * @return Principals instance
+     */
     public Principals getPrincipals() {
         return principals;
     }
 
+    /**
+     * Get {@link Credentials} singleton
+     *
+     * @return Credentials instance
+     */
     public Credentials getCredentials() {
         return credentials;
     }
 
+    /**
+     * Get {@link OAuthMetrics} singleton
+     *
+     * @return OAuthMetrics instance
+     */
     public OAuthMetrics getMetrics() {
         if (metrics == null) {
             synchronized (Services.class) {

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/services/SessionFuture.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/services/SessionFuture.java
@@ -8,21 +8,40 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.strimzi.kafka.oauth.common.BearerTokenWithPayload;
 
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
 
+/**
+ * A Java <code>Future</code> implementation used in conjunction with {@link Sessions#executeTask(ExecutorService, Predicate, Consumer)} method
+ *
+ * @param <T> A generic type of the Future result
+ */
 public class SessionFuture<T> implements Future<T> {
 
     private final Future<T> delegate;
     private final BearerTokenWithPayload token;
 
+    /**
+     * Create a new instance
+     *
+     * @param token Token object representing a session
+     * @param future Original future instance to wrap
+     */
     @SuppressFBWarnings("EI_EXPOSE_REP2")
     public SessionFuture(BearerTokenWithPayload token, Future<T> future) {
         this.token = token;
         this.delegate = future;
     }
 
+    /**
+     * Get a <code>BearerTokenWithPayload</code> object representing a session
+     *
+     * @return A token instance
+     */
     @SuppressFBWarnings("EI_EXPOSE_REP")
     public BearerTokenWithPayload getToken() {
         return token;

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/services/Sessions.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/services/Sessions.java
@@ -31,14 +31,33 @@ public class Sessions {
      */
     private final Map<BearerTokenWithPayload, Object> activeSessions = Collections.synchronizedMap(new WeakHashMap<>());
 
+    /**
+     * Put a new token object into sessions cache
+     *
+     * @param token A token to add
+     */
     public void put(BearerTokenWithPayload token) {
         activeSessions.put(token, NONE);
     }
 
+    /**
+     * Remove a token from sessions cache
+     *
+     * @param token A token to remove
+     */
     public void remove(BearerTokenWithPayload token) {
         activeSessions.remove(token);
     }
 
+    /**
+     * Iterate over all active sessions (represented by stored token objects) applying a filter and submit a task to the passed executor for each passing token.
+     * Return a list of {@link SessionFuture} instances.
+     *
+     * @param executor An Executor to use for submitting tasks
+     * @param filter A filter to decide if the task should be submitted for specific token
+     * @param task Logic to run on the token
+     * @return A list of SessionFuture instances
+     */
     public List<SessionFuture<?>> executeTask(ExecutorService executor, Predicate<BearerTokenWithPayload> filter,
                                            Consumer<BearerTokenWithPayload> task) {
         cleanupExpired();
@@ -58,6 +77,9 @@ public class Sessions {
         return results;
     }
 
+    /**
+     * Cleanup the sessions whose lifetime has expired
+     */
     public void cleanupExpired() {
         // In order to prevent the possible ConcurrentModificationException in the middle of using an iterator
         // we first make a local copy, then iterate over the copy

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/services/ValidatorKey.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/services/ValidatorKey.java
@@ -9,8 +9,10 @@ import io.strimzi.kafka.oauth.common.IOUtil;
 import java.util.Objects;
 
 /**
- * The class that holds the validator configuration and is used two compare different configurations for equality.
+ * The class that holds the validator configuration and is used to compare different configurations for equality.
  * It also calculates a unique identifier based on the configuration that is stable across application restarts.
+ *
+ * This mechanism allows sharing a single validator across multiple listeners, as long as they are configured with same config parameter values
  */
 public class ValidatorKey {
 
@@ -131,10 +133,18 @@ public class ValidatorKey {
                 enableMetrics);
     }
 
+    /**
+     * Get the calculated configuration hash for this instance
+     *
+     * @return a hash string used to determine equality of two different configurations
+     */
     public String getConfigIdHash() {
         return configIdHash;
     }
 
+    /**
+     * A <code>ValidatorKey</code> for {@link io.strimzi.kafka.oauth.validator.JWTSignatureValidator}
+     */
     public static class JwtValidatorKey extends ValidatorKey {
 
         private final String jwksEndpointUri;
@@ -147,6 +157,33 @@ public class ValidatorKey {
 
         private final String configIdHash;
 
+        /**
+         * Create a new instance. Arguments have to include all validator config options.
+         *
+         * @param validIssuerUri validIssuerUri
+         * @param audience audience
+         * @param customClaimCheck customClaimCheck
+         * @param usernameClaim usernameClaim
+         * @param fallbackUsernameClaim fallbackUsernameClaim
+         * @param fallbackUsernamePrefix fallbackUsernamePrefix
+         * @param groupQuery groupQuery
+         * @param groupDelimiter groupDelimiter
+         * @param sslTruststore sslTruststore
+         * @param sslStorePassword sslStorePassword
+         * @param sslStoreType sslStoreType
+         * @param sslRandom sslRandom
+         * @param hasHostnameVerifier hasHostnameVerifier
+         * @param jwksEndpointUri jwksEndpointUri
+         * @param jwksRefreshSeconds jwksRefreshSeconds
+         * @param jwksExpirySeconds jwksExpirySeconds
+         * @param jwksRefreshMinPauseSeconds jwksRefreshMinPauseSeconds
+         * @param jwksIgnoreKeyUse jwksIgnoreKeyUse
+         * @param checkAccessTokenType checkAccessTokenType
+         * @param connectTimeout connectTimeout
+         * @param readTimeout readTimeout
+         * @param enableMetrics enableMetrics
+         * @param failFast failFast
+         */
         @SuppressWarnings("checkstyle:parameternumber")
         public JwtValidatorKey(String validIssuerUri,
                                String audience,
@@ -240,6 +277,9 @@ public class ValidatorKey {
         }
     }
 
+    /**
+     * A <code>ValidatorKey</code> for {@link io.strimzi.kafka.oauth.validator.OAuthIntrospectionValidator}
+     */
     public static class IntrospectionValidatorKey extends ValidatorKey {
 
         private final String introspectionEndpoint;
@@ -251,6 +291,33 @@ public class ValidatorKey {
         private final long retryPauseMillis;
         private final String configIdHash;
 
+        /**
+         * Create a new instance. Arguments have to include all validator config options.
+         *
+         * @param validIssuerUri validIssuerUri
+         * @param audience audience
+         * @param customClaimCheck customClaimCheck
+         * @param usernameClaim usernameClaim
+         * @param fallbackUsernameClaim fallbackUsernameClaim
+         * @param fallbackUsernamePrefix fallbackUsernamePrefix
+         * @param groupQuery groupQuery
+         * @param groupDelimiter groupDelimiter
+         * @param sslTruststore sslTruststore
+         * @param sslStorePassword sslStorePassword
+         * @param sslStoreType sslStoreType
+         * @param sslRandom sslRandom
+         * @param hasHostnameVerifier hasHostnameVerifier
+         * @param introspectionEndpoint introspectionEndpoint
+         * @param userInfoEndpoint userInfoEndpoint
+         * @param validTokenType validTokenType
+         * @param clientId clientId
+         * @param clientSecret clientSecret
+         * @param connectTimeout connectTimeout
+         * @param readTimeout readTimeout
+         * @param enableMetrics enableMetrics
+         * @param retries retries
+         * @param retryPauseMillis retryPauseMillis
+         */
         @SuppressWarnings("checkstyle:parameternumber")
         public IntrospectionValidatorKey(String validIssuerUri,
                                   String audience,

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/services/Validators.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/services/Validators.java
@@ -11,6 +11,9 @@ import io.strimzi.kafka.oauth.validator.TokenValidator;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 
+/**
+ * A singleton holding the configured token validators
+ */
 public class Validators {
 
     /**
@@ -18,6 +21,14 @@ public class Validators {
      */
     private final ConcurrentHashMap<ConfigurationKey, ValidatorEntry> registry = new ConcurrentHashMap<>();
 
+    /**
+     * Get a {@link TokenValidator} for the given {@link ConfigurationKey}. If one has not been register yet,
+     * use the passed <code>factory</code> to create and register one.
+     *
+     * @param key A key representing a TokenValidator configured with particular configuration options
+     * @param factory A TokenValidator supplier
+     * @return An existing or new token validator
+     */
     @SuppressFBWarnings("JLM_JSR166_UTILCONCURRENT_MONITOR")
     public TokenValidator get(ConfigurationKey key, Supplier<TokenValidator> factory) {
         synchronized (registry) {

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/validator/BackOffTaskScheduler.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/validator/BackOffTaskScheduler.java
@@ -35,7 +35,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * <p>
  * If the scheduled task fails during its run, it will be rescheduled using the so called 'exponential backoff' delay.
  * Rather than being attempted again immediately, it will pause for an ever increasing time delay until some cutoff delay
- * is reached ({@link #cutoffIntervalSeconds}) when no further attempts are schedule, and another {@link #scheduleTask()}
+ * is reached ({@link #cutoffIntervalSeconds}) when no further attempts are scheduled, and another {@link #scheduleTask()}
  * call can again trigger a new refresh.
  * </p>
  */
@@ -76,10 +76,21 @@ public class BackOffTaskScheduler {
         }
     }
 
+    /**
+     * Get the minimum pause in seconds between two consecutive scheduled runs,
+     * so that the next run does not start immediately after the previous run completes.
+     *
+     * @return The minimum pause in seconds
+     */
     public int getMinPauseSeconds() {
         return minPauseSeconds;
     }
 
+    /**
+     * Get the cutoff interval in seconds for exponential backoff
+     *
+     * @return The cutoff interval in seconds
+     */
     public int getCutoffIntervalSeconds() {
         return cutoffIntervalSeconds;
     }

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/validator/TokenExpiredException.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/validator/TokenExpiredException.java
@@ -4,16 +4,30 @@
  */
 package io.strimzi.kafka.oauth.validator;
 
+/**
+ * A runtime exception that signals an expired token
+ */
 public class TokenExpiredException extends TokenValidationException {
 
     {
         status(Status.EXPIRED_TOKEN);
     }
 
+    /**
+     * Create a new instance
+     *
+     * @param message An error message
+     */
     public TokenExpiredException(String message) {
         super(message);
     }
 
+    /**
+     * Create a new instance
+     *
+     * @param message An error message
+     * @param cause A triggering cause of this exception
+     */
     public TokenExpiredException(String message, Throwable cause) {
         super(message, cause);
     }

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/validator/TokenSignatureException.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/validator/TokenSignatureException.java
@@ -4,16 +4,30 @@
  */
 package io.strimzi.kafka.oauth.validator;
 
+/**
+ * A runtime exception that signals an invalid token signature
+ */
 public class TokenSignatureException extends TokenValidationException {
 
     {
         status(Status.INVALID_TOKEN);
     }
 
+    /**
+     * Create a new instance
+     *
+     * @param message An error message
+     */
     public TokenSignatureException(String message) {
         super(message);
     }
 
+    /**
+     * Create a new instance
+     *
+     * @param message An error message
+     * @param cause A triggering cause of this exception
+     */
     public TokenSignatureException(String message, Throwable cause) {
         super(message, cause);
     }

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/validator/TokenValidationException.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/validator/TokenValidationException.java
@@ -6,37 +6,81 @@ package io.strimzi.kafka.oauth.validator;
 
 import java.util.Locale;
 
+/**
+ * A runtime exception used to signal an invalid token
+ */
 public class TokenValidationException extends ValidationException {
 
+    /**
+     * Validation check error status for this instance
+     */
     private String status;
 
     {
         status(Status.INVALID_TOKEN);
     }
 
+    /**
+     * Create a new instance
+     *
+     * @param message An error message
+     */
     public TokenValidationException(String message) {
         super(message);
     }
 
+    /**
+     * Create a new instance
+     *
+     * @param message An error message
+     * @param cause A triggering cause of this exception
+     */
     public TokenValidationException(String message, Throwable cause) {
         super(message, cause);
     }
 
+    /**
+     * Set the validation check status that caused validation failure
+     *
+     * @param status {@link Status} enum value
+     * @return This exception
+     */
     TokenValidationException status(Status status) {
         this.status = status.value();
         return this;
     }
 
+    /**
+     * Get the validation check error status for this exception
+     *
+     * @return A token validation error status as String
+     */
     public String status() {
         return status;
     }
 
-
+    /**
+     * An Enum for different token validation error statuses
+     */
     public enum Status {
+        /**
+         * Token is invalid
+         */
         INVALID_TOKEN,
+        /**
+         * Token is expired
+         */
         EXPIRED_TOKEN,
+        /**
+         * Token is rejected based on the token type
+         */
         UNSUPPORTED_TOKEN_TYPE;
 
+        /**
+         * Get enum value as a lowercase String
+         *
+         * @return a lowercase string
+         */
         public String value() {
             return name().toLowerCase(Locale.ENGLISH);
         }

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/validator/TokenValidator.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/validator/TokenValidator.java
@@ -6,9 +6,23 @@ package io.strimzi.kafka.oauth.validator;
 
 import io.strimzi.kafka.oauth.common.TokenInfo;
 
+/**
+ * An interface specifying a TokenValidator contract
+ */
 public interface TokenValidator {
 
+    /**
+     * Validate the passed access token return it wrapped in TokenInfo with
+     *
+     * @param token An access token to validate
+     * @return TokenInfo wrapping a valid token
+     */
     TokenInfo validate(String token);
 
+    /**
+     * Return the id of this validator
+     *
+     * @return A validator id
+     */
     String getValidatorId();
 }

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/validator/ValidationException.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/validator/ValidationException.java
@@ -4,12 +4,26 @@
  */
 package io.strimzi.kafka.oauth.validator;
 
+/**
+ * A runtime exception used to signal an error while performing token validation
+ */
 public class ValidationException extends RuntimeException {
 
+    /**
+     * Create new instance
+     *
+     * @param message An error message
+     */
     public ValidationException(String message) {
         super(message);
     }
 
+    /**
+     * Create a new instance
+     *
+     * @param message An error message
+     * @param cause A triggering cause of this exception
+     */
     public ValidationException(String message, Throwable cause) {
         super(message, cause);
     }

--- a/oauth-common/src/test/java/io/strimzi/kafka/oauth/common/HttpUtilTimeoutTest.java
+++ b/oauth-common/src/test/java/io/strimzi/kafka/oauth/common/HttpUtilTimeoutTest.java
@@ -90,7 +90,7 @@ public class HttpUtilTimeoutTest {
                 Assert.fail("Should fail with SocketTimeoutException");
             } catch (SocketTimeoutException e) {
                 long diff = System.currentTimeMillis() - start;
-                Assert.assertTrue("Unexpected error: " + e, e.toString().contains("connect timed out"));
+                Assert.assertTrue("Unexpected error: " + e, e.toString().contains("onnect timed out"));
                 Assert.assertTrue("Unexpected diff: " + diff, diff >= timeout * 1000 && diff < timeout * 1000 + 1000);
             } catch (IOException e) {
                 if (e.getCause() instanceof ConnectException) {
@@ -128,7 +128,7 @@ public class HttpUtilTimeoutTest {
                 long diff = System.currentTimeMillis() - start;
 
                 Assert.assertTrue("Wrong exception: " + e + " caused by " + cause, cause instanceof SocketTimeoutException);
-                Assert.assertTrue("Unexpected error: " + cause, cause.toString().contains("connect timed out"));
+                Assert.assertTrue("Unexpected error: " + cause, cause.toString().contains("onnect timed out"));
                 Assert.assertTrue("Unexpected diff: " + diff, diff >= timeout * 1000 && diff < timeout * 1000 + 1000);
             }
 

--- a/oauth-keycloak-authorizer/src/main/java/io/strimzi/kafka/oauth/server/authorizer/AuthzConfig.java
+++ b/oauth-keycloak-authorizer/src/main/java/io/strimzi/kafka/oauth/server/authorizer/AuthzConfig.java
@@ -8,31 +8,106 @@ import io.strimzi.kafka.oauth.common.Config;
 
 import java.util.Properties;
 
+/**
+ * Configuration handling class used in {@link KeycloakRBACAuthorizer}
+ */
 public class AuthzConfig extends Config {
 
+    /**
+     * "strimzi.authorization.client.id"
+     */
     public static final String STRIMZI_AUTHORIZATION_CLIENT_ID = "strimzi.authorization.client.id";
+
+    /**
+     * "strimzi.authorization.token.endpoint.uri"
+     */
     public static final String STRIMZI_AUTHORIZATION_TOKEN_ENDPOINT_URI = "strimzi.authorization.token.endpoint.uri";
 
+    /**
+     * "strimzi.authorization.kafka.cluster.name"
+     */
     public static final String STRIMZI_AUTHORIZATION_KAFKA_CLUSTER_NAME = "strimzi.authorization.kafka.cluster.name";
+
+    /**
+     * "strimzi.authorization.delegate.to.kafka.acl"
+     */
     public static final String STRIMZI_AUTHORIZATION_DELEGATE_TO_KAFKA_ACL = "strimzi.authorization.delegate.to.kafka.acl";
 
+    /**
+     * "strimzi.authorization.grants.refresh.period.seconds"
+     */
     public static final String STRIMZI_AUTHORIZATION_GRANTS_REFRESH_PERIOD_SECONDS = "strimzi.authorization.grants.refresh.period.seconds";
+
+    /**
+     * "strimzi.authorization.grants.refresh.pool.size"
+     */
     public static final String STRIMZI_AUTHORIZATION_GRANTS_REFRESH_POOL_SIZE = "strimzi.authorization.grants.refresh.pool.size";
+
+    /**
+     * "strimzi.authorization.http.retries"
+     */
     public static final String STRIMZI_AUTHORIZATION_HTTP_RETRIES = "strimzi.authorization.http.retries";
+
+    /**
+     * "strimzi.authorization.ssl.truststore.location"
+     */
     public static final String STRIMZI_AUTHORIZATION_SSL_TRUSTSTORE_LOCATION = "strimzi.authorization.ssl.truststore.location";
+
+    /**
+     * "strimzi.authorization.ssl.truststore.certificates"
+     */
     public static final String STRIMZI_AUTHORIZATION_SSL_TRUSTSTORE_CERTIFICATES = "strimzi.authorization.ssl.truststore.certificates";
+
+    /**
+     * "strimzi.authorization.ssl.truststore.password"
+     */
     public static final String STRIMZI_AUTHORIZATION_SSL_TRUSTSTORE_PASSWORD = "strimzi.authorization.ssl.truststore.password";
+
+    /**
+     * "strimzi.authorization.ssl.truststore.type"
+     */
     public static final String STRIMZI_AUTHORIZATION_SSL_TRUSTSTORE_TYPE = "strimzi.authorization.ssl.truststore.type";
+
+    /**
+     * "strimzi.authorization.ssl.secure.random.implementation"
+     */
     public static final String STRIMZI_AUTHORIZATION_SSL_SECURE_RANDOM_IMPLEMENTATION = "strimzi.authorization.ssl.secure.random.implementation";
+
+    /**
+     * "strimzi.authorization.ssl.endpoint.identification.algorithm"
+     */
     public static final String STRIMZI_AUTHORIZATION_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM = "strimzi.authorization.ssl.endpoint.identification.algorithm";
 
+    /**
+     * "strimzi.authorization.connect.timeout.seconds"
+     */
     public static final String STRIMZI_AUTHORIZATION_CONNECT_TIMEOUT_SECONDS = "strimzi.authorization.connect.timeout.seconds";
+
+    /**
+     * "strimzi.authorization.read.timeout.seconds"
+     */
     public static final String STRIMZI_AUTHORIZATION_READ_TIMEOUT_SECONDS = "strimzi.authorization.read.timeout.seconds";
+
+    /**
+     * "strimzi.authorization.enable.metrics"
+     */
     public static final String STRIMZI_AUTHORIZATION_ENABLE_METRICS = "strimzi.authorization.enable.metrics";
+
+    /**
+     * "strimzi.authorization.reuse.grants"
+     */
     public static final String STRIMZI_AUTHORIZATION_REUSE_GRANTS = "strimzi.authorization.reuse.grants";
 
+    /**
+     * Create a new instance
+     */
     AuthzConfig() {}
 
+    /**
+     * Create a new instance
+     *
+     * @param p Config properties
+     */
     AuthzConfig(Properties p) {
         super(p);
     }

--- a/oauth-keycloak-authorizer/src/main/java/io/strimzi/kafka/oauth/server/authorizer/KeycloakRBACAuthorizer.java
+++ b/oauth-keycloak-authorizer/src/main/java/io/strimzi/kafka/oauth/server/authorizer/KeycloakRBACAuthorizer.java
@@ -194,6 +194,10 @@ public class KeycloakRBACAuthorizer extends AclAuthorizer {
     private SensorKeyProducer authzSensorKeyProducer;
     private SensorKeyProducer grantsSensorKeyProducer;
     private final Semaphores<JsonNode> semaphores = new Semaphores<>();
+
+    /**
+     * Create a new instance
+     */
     public KeycloakRBACAuthorizer() {
         super();
     }

--- a/oauth-keycloak-authorizer/src/main/java/io/strimzi/kafka/oauth/server/authorizer/ResourceSpec.java
+++ b/oauth-keycloak-authorizer/src/main/java/io/strimzi/kafka/oauth/server/authorizer/ResourceSpec.java
@@ -7,15 +7,37 @@ package io.strimzi.kafka.oauth.server.authorizer;
 import java.util.Locale;
 
 /**
- * ResourceSpec is used to parse resource matching pattern and to perform matching to specific resource.
+ * ResourceSpec is used to parse a resource matching pattern and to perform matching to a specific resource.
  */
 public class ResourceSpec {
 
+    /**
+     * Kafka resource types
+     */
     public enum ResourceType {
+        /**
+         * TOPIC
+         */
         TOPIC,
+
+        /**
+         * GROUP
+         */
         GROUP,
+
+        /**
+         * CLUSTER
+         */
         CLUSTER,
+
+        /**
+         * TRANSACTIONAL_ID
+         */
         TRANSACTIONAL_ID,
+
+        /**
+         * DELEGATION_TOKEN
+         */
         DELEGATION_TOKEN
     }
 
@@ -27,22 +49,48 @@ public class ResourceSpec {
     private boolean resourceStartsWith;
 
 
+    /**
+     * Get a 'kafka-cluster' value (not the same as Kafka <code>Cluster</code> resource type).
+     * For example: <code>kafka-cluster:my-cluster,Cluster:kafka-cluster</code>
+     *
+     * @return Cluster name
+     */
     public String getClusterName() {
         return clusterName;
     }
 
+    /**
+     * See if 'kafka-cluster' specification uses an asterisk as in <code>kafka-cluster:*,Topic:orders</code>
+     *
+     * @return True if value ends with an asterisk
+     */
     public boolean isClusterStartsWith() {
         return clusterStartsWith;
     }
 
+    /**
+     * Get a resource type
+     *
+     * @return ResourceType enum value
+     */
     public ResourceType getResourceType() {
         return resourceType;
     }
 
+    /**
+     * Get resource name
+     *
+     * @return A resource name
+     */
     public String getResourceName() {
         return resourceName;
     }
 
+    /**
+     * See if a resource specification uses an asterisk as in <code>Topic:orders_*</code>
+     *
+     * @return True if value ends with an asterisk
+     */
     public boolean isResourceStartsWith() {
         return resourceStartsWith;
     }
@@ -89,6 +137,12 @@ public class ResourceSpec {
         }
     }
 
+    /**
+     * A factory method to parse a ResourceSpec from a string
+     *
+     * @param name Resource spec as a string
+     * @return A ResourceSpec instance
+     */
     public static ResourceSpec of(String name) {
         ResourceSpec spec = new ResourceSpec();
 

--- a/oauth-keycloak-authorizer/src/main/java/io/strimzi/kafka/oauth/server/authorizer/ScopesSpec.java
+++ b/oauth-keycloak-authorizer/src/main/java/io/strimzi/kafka/oauth/server/authorizer/ScopesSpec.java
@@ -8,20 +8,71 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Locale;
 
+/**
+ * This class represents parsed Keycloak Authorization Services grants as returned by the token endpoint
+ */
 public class ScopesSpec {
 
+    /**
+     * Keycloak Authorization Services scope. It aligns with all the possible authorization actions that Kafka understands
+     */
     public enum AuthzScope {
+        /**
+         * CREATE
+         */
         CREATE,
+
+        /**
+         * READ
+         */
         READ,
+
+        /**
+         * WRITE
+         */
         WRITE,
+
+        /**
+         * DELETE
+         */
         DELETE,
+
+        /**
+         * ALTER
+         */
         ALTER,
+
+        /**
+         * DESCRIBE
+         */
         DESCRIBE,
+
+        /**
+         * ALTER_CONFIGS or ALTERCONFIGS
+         */
         ALTER_CONFIGS,
+
+        /**
+         * DESCRIBE_CONFIGS or DESCRIBECONFIGS
+         */
         DESCRIBE_CONFIGS,
+
+        /**
+         * CLUSTER_ACTION or CLUSTERACTION
+         */
         CLUSTER_ACTION,
+
+        /**
+         * IDEMPOTENT_WRITE or IDEMPOTENTWRITE
+         */
         IDEMPOTENT_WRITE;
 
+        /**
+         * Get a AuthzScope enum value corresponding to the passed grant
+         *
+         * @param grantValue Grant as a string
+         * @return AuthzScope enum value
+         */
         public static AuthzScope of(String grantValue) {
             final String value = grantValue.toUpperCase(Locale.ROOT);
             switch (value) {
@@ -50,6 +101,12 @@ public class ScopesSpec {
         return new ScopesSpec(EnumSet.copyOf(scopes));
     }
 
+    /**
+     * See if the specific operation is granted based on the list of grants contained in this instance of <code>ScopesSpec</code>.
+     *
+     * @param operation Operation (permission) name
+     * @return True if operation is granted
+     */
     public boolean isGranted(String operation) {
         AuthzScope scope = AuthzScope.valueOf(operation);
         return granted.contains(scope);

--- a/oauth-keycloak-authorizer/src/main/java/io/strimzi/kafka/oauth/server/authorizer/UserSpec.java
+++ b/oauth-keycloak-authorizer/src/main/java/io/strimzi/kafka/oauth/server/authorizer/UserSpec.java
@@ -4,25 +4,50 @@
  */
 package io.strimzi.kafka.oauth.server.authorizer;
 
+/**
+ * A class used to hold parsed superusers specs
+ */
 public class UserSpec {
 
     private final String type;
     private final String name;
 
+    /**
+     * Create a new instance
+     *
+     * @param type A principal type
+     * @param name A principal name
+     */
     private UserSpec(String type, String name) {
         this.type = type;
         this.name = name;
     }
 
+    /**
+     * Get the type
+     *
+     * @return The type as a string
+     */
     public String getType() {
         return type;
     }
 
+    /**
+     * Get the name
+     *
+     * @return The name
+     */
     public String getName() {
         return name;
     }
 
 
+    /**
+     * Factory method to parse a <code>UserSpec</code> instance from a string
+     *
+     * @param principal A principal as a string
+     * @return A new UserSpec instance
+     */
     public static UserSpec of(String principal) {
         int pos = principal.indexOf(':');
         if (pos <= 0) {

--- a/oauth-keycloak-authorizer/src/main/java/io/strimzi/kafka/oauth/server/authorizer/metrics/GrantsHttpSensorKeyProducer.java
+++ b/oauth-keycloak-authorizer/src/main/java/io/strimzi/kafka/oauth/server/authorizer/metrics/GrantsHttpSensorKeyProducer.java
@@ -7,16 +7,32 @@ package io.strimzi.kafka.oauth.server.authorizer.metrics;
 import io.strimzi.kafka.oauth.metrics.AbstractSensorKeyProducer;
 import io.strimzi.kafka.oauth.metrics.MetricsUtil;
 import io.strimzi.kafka.oauth.metrics.SensorKey;
+import io.strimzi.kafka.oauth.metrics.SensorKeyProducer;
 
 import java.net.URI;
 import java.util.Map;
 
+/**
+ * A {@link SensorKeyProducer} used for token endpoint HTTP metrics for Keycloak grants requests performed by
+ * {@link io.strimzi.kafka.oauth.server.authorizer.KeycloakRBACAuthorizer}
+ */
 public class GrantsHttpSensorKeyProducer extends AbstractSensorKeyProducer {
 
+    /**
+     * Create a new instance
+     *
+     * @param contextId Context id (e.g. a config id or a label)
+     * @param uri A token endpoint url
+     */
     public GrantsHttpSensorKeyProducer(String contextId, URI uri) {
         super(contextId, uri);
     }
 
+    /**
+     * Generate a <code>SensorKey</code> for metrics about successful HTTP requests
+     *
+     * @return A sensor key
+     */
     @Override
     public SensorKey successKey() {
         Map<String, String> attrs = MetricsUtil.getSensorKeyAttrs(contextId, uri, "keycloak-authorization");
@@ -24,6 +40,12 @@ public class GrantsHttpSensorKeyProducer extends AbstractSensorKeyProducer {
         return SensorKey.of("http_requests", attrs);
     }
 
+    /**
+     * Generate a <code>SensorKey</code> for metrics about failed HTTP requests
+     *
+     * @param e The Throwable object to go with the failure
+     * @return A sensor key
+     */
     @Override
     public SensorKey errorKey(Throwable e) {
         Map<String, String> attrs = MetricsUtil.getSensorKeyAttrs(contextId, uri, "keycloak-authorization");

--- a/oauth-keycloak-authorizer/src/main/java/io/strimzi/kafka/oauth/server/authorizer/metrics/KeycloakAuthorizationSensorKeyProducer.java
+++ b/oauth-keycloak-authorizer/src/main/java/io/strimzi/kafka/oauth/server/authorizer/metrics/KeycloakAuthorizationSensorKeyProducer.java
@@ -7,16 +7,31 @@ package io.strimzi.kafka.oauth.server.authorizer.metrics;
 import io.strimzi.kafka.oauth.metrics.AbstractSensorKeyProducer;
 import io.strimzi.kafka.oauth.metrics.MetricsUtil;
 import io.strimzi.kafka.oauth.metrics.SensorKey;
+import io.strimzi.kafka.oauth.metrics.SensorKeyProducer;
 
 import java.net.URI;
 import java.util.Map;
 
+/**
+ * A {@link SensorKeyProducer} used for authorization metrics
+ */
 public class KeycloakAuthorizationSensorKeyProducer extends AbstractSensorKeyProducer {
 
+    /**
+     * Create a new instance
+     *
+     * @param contextId Context id (e.g. a config id or a label)
+     * @param uri A token endpoint url
+     */
     public KeycloakAuthorizationSensorKeyProducer(String contextId, URI uri) {
         super(contextId, uri);
     }
 
+    /**
+     * Generate a <code>SensorKey</code> for metrics about successful authorizations
+     *
+     * @return A sensor key
+     */
     @Override
     public SensorKey successKey() {
         Map<String, String> attrs = MetricsUtil.getSensorKeyAttrs(contextId, uri, "keycloak-authorization");
@@ -24,6 +39,12 @@ public class KeycloakAuthorizationSensorKeyProducer extends AbstractSensorKeyPro
         return SensorKey.of("authorization_requests", attrs);
     }
 
+    /**
+     * Generate a <code>SensorKey</code> for metrics about failed authorizations
+     *
+     * @param e The Throwable object to go with the failure
+     * @return A sensor key
+     */
     @Override
     public SensorKey errorKey(Throwable e) {
         Map<String, String> attrs = MetricsUtil.getSensorKeyAttrs(contextId, uri, "keycloak-authorization");

--- a/oauth-server-plain/src/main/java/io/strimzi/kafka/oauth/server/plain/ServerPlainConfig.java
+++ b/oauth-server-plain/src/main/java/io/strimzi/kafka/oauth/server/plain/ServerPlainConfig.java
@@ -8,13 +8,27 @@ import io.strimzi.kafka.oauth.common.Config;
 
 import java.util.Properties;
 
+/**
+ * Configuration handling class used in {@link JaasServerOauthOverPlainValidatorCallbackHandler}
+ */
 public class ServerPlainConfig extends Config {
 
+    /**
+     * "oauth.token.endpoint.uri"
+     */
     public static final String OAUTH_TOKEN_ENDPOINT_URI = "oauth.token.endpoint.uri";
 
+    /**
+     * Create a new instance
+     */
     public ServerPlainConfig() {
     }
 
+    /**
+     * Create a new instance
+     *
+     * @param p Config properties
+     */
     public ServerPlainConfig(Properties p) {
         super(p);
     }

--- a/oauth-server-plain/src/main/java/io/strimzi/kafka/oauth/server/plain/metrics/PlainHttpSensorKeyProducer.java
+++ b/oauth-server-plain/src/main/java/io/strimzi/kafka/oauth/server/plain/metrics/PlainHttpSensorKeyProducer.java
@@ -7,16 +7,32 @@ package io.strimzi.kafka.oauth.server.plain.metrics;
 import io.strimzi.kafka.oauth.metrics.AbstractSensorKeyProducer;
 import io.strimzi.kafka.oauth.metrics.MetricsUtil;
 import io.strimzi.kafka.oauth.metrics.SensorKey;
+import io.strimzi.kafka.oauth.metrics.SensorKeyProducer;
 
 import java.net.URI;
 import java.util.Map;
 
+/**
+ * A {@link SensorKeyProducer} used for token endpoint HTTP metrics for authentication requests performed by
+ * {@link io.strimzi.kafka.oauth.server.plain.JaasServerOauthOverPlainValidatorCallbackHandler} in client's name
+ */
 public class PlainHttpSensorKeyProducer extends AbstractSensorKeyProducer {
 
+    /**
+     * Create a new instance
+     *
+     * @param contextId Context id (e.g. a config id or a label)
+     * @param uri A token endpoint url
+     */
     public PlainHttpSensorKeyProducer(String contextId, URI uri) {
         super(contextId, uri);
     }
 
+    /**
+     * Generate a <code>SensorKey</code> for metrics about successful HTTP requests
+     *
+     * @return A sensor key
+     */
     @Override
     public SensorKey successKey() {
         Map<String, String> attrs = MetricsUtil.getSensorKeyAttrs(contextId, uri, "plain");
@@ -24,6 +40,12 @@ public class PlainHttpSensorKeyProducer extends AbstractSensorKeyProducer {
         return SensorKey.of("http_requests", attrs);
     }
 
+    /**
+     * Generate a <code>SensorKey</code> for metrics about failed HTTP requests
+     *
+     * @param e The Throwable object to go with the failure
+     * @return A sensor key
+     */
     @Override
     public SensorKey errorKey(Throwable e) {
         Map<String, String> attrs = MetricsUtil.getSensorKeyAttrs(contextId, uri, "plain");

--- a/oauth-server/src/main/java/io/strimzi/kafka/oauth/server/JaasServerOauthValidatorCallbackHandler.java
+++ b/oauth-server/src/main/java/io/strimzi/kafka/oauth/server/JaasServerOauthValidatorCallbackHandler.java
@@ -232,6 +232,14 @@ public class JaasServerOauthValidatorCallbackHandler implements AuthenticateCall
         delegatedConfigure(configs, saslMechanism, jaasConfigEntries);
     }
 
+    /**
+     * Part of configuration that can be directly invoked by an overriding class.
+     * Parameters are the same as for {@link #configure(Map, String, List)}
+     *
+     * @param configs Map of config properties
+     * @param saslMechanism The mechanism used by the connection
+     * @param jaasConfigEntries JAAS config parameters
+     */
     public void delegatedConfigure(Map<String, ?> configs, String saslMechanism, List<AppConfigurationEntry> jaasConfigEntries) {
 
         parseJaasConfig(jaasConfigEntries);
@@ -455,6 +463,12 @@ public class JaasServerOauthValidatorCallbackHandler implements AuthenticateCall
         }
     }
 
+    /**
+     * Parse the JAAS config into ServerConfig
+     *
+     * @param jaasConfigEntries JAAS config parameters
+     * @return ServerConfig instance
+     */
     protected ServerConfig parseJaasConfig(List<AppConfigurationEntry> jaasConfigEntries) {
         if (config != null) {
             return config;
@@ -564,6 +578,12 @@ public class JaasServerOauthValidatorCallbackHandler implements AuthenticateCall
         }
     }
 
+    /**
+     * Handle the callbacks. It can be invoked from a subclass.
+     *
+     * @param callbacks The callbacks passed to {@link #handle(Callback[])}
+     * @throws UnsupportedCallbackException If a callback type is not supported (due to misconfiguration)
+     */
     public void delegatedHandle(Callback[] callbacks) throws UnsupportedCallbackException {
         for (Callback callback : callbacks) {
             if (callback instanceof OAuthBearerValidatorCallback) {
@@ -656,26 +676,58 @@ public class JaasServerOauthValidatorCallbackHandler implements AuthenticateCall
         debugLogJWT(log, token);
     }
 
+    /**
+     * Get <code>oauth.access.token.is.jwt</code> configuration
+     *
+     * @return True if tokens are expected to be JWT tokens
+     */
     public boolean isJwt() {
         return isJwt;
     }
 
+    /**
+     * Get the <code>SSLSocketFactory</code> if configured.
+     * It is configured from <code>oauth.ssl.*</code> config options.
+     *
+     * @return A configured <code>SSLSocketFactory</code> or null
+     */
     public SSLSocketFactory getSocketFactory() {
         return socketFactory;
     }
 
+    /**
+     * Get the <code>HostnameVerifier</code> if configured.
+     * It is configured from <code>oauth.ssl.endpoint.identification.algorithm</code>
+     *
+     * @return A configured <code>HostnameVerifier</code>
+     */
     public HostnameVerifier getVerifier() {
         return verifier;
     }
 
+    /**
+     * Get the configured <code>PrincipalExtractor</code>
+     *
+     * @return a configured <code>PrincipalExtractor</code>
+     */
     public PrincipalExtractor getPrincipalExtractor() {
         return principalExtractor;
     }
 
+    /**
+     * Get the configured connect timeout (<code>oauth.connect.timeout.seconds</code>)
+     *
+     * @return Connect timeout in seconds
+     */
     public int getConnectTimeout() {
         return connectTimeout;
     }
 
+    /**
+     * Get the configured read timeout (<code>oauth.read.timeout.seconds</code>)
+     *
+     * @return Read timeout in seconds
+     */
     public int getReadTimeout() {
         return readTimeout;
     }

--- a/oauth-server/src/main/java/io/strimzi/kafka/oauth/server/OAuthKafkaPrincipal.java
+++ b/oauth-server/src/main/java/io/strimzi/kafka/oauth/server/OAuthKafkaPrincipal.java
@@ -26,10 +26,23 @@ public final class OAuthKafkaPrincipal extends KafkaPrincipal {
     private final BearerTokenWithPayload jwt;
     private final Set<String> groups;
 
+    /**
+     * Create a new instance
+     *
+     * @param principalType Principal type (e.g. USER)
+     * @param name A name
+     */
     public OAuthKafkaPrincipal(String principalType, String name) {
         this(principalType, name, (Set<String>) null);
     }
 
+    /**
+     * Create a new instance
+     *
+     * @param principalType Principal type (e.g. USER)
+     * @param name A name
+     * @param groups A set of groups for the user
+     */
     public OAuthKafkaPrincipal(String principalType, String name, Set<String> groups) {
         super(principalType, name);
         this.jwt = null;
@@ -37,6 +50,13 @@ public final class OAuthKafkaPrincipal extends KafkaPrincipal {
         this.groups = groups == null ? null : Collections.unmodifiableSet(groups);
     }
 
+    /**
+     * Create a new instance, and extract groups info from the passed {@link BearerTokenWithPayload}
+     *
+     * @param principalType Principal type (e.g. USER)
+     * @param name A name
+     * @param jwt <code>BearerTokenWithPayload</code> object with token info
+     */
     @SuppressFBWarnings("EI_EXPOSE_REP2")
     public OAuthKafkaPrincipal(String principalType, String name, BearerTokenWithPayload jwt) {
         super(principalType, name);
@@ -46,11 +66,21 @@ public final class OAuthKafkaPrincipal extends KafkaPrincipal {
         this.groups = parsedGroups == null ? null : Collections.unmodifiableSet(parsedGroups);
     }
 
+    /**
+     * Get the token info
+     *
+     * @return <code>BearerTokenWithPayload</code> instance
+     */
     @SuppressFBWarnings("EI_EXPOSE_REP")
     public BearerTokenWithPayload getJwt() {
         return jwt;
     }
 
+    /**
+     * Get the initialised groups associated with this principal
+     *
+     * @return Set of groups
+     */
     @SuppressFBWarnings("EI_EXPOSE_REP")
     public Set<String> getGroups() {
         return groups;

--- a/oauth-server/src/main/java/io/strimzi/kafka/oauth/server/OAuthKafkaPrincipalBuilder.java
+++ b/oauth-server/src/main/java/io/strimzi/kafka/oauth/server/OAuthKafkaPrincipalBuilder.java
@@ -21,7 +21,6 @@ import javax.security.sasl.SaslServer;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.Collections;
 import java.util.List;
@@ -43,6 +42,7 @@ import java.util.Map;
  * property definition in server.properties to install it.
  * </p>
  */
+@SuppressWarnings({"deprecation", "removal"})
 public class OAuthKafkaPrincipalBuilder extends DefaultKafkaPrincipalBuilder implements Configurable {
 
     private static final SetAccessibleAction SET_PRINCIPAL_MAPPER = SetAccessibleAction.newInstance();
@@ -62,7 +62,7 @@ public class OAuthKafkaPrincipalBuilder extends DefaultKafkaPrincipalBuilder imp
         }
 
         void invoke(DefaultKafkaPrincipalBuilder target, Object value) throws IllegalAccessException {
-            AccessController.doPrivileged(this);
+            java.security.AccessController.doPrivileged(this);
             field.set(target, value);
         }
 
@@ -76,6 +76,9 @@ public class OAuthKafkaPrincipalBuilder extends DefaultKafkaPrincipalBuilder imp
     }
 
 
+    /**
+     * Create a new instance
+     */
     public OAuthKafkaPrincipalBuilder() {
         super(null, null);
     }

--- a/oauth-server/src/main/java/io/strimzi/kafka/oauth/server/OAuthSaslAuthenticationException.java
+++ b/oauth-server/src/main/java/io/strimzi/kafka/oauth/server/OAuthSaslAuthenticationException.java
@@ -18,22 +18,48 @@ import org.apache.kafka.common.errors.SaslAuthenticationException;
  */
 public class OAuthSaslAuthenticationException extends SaslAuthenticationException {
 
+    /**
+     * An error id
+     */
     private final String errId;
 
+    /**
+     * Create a new instance
+     *
+     * @param message An error message
+     * @param errId An error id that is logged to facilitate debugging
+     */
     public OAuthSaslAuthenticationException(String message, String errId) {
         super(message);
         this.errId = errId;
     }
 
+    /**
+     * Create a new instance
+     *
+     * @param message An error message
+     * @param errId An error id that is logged to facilitate debugging
+     * @param cause A triggering cause of this exception
+     */
     public OAuthSaslAuthenticationException(String message, String errId, Throwable cause) {
         super(message, cause);
         this.errId = errId;
     }
 
+    /**
+     * Get the error id
+     *
+     * @return An error id
+     */
     public String getErrId() {
         return errId;
     }
 
+    /**
+     * Get the error message with error id attached
+     *
+     * @return An error message
+     */
     @Override
     public String getMessage() {
         return super.getMessage() + " (ErrId: " + errId + ")";

--- a/oauth-server/src/main/java/io/strimzi/kafka/oauth/server/ServerConfig.java
+++ b/oauth-server/src/main/java/io/strimzi/kafka/oauth/server/ServerConfig.java
@@ -8,34 +8,118 @@ import io.strimzi.kafka.oauth.common.Config;
 
 import java.util.Properties;
 
+/**
+ * Configuration handling class used in server callback handlers
+ */
 public class ServerConfig extends Config {
 
+    /**
+     * "oauth.jwks.endpoint.uri"
+     */
     public static final String OAUTH_JWKS_ENDPOINT_URI = "oauth.jwks.endpoint.uri";
+
+    /**
+     * "oauth.jwks.expiry.seconds"
+     */
     public static final String OAUTH_JWKS_EXPIRY_SECONDS = "oauth.jwks.expiry.seconds";
+
+    /**
+     * "oauth.jwks.refresh.seconds"
+     */
     public static final String OAUTH_JWKS_REFRESH_SECONDS = "oauth.jwks.refresh.seconds";
+
+    /**
+     * "oauth.jwks.refresh.min.pause.seconds"
+     */
     public static final String OAUTH_JWKS_REFRESH_MIN_PAUSE_SECONDS = "oauth.jwks.refresh.min.pause.seconds";
+
+    /**
+     * "oauth.jwks.ignore.key.use"
+     */
     public static final String OAUTH_JWKS_IGNORE_KEY_USE = "oauth.jwks.ignore.key.use";
+
+    /**
+     * "oauth.valid.issuer.uri"
+     */
     public static final String OAUTH_VALID_ISSUER_URI = "oauth.valid.issuer.uri";
+
+    /**
+     * "oauth.introspection.endpoint.uri"
+     */
     public static final String OAUTH_INTROSPECTION_ENDPOINT_URI = "oauth.introspection.endpoint.uri";
+
+    /**
+     * "oauth.userinfo.endpoint.uri"
+     */
     public static final String OAUTH_USERINFO_ENDPOINT_URI = "oauth.userinfo.endpoint.uri";
+
+    /**
+     * "oauth.check.access.token.type"
+     */
     public static final String OAUTH_CHECK_ACCESS_TOKEN_TYPE = "oauth.check.access.token.type";
+
+    /**
+     * "oauth.check.issuer"
+     */
     public static final String OAUTH_CHECK_ISSUER = "oauth.check.issuer";
+
+    /**
+     * "oauth.check.audience"
+     */
     public static final String OAUTH_CHECK_AUDIENCE = "oauth.check.audience";
+
+    /**
+     * "oauth.custom.claim.check"
+     */
     public static final String OAUTH_CUSTOM_CLAIM_CHECK = "oauth.custom.claim.check";
+
+    /**
+     * "oauth.groups.claim"
+     */
     public static final String OAUTH_GROUPS_CLAIM = "oauth.groups.claim";
+
+    /**
+     * "oauth.groups.claim.delimiter"
+     */
     public static final String OAUTH_GROUPS_CLAIM_DELIMITER = "oauth.groups.claim.delimiter";
+
+    /**
+     * "oauth.valid.token.type"
+     */
     public static final String OAUTH_VALID_TOKEN_TYPE = "oauth.valid.token.type";
+
+    /**
+     * "oauth.fail.fast"
+     */
     public static final String OAUTH_FAIL_FAST = "oauth.fail.fast";
 
+    /**
+     * "strimzi.authorizer.delegate.class.name"
+     */
     public static final String STRIMZI_AUTHORIZER_DELEGATE_CLASS_NAME = "strimzi.authorizer.delegate.class.name";
+
+    /**
+     * "strimzi.authorizer.grant.when.no.delegate"
+     */
     public static final String STRIMZI_AUTHORIZER_GRANT_WHEN_NO_DELEGATE = "strimzi.authorizer.grant.when.no.delegate";
 
+    /**
+     * "oauth.validation.skip.type.check"
+     */
     @Deprecated
     public static final String OAUTH_VALIDATION_SKIP_TYPE_CHECK = "oauth.validation.skip.type.check";
 
+    /**
+     * Create a new instance
+     */
     public ServerConfig() {
     }
 
+    /**
+     * Create a new instance
+     *
+     * @param p Config properties
+     */
     public ServerConfig(Properties p) {
         super(p);
     }

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
         <maven.compiler.version>3.8.1</maven.compiler.version>
         <maven.dependency.version>3.1.1</maven.dependency.version>
         <maven.surefire.version>2.22.1</maven.surefire.version>
-        <maven.javadoc.version>3.1.0</maven.javadoc.version>
+        <maven.javadoc.version>3.4.1</maven.javadoc.version>
         <maven.source.version>3.0.1</maven.source.version>
         <maven.gpg.version>1.6</maven.gpg.version>
         <maven.checkstyle.version>3.1.0</maven.checkstyle.version>

--- a/pom.xml
+++ b/pom.xml
@@ -67,19 +67,18 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.compiler.version>3.8.1</maven.compiler.version>
-        <maven.dependency.version>3.1.1</maven.dependency.version>
-        <maven.surefire.version>2.22.1</maven.surefire.version>
-        <maven.javadoc.version>3.4.1</maven.javadoc.version>
-        <maven.source.version>3.0.1</maven.source.version>
-        <maven.gpg.version>1.6</maven.gpg.version>
-        <maven.checkstyle.version>3.1.0</maven.checkstyle.version>
-        <maven.resources.version>3.1.0</maven.resources.version>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.version>3.11.0</maven.compiler.version>
+        <maven.dependency.version>3.5.0</maven.dependency.version>
+        <maven.surefire.version>3.0.0-M9</maven.surefire.version>
+        <maven.javadoc.version>3.5.0</maven.javadoc.version>
+        <maven.source.version>3.2.1</maven.source.version>
+        <maven.gpg.version>3.0.1</maven.gpg.version>
+        <maven.checkstyle.version>3.2.1</maven.checkstyle.version>
+        <maven.resources.version>3.3.0</maven.resources.version>
         <spotbugs.version>4.7.0</spotbugs.version>
         <sonatype.nexus.staging>1.6.3</sonatype.nexus.staging>
-
         <kafka.version>3.3.1</kafka.version>
         <jackson.version>2.13.4</jackson.version>
         <jackson.databind.version>2.13.4.2</jackson.databind.version>
@@ -344,6 +343,38 @@
     </build>
 
     <profiles>
+        <profile>
+            <id>java-8</id>
+            <activation>
+                <jdk>1.8</jdk>
+            </activation>
+            <properties>
+                <maven.compiler.source>1.8</maven.compiler.source>
+                <maven.compiler.target>1.8</maven.compiler.target>
+            </properties>
+        </profile>
+        <profile>
+            <id>java-11</id>
+            <activation>
+                <jdk>[11,17)</jdk>
+            </activation>
+            <properties>
+                <maven.compiler.source>11</maven.compiler.source>
+                <maven.compiler.target>11</maven.compiler.target>
+                <maven.compiler.release>11</maven.compiler.release>
+            </properties>
+        </profile>
+        <profile>
+            <id>java-17</id>
+            <activation>
+                <jdk>[17,</jdk>
+            </activation>
+            <properties>
+                <maven.compiler.source>11</maven.compiler.source>
+                <maven.compiler.target>17</maven.compiler.target>
+                <maven.compiler.release>17</maven.compiler.release>
+            </properties>
+        </profile>
         <profile>
             <id>ossrh</id>
             <activation>

--- a/testsuite/mock-oauth-server/Dockerfile
+++ b/testsuite/mock-oauth-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk:11-jre-hotspot
+FROM eclipse-temurin:17-jre-centos7
 
 ENV APP_DIR /application
 ENV APP_FILE container-uber-jar.jar

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -30,8 +30,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <maven.compiler.version>3.8.1</maven.compiler.version>
         <maven.resources.version>3.1.0</maven.resources.version>
         <maven.dependency.version>3.1.1</maven.dependency.version>
@@ -284,96 +284,112 @@
         <profile>
             <id>kafka-2_3_1</id>
             <properties>
+                <!-- Uses JDK 1.8.0 -->
                 <kafka.docker.image>quay.io/strimzi/kafka:0.17.0-kafka-2.3.1</kafka.docker.image>
             </properties>
         </profile>
         <profile>
             <id>kafka-2_4_0</id>
             <properties>
+                <!-- Uses JDK 11.0.x -->
                 <kafka.docker.image>quay.io/strimzi/kafka:0.19.0-kafka-2.4.0</kafka.docker.image>
             </properties>
         </profile>
         <profile>
             <id>kafka-2_4_1</id>
             <properties>
+                <!-- Uses JDK 11.0.x -->
                 <kafka.docker.image>quay.io/strimzi/kafka:0.19.0-kafka-2.4.1</kafka.docker.image>
             </properties>
         </profile>
         <profile>
             <id>kafka-2_5_0</id>
             <properties>
+                <!-- Uses JDK 11.0.x -->
                 <kafka.docker.image>quay.io/strimzi/kafka:0.22.1-kafka-2.5.0</kafka.docker.image>
             </properties>
         </profile>
         <profile>
             <id>kafka-2_5_1</id>
             <properties>
+                <!-- Uses JDK 11.0.x -->
                 <kafka.docker.image>quay.io/strimzi/kafka:0.22.1-kafka-2.5.1</kafka.docker.image>
             </properties>
         </profile>
         <profile>
             <id>kafka-2_6_0</id>
             <properties>
+                <!-- Uses JDK 11.0.x -->
                 <kafka.docker.image>quay.io/strimzi/kafka:0.23.0-kafka-2.6.0</kafka.docker.image>
             </properties>
         </profile>
         <profile>
             <id>kafka-2_6_2</id>
             <properties>
+                <!-- Uses JDK 11.0.x -->
                 <kafka.docker.image>quay.io/strimzi/kafka:0.23.0-kafka-2.6.2</kafka.docker.image>
             </properties>
         </profile>
         <profile>
             <id>kafka-2_7_0</id>
             <properties>
+                <!-- Uses JDK 11.0.x -->
                 <kafka.docker.image>quay.io/strimzi/kafka:0.25.0-kafka-2.7.0</kafka.docker.image>
             </properties>
         </profile>
         <profile>
             <id>kafka-2_7_1</id>
             <properties>
+                <!-- Uses JDK 11.0.x -->
                 <kafka.docker.image>quay.io/strimzi/kafka:0.25.0-kafka-2.7.1</kafka.docker.image>
             </properties>
         </profile>
         <profile>
             <id>kafka-2_8_0</id>
             <properties>
+                <!-- Uses JDK 11.0.x -->
                 <kafka.docker.image>quay.io/strimzi/kafka:0.27.1-kafka-2.8.0</kafka.docker.image>
             </properties>
         </profile>
         <profile>
             <id>kafka-2_8_1</id>
             <properties>
+                <!-- Uses JDK 11.0.x -->
                 <kafka.docker.image>quay.io/strimzi/kafka:0.27.1-kafka-2.8.1</kafka.docker.image>
             </properties>
         </profile>
         <profile>
             <id>kafka-3_0_0</id>
             <properties>
+                <!-- Uses JDK 11.0.x -->
                 <kafka.docker.image>quay.io/strimzi/kafka:0.28.0-kafka-3.0.0</kafka.docker.image>
             </properties>
         </profile>
         <profile>
             <id>kafka-3_1_2</id>
             <properties>
+                <!-- Uses JDK 11.0.x -->
                 <kafka.docker.image>quay.io/strimzi/kafka:0.31.1-kafka-3.1.2</kafka.docker.image>
             </properties>
         </profile>
         <profile>
             <id>kafka-3_2_3</id>
             <properties>
+                <!-- Uses JDK 17.0.x -->
                 <kafka.docker.image>quay.io/strimzi/kafka:0.33.0-kafka-3.2.3</kafka.docker.image>
             </properties>
         </profile>
         <profile>
             <id>kafka-3_3_1</id>
             <properties>
+                <!-- Uses JDK 17.0.x -->
                 <kafka.docker.image>quay.io/strimzi/kafka:0.33.0-kafka-3.3.1</kafka.docker.image>
             </properties>
         </profile>
         <profile>
             <id>kafka-3_3_2</id>
             <properties>
+                <!-- Uses JDK 17.0.x -->
                 <kafka.docker.image>quay.io/strimzi/kafka:0.33.1-kafka-3.3.2</kafka.docker.image>
             </properties>
         </profile>
@@ -383,5 +399,38 @@
             -->
             <id>custom</id>
         </profile>
+        <profile>
+            <id>java-8</id>
+            <activation>
+                <jdk>1.8</jdk>
+            </activation>
+            <properties>
+                <maven.compiler.source>1.8</maven.compiler.source>
+                <maven.compiler.target>1.8</maven.compiler.target>
+            </properties>
+        </profile>
+        <profile>
+            <id>java-11</id>
+            <activation>
+                <jdk>[11,17)</jdk>
+            </activation>
+            <properties>
+                <maven.compiler.source>11</maven.compiler.source>
+                <maven.compiler.target>11</maven.compiler.target>
+                <maven.compiler.release>11</maven.compiler.release>
+            </properties>
+        </profile>
+        <profile>
+            <id>java-17</id>
+            <activation>
+                <jdk>[17,</jdk>
+            </activation>
+            <properties>
+                <maven.compiler.source>11</maven.compiler.source>
+                <maven.compiler.target>17</maven.compiler.target>
+                <maven.compiler.release>17</maven.compiler.release>
+            </properties>
+        </profile>
+
     </profiles>
 </project>


### PR DESCRIPTION
- Added three profiles: java-8, java-11, and java-17 that activate automatically based on the JDK used
- Fixed JavaDoc warnings so the project builds with Java 17
- Fixed `.travis/build.sh` script to use Java 11 and run testsuite on x86_64 