### PR TITLE
Bump jsonpath dependency to 2.8.0 for sub-dependency CVE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
         <kafka.version>3.3.1</kafka.version>
         <jackson.version>2.13.4</jackson.version>
         <jackson.databind.version>2.13.4.2</jackson.databind.version>
-        <jsonpath.version>2.6.0</jsonpath.version>
+        <jsonpath.version>2.8.0</jsonpath.version>
         <junit.version>4.13.1</junit.version>
         <slf4j.version>1.7.36</slf4j.version>
         <mockito.version>3.12.4</mockito.version>


### PR DESCRIPTION
Mitigates CVE-2023-1370, which is found in json-smart, which is a sub-dependency 
of the com.jayway.jsonpath:json-path dependency.