### PR TITLE
Remove the use of `metric.reporters` in OAuth metrics, use `strimzi.metric.reporters` instead

### DIFF
--- a/examples/kubernetes/kafka-oauth-authz-metrics-client.yaml
+++ b/examples/kubernetes/kafka-oauth-authz-metrics-client.yaml
@@ -46,6 +46,8 @@ spec:
       env:
         - name: OAUTH_ENABLE_METRICS
           value: "true"
+        - name: STRIMZI_METRIC_REPORTERS
+          value: org.apache.kafka.common.metrics.JmxReporter
         - name: SECRET
           valueFrom:
             secretKeyRef:

--- a/examples/kubernetes/kafka-oauth-single-authz-metrics.yaml
+++ b/examples/kubernetes/kafka-oauth-single-authz-metrics.yaml
@@ -5,7 +5,7 @@ metadata:
   name: my-cluster
 spec:
   kafka:
-    version: 3.3.2
+    version: 3.4.0
     replicas: 1
     listeners:
       - name: plain
@@ -68,12 +68,14 @@ spec:
         env:
           - name: OAUTH_ENABLE_METRICS
             value: "true"
-    #      - name: KAFKA_DEBUG
-    #        value: "y"
-    #      - name: DEBUG_SUSPEND_FLAG
-    #        value: "y"
-    #      - name: JAVA_DEBUG_PORT
-    #        value: "5005"
+          - name: STRIMZI_METRIC_REPORTERS
+            value: org.apache.kafka.common.metrics.JmxReporter
+          #- name: KAFKA_DEBUG
+          #  value: "y"
+          #- name: DEBUG_SUSPEND_FLAG
+          #  value: "n"
+          #- name: JAVA_DEBUG_PORT
+          #  value: "5005"
     jmxOptions: {}
 
   zookeeper:
@@ -94,6 +96,7 @@ spec:
   entityOperator:
     topicOperator: {}
     userOperator: {}
+
 ---
 kind: ConfigMap
 apiVersion: v1

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/metrics/GlobalConfig.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/metrics/GlobalConfig.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2017-2023, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.kafka.oauth.metrics;
+
+import io.strimzi.kafka.oauth.common.Config;
+
+/**
+ * Configuration that can be specified as ENV vars, System properties or in <code>server.properties</code> configuration file,
+ * but not as part of the JAAS configuration.
+ */
+public class GlobalConfig extends Config {
+
+    /** The name of the 'strimzi.metric.reporters' config option */
+    public static final String STRIMZI_METRIC_REPORTERS = "strimzi.metric.reporters";
+}

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/services/Services.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/services/Services.java
@@ -40,6 +40,13 @@ public class Services {
     }
 
     /**
+     * Close any configured Services so they can be reinitialised again
+     */
+    public static synchronized void close() {
+        services = null;
+    }
+
+    /**
      * Get a configured singleton instance
      *
      * @return Services object

--- a/testsuite/common/src/main/java/io/strimzi/testsuite/oauth/common/TestUtil.java
+++ b/testsuite/common/src/main/java/io/strimzi/testsuite/oauth/common/TestUtil.java
@@ -93,4 +93,32 @@ public class TestUtil {
         System.out.println("========    "  + msg);
         System.out.println();
     }
+
+    public static int findFirstMatchingInLog(List<String> log, String regex) {
+        int lineNum = 0;
+        Pattern pattern = Pattern.compile(prepareRegex(regex));
+        for (String line: log) {
+            if (pattern.matcher(line).matches()) {
+                return lineNum;
+            }
+            lineNum++;
+        }
+        return -1;
+    }
+
+    public static String prepareRegex(String regex) {
+        String prefix = regex.startsWith("^") ? "" : ".*";
+        String suffix = regex.endsWith("$") ? "" : ".*";
+        return prefix + regex + suffix;
+    }
+
+    public static boolean checkLogForRegex(List<String> log, String regex) {
+        Pattern pattern = Pattern.compile(prepareRegex(regex));
+        for (String line: log) {
+            if (pattern.matcher(line).matches()) {
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/testsuite/common/src/main/java/io/strimzi/testsuite/oauth/common/metrics/TestMetricsReporter.java
+++ b/testsuite/common/src/main/java/io/strimzi/testsuite/oauth/common/metrics/TestMetricsReporter.java
@@ -2,7 +2,7 @@
  * Copyright 2017-2022, Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
-package io.strimzi.testsuite.oauth.auth.metrics;
+package io.strimzi.testsuite.oauth.common.metrics;
 
 import org.apache.kafka.common.metrics.KafkaMetric;
 import org.slf4j.Logger;

--- a/testsuite/keycloak-auth-tests/docker-compose.yml
+++ b/testsuite/keycloak-auth-tests/docker-compose.yml
@@ -45,7 +45,7 @@ services:
       - "5006:5006"
     volumes:
       - ${PWD}/../docker/target/kafka/libs:/opt/kafka/libs/strimzi
-      - ${PWD}/target/test-classes:/opt/kafka/libs/strimzi/reporters
+      - ${PWD}/../common/target/classes:/opt/kafka/libs/strimzi/reporters
       - ${PWD}/../docker/kafka/config:/opt/kafka/config/strimzi
       - ${PWD}/../docker/kafka/scripts:/opt/kafka/strimzi
     command:
@@ -65,9 +65,6 @@ services:
       - KAFKA_SASL_ENABLED_MECHANISMS=OAUTHBEARER
       - KAFKA_INTER_BROKER_LISTENER_NAME=INTROSPECT
       - KAFKA_SASL_MECHANISM_INTER_BROKER_PROTOCOL=OAUTHBEARER
-
-      # Common settings for all the listeners
-      - OAUTH_ENABLE_METRICS=true
 
       # username extraction from JWT token claim
       - OAUTH_USERNAME_CLAIM=preferred_username
@@ -129,11 +126,23 @@ services:
       - KAFKA_LISTENER_NAME_FORGE_OAUTHBEARER_SASL_SERVER_CALLBACK_HANDLER_CLASS=io.strimzi.kafka.oauth.server.JaasServerOauthValidatorCallbackHandler
 
       # Test Metrics Reporters
-      - KAFKA_METRIC_REPORTERS=io.strimzi.testsuite.oauth.auth.metrics.TestMetricsReporter
       - KAFKA_METRICS_CONTEXT_TEST_LABEL=testvalue
       - KAFKA_METRICS_NUM_SAMPLES=3
       - KAFKA_METRICS_RECORDING_LEVEL=DEBUG
       - KAFKA_METRICS_SAMPLE_WINDOW_MS=15000
+
+
+      # OAuth metrics configuration
+
+      - OAUTH_ENABLE_METRICS=true
+      #   When enabling metrics we also have to explicitly configure JmxReporter to have metrics available in JMX
+      #   The following value will be available as env var STRIMZI_METRIC_REPORTERS
+      - STRIMZI_METRIC_REPORTERS=org.apache.kafka.common.metrics.JmxReporter,io.strimzi.testsuite.oauth.common.metrics.TestMetricsReporter
+
+      #   The following value will turn to 'strimzi.metric.reporters=...' in 'strimzi.properties' file
+      #   However, that won't work as the value may be filtered to the component that happens to initialise OAuthMetrics
+      #- KAFKA_STRIMZI_METRIC_REPORTERS=org.apache.kafka.common.metrics.JmxReporter
+
 
       # For start.sh script to know where the keycloak is listening
       - KEYCLOAK_HOST=${KEYCLOAK_HOST:-keycloak}

--- a/testsuite/keycloak-auth-tests/src/test/java/io/strimzi/testsuite/oauth/auth/BasicTests.java
+++ b/testsuite/keycloak-auth-tests/src/test/java/io/strimzi/testsuite/oauth/auth/BasicTests.java
@@ -62,12 +62,11 @@ public class BasicTests {
     void oauthMetricsConfigIntegration() {
         System.out.println("    ====    KeycloakAuthenticationTest :: oauthMetricsConfigIntegrationTest");
 
-        // Test MetricReporter config works as expected
+        // Test that MetricReporter config works as expected
         // Get kafka log and make sure the TestMetricReporter was initialised exactly twice
         List<String> lines = getContainerLogsForString(kafkaContainer, "TestMetricsReporter no. ");
-        Assert.assertEquals("Kafka log should contain: \"TestMetricsReporter no. \" exactly twice", 2, lines.size());
+        Assert.assertEquals("Kafka log should contain: \"TestMetricsReporter no. \" exactly once", 1, lines.size());
         Assert.assertTrue("Contains \"TestMetricsReporter no. 1\"", lines.get(0).contains("TestMetricsReporter no. 1 "));
-        Assert.assertTrue("Contains \"TestMetricsReporter no. 2\"", lines.get(1).contains("TestMetricsReporter no. 2 "));
 
         // Ensure the configuration was applied as expected
         lines = getContainerLogsForString(kafkaContainer, "Creating Metrics:");
@@ -82,7 +81,7 @@ public class BasicTests {
         Assert.assertTrue("kafka.broker.id=1", line.contains("kafka.broker.id=1"));
 
         line = lines.get(3);
-        Assert.assertTrue("io.strimzi.testsuite.oauth.auth.metrics.TestMetricsReporter", line.contains("io.strimzi.testsuite.oauth.auth.metrics.TestMetricsReporter"));
+        Assert.assertTrue("io.strimzi.testsuite.oauth.common.metrics.TestMetricsReporter", line.contains("io.strimzi.testsuite.oauth.common.metrics.TestMetricsReporter"));
         Assert.assertTrue("org.apache.kafka.common.metrics.JmxReporter", line.contains("org.apache.kafka.common.metrics.JmxReporter"));
     }
 

--- a/testsuite/keycloak-authz-kraft-tests/docker-compose.yml
+++ b/testsuite/keycloak-authz-kraft-tests/docker-compose.yml
@@ -74,8 +74,6 @@ services:
       - OAUTH_USERNAME_CLAIM=preferred_username
       - OAUTH_CONNECT_TIMEOUT_SECONDS=20
 
-      - OAUTH_ENABLE_METRICS=true
-
       # Configuration of individual listeners
       - KAFKA_LISTENER_NAME_CONTROLLER_SASL_ENABLED_MECHANISMS=PLAIN
       - KAFKA_LISTENER_NAME_CONTROLLER_PLAIN_SASL_JAAS_CONFIG=org.apache.kafka.common.security.plain.PlainLoginModule required    username=\"admin\"    password=\"admin-password\"    user_admin=\"admin-password\"    user_bobby=\"bobby-secret\" ;
@@ -133,6 +131,19 @@ services:
       - KAFKA_STRIMZI_AUTHORIZATION_ENABLE_METRICS=true
 
       - KAFKA_SUPER_USERS=User:admin;User:service-account-kafka
+
+
+      # OAuth metrics configuration
+
+      - OAUTH_ENABLE_METRICS=true
+      #   When enabling metrics we also have to explicitly configure JmxReporter to have metrics available in JMX
+      #   The following value will be available as env var STRIMZI_METRIC_REPORTERS
+      - STRIMZI_METRIC_REPORTERS=org.apache.kafka.common.metrics.JmxReporter
+
+      #   The following value will turn to 'strimzi.metric.reporters=...' in 'strimzi.properties' file
+      #   However, that won't work as the value may be filtered to the component that happens to initialise OAuthMetrics
+      #- KAFKA_STRIMZI_METRIC_REPORTERS=org.apache.kafka.common.metrics.JmxReporter
+
 
       # Other configuration
       - KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1

--- a/testsuite/keycloak-authz-tests/docker-compose.yml
+++ b/testsuite/keycloak-authz-tests/docker-compose.yml
@@ -68,8 +68,6 @@ services:
       - OAUTH_USERNAME_CLAIM=preferred_username
       - OAUTH_CONNECT_TIMEOUT_SECONDS=20
 
-      - OAUTH_ENABLE_METRICS=true
-
       # Configuration of individual listeners
       - KAFKA_LISTENER_NAME_JWT_OAUTHBEARER_SASL_JAAS_CONFIG=org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required    oauth.jwks.endpoint.uri=\"http://keycloak:8080/auth/realms/kafka-authz/protocol/openid-connect/certs\"    oauth.valid.issuer.uri=\"http://keycloak:8080/auth/realms/kafka-authz\"    oauth.token.endpoint.uri=\"http://keycloak:8080/auth/realms/kafka-authz/protocol/openid-connect/token\"    oauth.client.id=\"kafka\"    oauth.client.secret=\"kafka-secret\"    oauth.groups.claim=\"$$.realm_access.roles\" ;
       - KAFKA_LISTENER_NAME_JWT_OAUTHBEARER_SASL_SERVER_CALLBACK_HANDLER_CLASS=io.strimzi.kafka.oauth.server.JaasServerOauthValidatorCallbackHandler
@@ -121,6 +119,19 @@ services:
       - KAFKA_STRIMZI_AUTHORIZATION_ENABLE_METRICS=true
 
       - KAFKA_SUPER_USERS=User:admin;User:service-account-kafka
+
+
+      # OAuth metrics configuration
+
+      - OAUTH_ENABLE_METRICS=true
+      #   When enabling metrics we also have to explicitly configure JmxReporter to have metrics available in JMX
+      #   The following value will be available as env var STRIMZI_METRIC_REPORTERS
+      - STRIMZI_METRIC_REPORTERS=org.apache.kafka.common.metrics.JmxReporter
+
+      #   The following value will turn to 'strimzi.metric.reporters=...' in 'strimzi.properties' file
+      #   However, that won't work as the value may be filtered to the component that happens to initialise OAuthMetrics
+      #- KAFKA_STRIMZI_METRIC_REPORTERS=org.apache.kafka.common.metrics.JmxReporter
+
 
       # Other configuration
       - KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1

--- a/testsuite/keycloak-authz-zk-tests/docker-compose.yml
+++ b/testsuite/keycloak-authz-zk-tests/docker-compose.yml
@@ -68,8 +68,6 @@ services:
       - OAUTH_USERNAME_CLAIM=preferred_username
       - OAUTH_CONNECT_TIMEOUT_SECONDS=20
 
-      - OAUTH_ENABLE_METRICS=true
-
       # Configuration of individual listeners
       - KAFKA_LISTENER_NAME_JWT_OAUTHBEARER_SASL_JAAS_CONFIG=org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required    oauth.jwks.endpoint.uri=\"http://keycloak:8080/auth/realms/kafka-authz/protocol/openid-connect/certs\"    oauth.valid.issuer.uri=\"http://keycloak:8080/auth/realms/kafka-authz\"    oauth.token.endpoint.uri=\"http://keycloak:8080/auth/realms/kafka-authz/protocol/openid-connect/token\"    oauth.client.id=\"kafka\"    oauth.client.secret=\"kafka-secret\"    oauth.groups.claim=\"$$.realm_access.roles\" ;
       - KAFKA_LISTENER_NAME_JWT_OAUTHBEARER_SASL_SERVER_CALLBACK_HANDLER_CLASS=io.strimzi.kafka.oauth.server.JaasServerOauthValidatorCallbackHandler
@@ -125,6 +123,19 @@ services:
       - KAFKA_STRIMZI_AUTHORIZATION_ENABLE_METRICS=true
 
       - KAFKA_SUPER_USERS=User:admin;User:service-account-kafka
+
+
+      # OAuth metrics configuration
+
+      - OAUTH_ENABLE_METRICS=true
+      #   When enabling metrics we also have to explicitly configure JmxReporter to have metrics available in JMX
+      #   The following value will be available as env var STRIMZI_METRIC_REPORTERS
+      - STRIMZI_METRIC_REPORTERS=org.apache.kafka.common.metrics.JmxReporter
+
+      #   The following value will turn to 'strimzi.metric.reporters=...' in 'strimzi.properties' file
+      #   However, that won't work as the value may be filtered to the component that happens to initialise OAuthMetrics
+      #- KAFKA_STRIMZI_METRIC_REPORTERS=org.apache.kafka.common.metrics.JmxReporter
+
 
       # Other configuration
       - KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1

--- a/testsuite/mockoauth-tests/docker-compose.yml
+++ b/testsuite/mockoauth-tests/docker-compose.yml
@@ -34,6 +34,8 @@ services:
       - "9097:9097"
       - "9098:9098"
       - "9404:9404"
+
+      # Debug port
       - "5006:5006"
     volumes:
       - ${PWD}/../docker/target/kafka/libs:/opt/kafka/libs/strimzi
@@ -104,7 +106,18 @@ services:
       - OAUTH_SSL_TRUSTSTORE_TYPE=pkcs12
       - OAUTH_CONNECT_TIMEOUT_SECONDS=10
       - OAUTH_READ_TIMEOUT_SECONDS=10
+
+
+      # OAuth metrics configuration
+
       - OAUTH_ENABLE_METRICS=true
+      #   When enabling metrics we also have to explicitly configure JmxReporter to have metrics available in JMX
+      #   The following value will be available as env var STRIMZI_METRIC_REPORTERS
+      - STRIMZI_METRIC_REPORTERS=org.apache.kafka.common.metrics.JmxReporter
+
+      #   The following value will turn to 'strimzi.metric.reporters=...' in 'strimzi.properties' file
+      #   However, that won't work as the value may be filtered to the component that happens to initialise OAuthMetrics
+      #- KAFKA_STRIMZI_METRIC_REPORTERS=org.apache.kafka.common.metrics.JmxReporter
 
   zookeeper:
     image: ${KAFKA_DOCKER_IMAGE}

--- a/testsuite/mockoauth-tests/src/test/java/io/strimzi/testsuite/oauth/MockOAuthTests.java
+++ b/testsuite/mockoauth-tests/src/test/java/io/strimzi/testsuite/oauth/MockOAuthTests.java
@@ -6,7 +6,7 @@ package io.strimzi.testsuite.oauth;
 
 import io.strimzi.testsuite.oauth.common.TestContainersLogCollector;
 import io.strimzi.testsuite.oauth.common.TestContainersWatcher;
-import io.strimzi.testsuite.oauth.metrics.MetricsTest;
+import io.strimzi.testsuite.oauth.mockoauth.metrics.MetricsTest;
 import io.strimzi.testsuite.oauth.mockoauth.ConnectTimeoutTests;
 import io.strimzi.testsuite.oauth.mockoauth.JWKSKeyUseTest;
 import io.strimzi.testsuite.oauth.mockoauth.JaasClientConfigTest;

--- a/testsuite/mockoauth-tests/src/test/java/io/strimzi/testsuite/oauth/mockoauth/Common.java
+++ b/testsuite/mockoauth-tests/src/test/java/io/strimzi/testsuite/oauth/mockoauth/Common.java
@@ -13,7 +13,7 @@ import io.strimzi.kafka.oauth.common.PrincipalExtractor;
 import io.strimzi.kafka.oauth.common.SSLUtil;
 import io.strimzi.kafka.oauth.common.TimeUtil;
 import io.strimzi.kafka.oauth.common.TokenInfo;
-import io.strimzi.testsuite.oauth.metrics.Metrics;
+import io.strimzi.testsuite.oauth.mockoauth.metrics.Metrics;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.junit.Assert;
@@ -35,6 +35,7 @@ import java.util.Set;
 public class Common {
 
     static final String WWW_FORM_CONTENT_TYPE = "application/x-www-form-urlencoded";
+    public static final String LOG_PATH = "target/test.log";
 
     static String getJaasConfigOptionsString(Map<String, String> options) {
         StringBuilder sb = new StringBuilder();

--- a/testsuite/mockoauth-tests/src/test/java/io/strimzi/testsuite/oauth/mockoauth/KeycloakAuthorizerTest.java
+++ b/testsuite/mockoauth-tests/src/test/java/io/strimzi/testsuite/oauth/mockoauth/KeycloakAuthorizerTest.java
@@ -71,8 +71,6 @@ public class KeycloakAuthorizerTest {
     static final int LOOP_PAUSE_MS = 1000;
     static final int TIMEOUT_SECONDS = 30;
 
-    static final String LOG_PATH = "target/test.log";
-
     static final String CLIENT_CLI = "kafka-cli";
 
     static final String USER_ALICE = "alice";
@@ -121,7 +119,7 @@ public class KeycloakAuthorizerTest {
 
         changeAuthServerMode("token", "MODE_200");
 
-        LogLineReader logReader = new LogLineReader(LOG_PATH);
+        LogLineReader logReader = new LogLineReader(Common.LOG_PATH);
         logReader.readNext();
 
         List<String> lines;
@@ -160,16 +158,16 @@ public class KeycloakAuthorizerTest {
             Assert.assertEquals("Authorizer should return ALLOWED", AuthorizationResult.ALLOWED, result.get(0));
 
             lines = logReader.readNext();
-            Assert.assertTrue("Saving non-null grants", checkLogForRegex(lines, "Saving non-null grants"));
+            Assert.assertTrue("Saving non-null grants", TestUtil.checkLogForRegex(lines, "Saving non-null grants"));
 
             // Switch grants endpoint to 401 mode
             changeAuthServerMode("grants", "MODE_401");
 
             LOG.info("Waiting for: Done refreshing"); // Make sure to not repeat the below condition in the string here
-            lines = waitFor(logReader, "Done refreshing grants");
-            Assert.assertTrue("Failed to fetch", checkLogForRegex(lines, "Failed to fetch grants .* status 401"));
-            Assert.assertTrue("Removed user from grants cache", checkLogForRegex(lines, "Removed user from grants cache: alice"));
-            Assert.assertTrue("Removed invalid session", checkLogForRegex(lines, "Removed invalid session from sessions map \\(userId: alice"));
+            lines = logReader.waitFor("Done refreshing grants");
+            Assert.assertTrue("Failed to fetch", TestUtil.checkLogForRegex(lines, "Failed to fetch grants .* status 401"));
+            Assert.assertTrue("Removed user from grants cache", TestUtil.checkLogForRegex(lines, "Removed user from grants cache: alice"));
+            Assert.assertTrue("Removed invalid session", TestUtil.checkLogForRegex(lines, "Removed invalid session from sessions map \\(userId: alice"));
 
         } finally {
             changeAuthServerMode("grants", "MODE_200");
@@ -184,7 +182,7 @@ public class KeycloakAuthorizerTest {
         // Switch grants endpoint to 403 mode
         changeAuthServerMode("grants", "MODE_403");
 
-        LogLineReader logReader = new LogLineReader(LOG_PATH);
+        LogLineReader logReader = new LogLineReader(Common.LOG_PATH);
         logReader.readNext();
 
         List<String> lines;
@@ -211,8 +209,8 @@ public class KeycloakAuthorizerTest {
 
             lines = logReader.readNext();
 
-            Assert.assertTrue("Saving non-null grants", checkLogForRegex(lines, "Saving non-null grants"));
-            Assert.assertTrue("grants for user: {}", checkLogForRegex(lines, "grants for .*: \\{\\}"));
+            Assert.assertTrue("Saving non-null grants", TestUtil.checkLogForRegex(lines, "Saving non-null grants"));
+            Assert.assertTrue("grants for user: {}", TestUtil.checkLogForRegex(lines, "grants for .*: \\{\\}"));
 
         } finally {
             changeAuthServerMode("grants", "MODE_200");
@@ -298,13 +296,13 @@ public class KeycloakAuthorizerTest {
         try (KeycloakAuthorizer authorizer = new KeycloakAuthorizer()) {
             authorizer.configure(props);
 
-            LogLineReader logReader = new LogLineReader(LOG_PATH);
+            LogLineReader logReader = new LogLineReader(Common.LOG_PATH);
             List<String> lines = logReader.readNext();
 
             if (withReuse) {
-                Assert.assertTrue("reuseGrants should be true", checkLogForRegex(lines, "reuseGrants: true"));
+                Assert.assertTrue("reuseGrants should be true", TestUtil.checkLogForRegex(lines, "reuseGrants: true"));
             } else {
-                Assert.assertTrue("reuseGrants should default to false", checkLogForRegex(lines, "reuseGrants: false"));
+                Assert.assertTrue("reuseGrants should default to false", TestUtil.checkLogForRegex(lines, "reuseGrants: false"));
             }
 
             TokenInfo tokenInfo = login(FAILING_TOKEN_ENDPOINT, user, userPass, 1);
@@ -428,7 +426,7 @@ public class KeycloakAuthorizerTest {
         }
         config.put(AuthzConfig.STRIMZI_AUTHORIZATION_CLIENT_ID, "kafka");
 
-        LogLineReader logReader = new LogLineReader(LOG_PATH);
+        LogLineReader logReader = new LogLineReader(Common.LOG_PATH);
 
         // Position to the end of the existing log file
         logReader.readNext();
@@ -554,11 +552,11 @@ public class KeycloakAuthorizerTest {
 
 
             // check the logs for updated access token
-            LogLineReader logReader = new LogLineReader(LOG_PATH);
+            LogLineReader logReader = new LogLineReader(Common.LOG_PATH);
 
             // wait for cgGrants run on 0 users
             LOG.info("Waiting for: active users count: 0"); // Make sure to not repeat the below condition in the string here
-            waitFor(logReader, "Grants gc: active users count: 0");
+            logReader.waitFor("Grants gc: active users count: 0");
 
             LOG.info("Authenticate (validate) as gcUser1");
             OAuthKafkaPrincipal principal = authenticate(authHandler, tokenInfo);
@@ -598,7 +596,7 @@ public class KeycloakAuthorizerTest {
 
             LOG.info("Waiting for: active users count: 2, grantsCache size before: 1, grantsCache size after: 1"); // Make sure to not repeat the below condition in the string here
             // wait for cgGrants run on 2 users
-            waitFor(logReader, "Grants gc: active users count: 2, grantsCache size before: 1, grantsCache size after: 1");
+            logReader.waitFor("Grants gc: active users count: 2, grantsCache size before: 1, grantsCache size after: 1");
 
 
             authzContext = newAuthorizableRequestContext(principal);
@@ -609,12 +607,12 @@ public class KeycloakAuthorizerTest {
 
             // wait for cgGrants run on 2 users and two grants cache entries
             LOG.info("Waiting for: active users count: 2, grantsCache size before: 2, grantsCache size after: 2"); // Make sure to not repeat the below condition in the string here
-            waitFor(logReader, "Grants gc: active users count: 2, grantsCache size before: 2, grantsCache size after: 2");
+            logReader.waitFor("Grants gc: active users count: 2, grantsCache size before: 2, grantsCache size after: 2");
 
 
             // now wait for token to expire for gcUser2
             LOG.info("Waiting for: active users count: 1, grantsCache size before: 2, grantsCache size after: 1"); // Make sure to not repeat the below condition in the string here
-            waitFor(logReader, "Grants gc: active users count: 1, grantsCache size before: 2, grantsCache size after: 1");
+            logReader.waitFor("Grants gc: active users count: 1, grantsCache size before: 2, grantsCache size after: 1");
 
 
             // authorization should now fail since the token has expired
@@ -697,7 +695,7 @@ public class KeycloakAuthorizerTest {
                 new ResourcePattern(ResourceType.TOPIC, "my-topic", PatternType.LITERAL),
                 1, true, true));
 
-        LogLineReader logReader = new LogLineReader(LOG_PATH);
+        LogLineReader logReader = new LogLineReader(Common.LOG_PATH);
         // seek to the end of log file
         logReader.readNext();
 
@@ -716,7 +714,7 @@ public class KeycloakAuthorizerTest {
 
             // This is a first authorize() call on the KeycloakAuthorizer -> the grantsCache is empty
             LOG.info("Waiting for: unsupported segment type: Topc"); // Make sure to not repeat the below condition in the string here
-            waitFor(logReader, "Failed to parse .* unsupported segment type: Topc");
+            logReader.waitFor("Failed to parse .* unsupported segment type: Topc");
 
 
             // malformed resource spec - no ':' in Topic;my-topic*
@@ -726,7 +724,7 @@ public class KeycloakAuthorizerTest {
 
             // wait for grants refresh
             LOG.info("Waiting for: Done refreshing grants"); // Make sure to not repeat the below condition in the string here
-            waitFor(logReader, "Response body .*Topic;my-topic");
+            logReader.waitFor("Response body .*Topic;my-topic");
 
 
             LOG.info("Call authorize() - test grants record with malformed resource spec 'Topic;my-topic*' (no ':')");
@@ -734,7 +732,7 @@ public class KeycloakAuthorizerTest {
             Assert.assertEquals("Authz result: DENIED", AuthorizationResult.DENIED, result.get(0));
 
             LOG.info("Waiting for: doesn't follow TYPE:NAME pattern"); // Make sure to not repeat the below condition in the string here
-            waitFor(logReader, "part doesn't follow TYPE:NAME pattern");
+            logReader.waitFor("part doesn't follow TYPE:NAME pattern");
 
             // malformed resource spec - '*' not at the end in 'Topic:*-topic'
             addGrantsForToken(tokenInfo.token(), "[{\"scopes\":[\"Delete\",\"Write\",\"Describe\",\"Read\",\"Alter\",\"Create\",\"DescribeConfigs\",\"AlterConfigs\"],\"rsid\":\"ca6f195f-dbdc-48b7-a953-8e441d17f7fa\",\"rsname\":\"Topic:*-topic\"}," +
@@ -743,7 +741,7 @@ public class KeycloakAuthorizerTest {
 
             // wait for grants refresh
             LOG.info("Waiting for: Done refreshing grants"); // Make sure to not repeat the below condition in the string here
-            waitFor(logReader, "Response body .*Topic:\\*-topic");
+            logReader.waitFor("Response body .*Topic:\\*-topic");
 
             LOG.info("Call authorize() - test grants record with malformed resource spec 'Topic:*-topic' ('*' only interpreted as asterisk at the end of resource spec)");
             result = authorizer.authorize(authzContext, actions);
@@ -757,7 +755,7 @@ public class KeycloakAuthorizerTest {
 
             // wait for grants refresh
             LOG.info("Waiting for: Done refreshing grants"); // Make sure to not repeat the below condition in the string here
-            waitFor(logReader, "Response body .*Crate");
+            logReader.waitFor("Response body .*Crate");
 
             LOG.info("Call authorize() - test grants record with unknown / invalid scope 'Crate' (it should be 'Create')");
             result = authorizer.authorize(authzContext, actions);
@@ -793,7 +791,7 @@ public class KeycloakAuthorizerTest {
                 new ResourcePattern(ResourceType.TOPIC, "x_topic", PatternType.LITERAL),
                 1, true, true));
 
-        LogLineReader logReader = new LogLineReader(LOG_PATH);
+        LogLineReader logReader = new LogLineReader(Common.LOG_PATH);
         // seek to the end of log file
         logReader.readNext();
 
@@ -812,7 +810,7 @@ public class KeycloakAuthorizerTest {
 
             // Check log for 'Saving non-null grants for user: alice'
             LOG.info("Waiting for: Saving non-null grants"); // Make sure to not repeat the below condition in the string here
-            waitFor(logReader, "Saving non-null grants for user: alice");
+            logReader.waitFor("Saving non-null grants for user: alice");
 
             // set grants for the user to `grants2` which are semantically different from `grants1`
             addGrantsForToken(tokenInfo.token(), grants2);
@@ -820,19 +818,19 @@ public class KeycloakAuthorizerTest {
             // wait for the refresh job to fetch the new grants
             // Check log for 'Grants have changed for user: alice'
             LOG.info("Waiting for: Grants have changed"); // Make sure to not repeat the below condition in the string here
-            waitFor(logReader, "Grants have changed for user: alice");
+            logReader.waitFor("Grants have changed for user: alice");
 
             // set grants for the user to `grants3` which are semantically equal to `grants2`
             addGrantsForToken(tokenInfo.token(), grants3);
 
             // wait for the refresh job to fetch the new grants
             LOG.info("Waiting for: Refreshing grants to start"); // Make sure to not repeat the below condition in the string here
-            waitFor(logReader, "Refreshing authorization grants");
+            logReader.waitFor("Refreshing authorization grants");
 
             // Check log for 'Done refreshing grants' and there should be no preceding line containing 'Grants have changed for user'
             // wait for refresh grants job to complete
             LOG.info("Waiting for grants refresh to complete"); // Make sure to not repeat the below condition in the string here
-            List<String> lines = waitFor(logReader, "Done refreshing grants");
+            List<String> lines = logReader.waitFor("Done refreshing grants");
 
             int matchCount = countLogForRegex(lines, "Grants have changed for user");
             Assert.assertEquals("Grants have changed again ?!?", 0, matchCount);
@@ -849,7 +847,7 @@ public class KeycloakAuthorizerTest {
 
         HashMap<String, String> config = configureAuthorizer();
 
-        LogLineReader logReader = new LogLineReader(LOG_PATH);
+        LogLineReader logReader = new LogLineReader(Common.LOG_PATH);
         logReader.readNext();
 
         List<String> lines;
@@ -869,26 +867,6 @@ public class KeycloakAuthorizerTest {
         }
 
         TestAuthzUtil.clearKeycloakAuthorizerService();
-    }
-
-    private List<String> waitFor(LogLineReader logReader, String condition) throws TimeoutException, InterruptedException {
-        List<String> result = new ArrayList<>();
-        TestUtil.waitForCondition(() -> {
-            try {
-                List<String> lines = logReader.readNext();
-                int lineNum = findFirstMatchingInLog(lines, condition);
-                if (lineNum >= 0) {
-                    result.addAll(lines.subList(0, lineNum));
-                    return true;
-                }
-                result.addAll(lines);
-                return false;
-            } catch (Exception e) {
-                throw new RuntimeException("Failed to read log", e);
-            }
-        }, LOOP_PAUSE_MS, TIMEOUT_SECONDS);
-
-        return result;
     }
 
     private static Future<List<AuthorizationResult>> submitAuthorizationCall(KeycloakAuthorizer authorizer, AuthorizableRequestContext ctx, ExecutorService executorService, String topic) {
@@ -931,41 +909,13 @@ public class KeycloakAuthorizerTest {
 
     static int countLogForRegex(List<String> log, String regex) {
         int count = 0;
-        Pattern pattern = Pattern.compile(prepareRegex(regex));
+        Pattern pattern = Pattern.compile(TestUtil.prepareRegex(regex));
         for (String line: log) {
             if (pattern.matcher(line).matches()) {
                 count += 1;
             }
         }
         return count;
-    }
-
-    static int findFirstMatchingInLog(List<String> log, String regex) {
-        int lineNum = 0;
-        Pattern pattern = Pattern.compile(prepareRegex(regex));
-        for (String line: log) {
-            if (pattern.matcher(line).matches()) {
-                return lineNum;
-            }
-            lineNum++;
-        }
-        return -1;
-    }
-
-    static String prepareRegex(String regex) {
-        String prefix = regex.startsWith("^") ? "" : ".*";
-        String suffix = regex.endsWith("$") ? "" : ".*";
-        return prefix + regex + suffix;
-    }
-
-    static boolean checkLogForRegex(List<String> log, String regex) {
-        Pattern pattern = Pattern.compile(prepareRegex(regex));
-        for (String line: log) {
-            if (pattern.matcher(line).matches()) {
-                return true;
-            }
-        }
-        return false;
     }
 
     private AuthorizableRequestContext newAuthorizableRequestContext(KafkaPrincipal principal) {

--- a/testsuite/mockoauth-tests/src/test/java/io/strimzi/testsuite/oauth/mockoauth/LogLineReader.java
+++ b/testsuite/mockoauth-tests/src/test/java/io/strimzi/testsuite/oauth/mockoauth/LogLineReader.java
@@ -4,10 +4,14 @@
  */
 package io.strimzi.testsuite.oauth.mockoauth;
 
+import io.strimzi.testsuite.oauth.common.TestUtil;
+
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.TimeoutException;
 
 /**
  * A very inefficient but simple and good-enough-for-tests implementation of incrementally reading a log file and serving content as lines
@@ -17,11 +21,32 @@ public class LogLineReader {
     private final String logPath;
     private int logLineOffset = 0;
 
-    LogLineReader(String logPath) {
+    public LogLineReader(String logPath) {
         this.logPath = logPath;
     }
 
-    List<String> readNext() throws IOException {
+    public List<String> waitFor(String condition) throws TimeoutException, InterruptedException {
+        List<String> result = new ArrayList<>();
+        TestUtil.waitForCondition(() -> {
+            try {
+                List<String> lines = readNext();
+                int lineNum = TestUtil.findFirstMatchingInLog(lines, condition);
+                if (lineNum >= 0) {
+                    result.addAll(lines.subList(0, lineNum));
+                    logLineOffset -= lines.size() - lineNum + 1;
+                    return true;
+                }
+                result.addAll(lines);
+                return false;
+            } catch (Exception e) {
+                throw new RuntimeException("Failed to read log", e);
+            }
+        }, KeycloakAuthorizerTest.LOOP_PAUSE_MS, KeycloakAuthorizerTest.TIMEOUT_SECONDS);
+
+        return result;
+    }
+
+    public List<String> readNext() throws IOException {
         List<String> lines = Files.readAllLines(Paths.get(logPath));
         List<String> result = lines.subList(logLineOffset, lines.size());
         logLineOffset = lines.size();

--- a/testsuite/mockoauth-tests/src/test/java/io/strimzi/testsuite/oauth/mockoauth/metrics/MetricEntry.java
+++ b/testsuite/mockoauth-tests/src/test/java/io/strimzi/testsuite/oauth/mockoauth/metrics/MetricEntry.java
@@ -2,7 +2,7 @@
  * Copyright 2017-2022, Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
-package io.strimzi.testsuite.oauth.metrics;
+package io.strimzi.testsuite.oauth.mockoauth.metrics;
 
 import java.util.Map;
 

--- a/testsuite/mockoauth-tests/src/test/java/io/strimzi/testsuite/oauth/mockoauth/metrics/Metrics.java
+++ b/testsuite/mockoauth-tests/src/test/java/io/strimzi/testsuite/oauth/mockoauth/metrics/Metrics.java
@@ -2,7 +2,7 @@
  * Copyright 2017-2022, Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
-package io.strimzi.testsuite.oauth.metrics;
+package io.strimzi.testsuite.oauth.mockoauth.metrics;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;

--- a/testsuite/mockoauth-tests/src/test/java/io/strimzi/testsuite/oauth/mockoauth/metrics/MetricsTest.java
+++ b/testsuite/mockoauth-tests/src/test/java/io/strimzi/testsuite/oauth/mockoauth/metrics/MetricsTest.java
@@ -2,12 +2,29 @@
  * Copyright 2017-2021, Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
-package io.strimzi.testsuite.oauth.metrics;
+package io.strimzi.testsuite.oauth.mockoauth.metrics;
 
+import io.strimzi.kafka.oauth.client.ClientConfig;
+import io.strimzi.kafka.oauth.metrics.GlobalConfig;
+import io.strimzi.kafka.oauth.services.Services;
+import io.strimzi.testsuite.oauth.common.TestUtil;
+import io.strimzi.testsuite.oauth.mockoauth.Common;
+import io.strimzi.testsuite.oauth.mockoauth.LogLineReader;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerRecord;
 import org.junit.Assert;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.net.URI;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.TimeoutException;
 
 import static io.strimzi.testsuite.oauth.mockoauth.Common.changeAuthServerMode;
 import static io.strimzi.testsuite.oauth.mockoauth.Common.getPrometheusMetrics;
@@ -16,7 +33,13 @@ import static io.strimzi.testsuite.oauth.mockoauth.Common.reloadMetrics;
 
 public class MetricsTest {
 
+    private static final Logger LOG = LoggerFactory.getLogger(MetricsTest.class);
+
     private final static int PAUSE_MILLIS = 15_000;
+
+    private static final String KAFKA_BOOTSTRAP = "kafka:9092";
+    private static final String TOKEN_ENDPOINT_URI = "https://mockoauth:8090/token";
+
 
     public void doTest() throws Exception {
 
@@ -34,6 +57,65 @@ public class MetricsTest {
 
         logStart("Check 5xx errors show in Prometheus metrics");
         testInternalServerErrors();
+
+        logStart("Check `strimzi.metric.reporters` configuration handling");
+        testOAuthMetricReporters();
+
+        logStart("Check enabling metrics with JMX for the Kafka client");
+        testKafkaClientConfig();
+    }
+
+    private void testKafkaClientConfig() throws Exception {
+
+        Map<String, String> oauthConfig = new HashMap<>();
+        oauthConfig.put(ClientConfig.OAUTH_TOKEN_ENDPOINT_URI, TOKEN_ENDPOINT_URI);
+        oauthConfig.put(ClientConfig.OAUTH_CLIENT_ID, "ignored");
+        oauthConfig.put(ClientConfig.OAUTH_CLIENT_SECRET, "ignored");
+        oauthConfig.put(ClientConfig.OAUTH_ENABLE_METRICS, "true");
+
+        Properties producerProps = new Properties();
+
+        LogLineReader logReader = new LogLineReader(Common.LOG_PATH);
+        logReader.readNext();
+
+        // Clear the configured metrics in order to trigger reinitialisation
+        Services.close();
+
+        try {
+            initJaas(oauthConfig, producerProps);
+            Assert.fail("Should have failed due to bad access token");
+
+        } catch (Exception e) {
+            LOG.debug("[IGNORED] Failed as expected: {}", e.getMessage(), e);
+        }
+
+        List<String> lines = logReader.readNext();
+        Assert.assertTrue("Contains log warning", TestUtil.checkLogForRegex(lines, "OAuth metrics will not be exported to JMX"));
+
+        producerProps.put(GlobalConfig.STRIMZI_METRIC_REPORTERS, "org.apache.kafka.common.metrics.JmxReporter");
+
+        // Clear the configured metrics in order to trigger reinitialisation
+        Services.close();
+
+        try {
+            initJaas(oauthConfig, producerProps);
+            Assert.fail("Should have failed due to bad access token");
+
+        } catch (Exception e) {
+            LOG.debug("[IGNORED] Failed as expected: {}", e.getMessage(), e);
+        }
+
+        lines = logReader.readNext();
+        Assert.assertFalse("Contains log warning", TestUtil.checkLogForRegex(lines, "OAuth metrics will not be exported to JMX"));
+        Assert.assertTrue("Instantiated JMX Reporter", TestUtil.checkLogForRegex(lines, "reporters: \\[org.apache.kafka.common.metrics.JmxReporter"));
+    }
+
+    private void initJaas(Map<String, String> oauthConfig, Properties additionalProps) throws Exception {
+        Properties producerProps = Common.buildProducerConfigOAuthBearer(KAFKA_BOOTSTRAP, oauthConfig);
+        producerProps.putAll(additionalProps);
+        try (Producer<String, String> producer = new KafkaProducer<>(producerProps)) {
+            producer.send(new ProducerRecord<>("Test-testTopic", "The Message")).get();
+        }
     }
 
     private void testInternalServerErrors() throws IOException, InterruptedException {
@@ -153,6 +235,57 @@ public class MetricsTest {
 
         value = metrics.getValue("strimzi_oauth_http_requests_totaltimems", "context", "JWTPLAIN", "outcome", "success");
         Assert.assertNull(value);
+    }
+
+    private void testOAuthMetricReporters() throws IOException, InterruptedException, TimeoutException {
+
+        LogLineReader logReader = new LogLineReader(Common.LOG_PATH);
+        // seek to the end of log file
+        logReader.readNext();
+
+        Map<String, String> configs = new HashMap<>();
+        configs.put("strimzi.metric.reporters", "io.strimzi.testsuite.oauth.common.metrics.TestMetricsReporter");
+        reinitServices(configs);
+        Services.getInstance().getMetrics();
+        LOG.info("Waiting for: reporters: TestMetricsReporter"); // Make sure to not repeat the below condition in the string here
+        logReader.waitFor("reporters: \\[io\\.strimzi\\.testsuite\\.oauth\\.common\\.metrics\\.TestMetricsReporter");
+
+        configs.remove("strimzi.metric.reporters");
+        configs.put("metric.reporters", "io.strimzi.testsuite.oauth.common.metrics.TestMetricsReporter");
+        reinitServices(configs);
+        // No reporter will be instantiated
+        Services.getInstance().getMetrics();
+        LOG.info("Waiting for reporters warning"); // Make sure to not repeat the below condition in the string here
+        logReader.waitFor("OAuth metrics will not be exported to JMX");
+
+        LOG.info("Waiting for: reporters: <empty>"); // Make sure to not repeat the below condition in the string here
+        logReader.waitFor("reporters: \\[\\]");
+
+        configs.put("strimzi.metric.reporters", "org.apache.kafka.common.metrics.JmxReporter");
+        reinitServices(configs);
+        // Only JmxReporter will be instantiated the other setting is ignored
+        Services.getInstance().getMetrics();
+        LOG.info("Waiting for: reporters: JmxReporter"); // Make sure to not repeat the below condition in the string here
+        logReader.waitFor("reporters: \\[org\\.apache\\.kafka\\.common\\.metrics\\.JmxReporter");
+
+        configs.put("strimzi.metric.reporters", "");
+        reinitServices(configs);
+        // No reporter will be instantiated
+        Services.getInstance().getMetrics();
+        LOG.info("Waiting for: reporters: <empty>"); // Make sure to not repeat the below condition in the string here
+        logReader.waitFor("reporters: \\[\\]");
+
+        configs.put("strimzi.metric.reporters", "org.apache.kafka.common.metrics.JmxReporter,io.strimzi.testsuite.oauth.common.metrics.TestMetricsReporter");
+        reinitServices(configs);
+        // JmxReporter and TestMetricsReporter are instantiated
+        Services.getInstance().getMetrics();
+        LOG.info("Waiting for: reporters: JmxReporter,TestMetricsReporter"); // Make sure to not repeat the below condition in the string here
+        logReader.waitFor("reporters: \\[org\\.apache\\.kafka\\.common\\.metrics\\.JmxReporter.*, io\\.strimzi\\.testsuite\\.oauth\\.common\\.metrics\\.TestMetricsReporter");
+    }
+
+    private void reinitServices(Map<String, String> configs) {
+        Services.close();
+        Services.configure(configs);
     }
 
     private void logStart(String msg) {


### PR DESCRIPTION
This PR removes the use of `metric.reporters` in OAuth metrics to configure the reporters to instantiate.
The reason is that OAuth metrics integrates with the reporters by creating new instances of them, resulting in one instance being created by Kafka broker, and another instance created by OAuth metrics. Not all reporters work properly when multiple instances are instantiated.

With this PR OAuth metrics, when enabled, will use `strimzi.metric.reporters` as a configuration of which reporters to instantiate.

Also, previously `org.apache.kafka.common.metrics.JmxReporter` was automatically instantiated every time, mirroring how Kafka handles `metric.reporters`. With Kafka 4.0 the behaviour of `metric.reporters` is set to change and only instantiate explicitly listed reporters. `strimzi.metric.reporters` already implements this behavour for OAuth metrics regardless of the Kafka version used.

In order to migrate existing broker configuration add the following env variable:
```
STRIMZI_METRIC_REPORTERS=org.apache.kafka.common.metrics.JmxReporter
```

See README.md for more information.