### PR TITLE
Principal extraction from nested username claim was broken

### DIFF
--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -69,13 +69,13 @@ elif [[ "$arch" != 'ppc64le' ]]; then
   EXIT=$?
   exitIfError
 
-  clearDockerEnv
-  mvn -e -V -B clean install -f testsuite -Pkafka-3_3_2
-  EXIT=$?
-  exitIfError
-
   # Excluded by default to not exceed Travis job timeout
   if [ "$SKIP_DISABLED" == "false" ]; then
+
+    clearDockerEnv
+    mvn -e -V -B clean install -f testsuite -Pkafka-3_3_2
+    EXIT=$?
+    exitIfError
 
     clearDockerEnv
     mvn -e -V -B clean install -f testsuite -Pkafka-3_2_3 -DfailIfNoTests=false -Dtest=\!KeycloakKRaftAuthorizationTests

--- a/README.md
+++ b/README.md
@@ -316,12 +316,12 @@ If the configured `oauth.client.id` is `kafka`, the following are valid examples
 
 JWT tokens contain unique user identification in `sub` claim. However, this is often a long number or a UUID, but we usually prefer to use human-readable usernames, which may also be present in JWT token.
 Use `oauth.username.claim` to map the claim (attribute) where the value you want to use as user id is stored:
-- `oauth.username.claim` (e.g.: "preferred_username", for nested attributes use '.')
+- `oauth.username.claim` (e.g.: "preferred_username", for nested attributes use `[topAttrKey].[subAttrKey]`. Claim names can also be single quoted: `['topAttrKey'].['subAttrKey']`)
 
 If `oauth.username.claim` is specified the value of that claim is used instead, but if not set, the automatic fallback claim is the `sub` claim.
 
 You can specify the secondary claim to fall back to, which allows you to map multiple account types into the same principal namespace: 
-- `oauth.fallback.username.claim` (e.g.: "client_id", for nested attributes use '.')
+- `oauth.fallback.username.claim` (e.g.: "client_id", for nested attributes use `[topAttrKey].[subAttrKey]`. Claim names can also be single quoted: `['topAttrKey'].['subAttrKey']`)
 - `oauth.fallback.username.prefix` (e.g.: "client-account-")
 
 If `oauth.username.claim` is specified but value does not exist in the token, then `oauth.fallback.username.claim` is used. If value for that doesn't exist either, the exception is thrown.
@@ -400,10 +400,10 @@ Introspection Endpoint may or may not return identifying information which we co
 If the information is available we attempt to extract the user id from Introspection Endpoint response.
 
 Use `oauth.username.claim` to map the attribute where the user id is stored:
-- `oauth.username.claim` (e.g.: "preferred_username", for nested attributes use '.')
+- `oauth.username.claim` (e.g.: "preferred_username", for nested attributes use `[topAttrKey].[subAttrKey]`. Claim names can also be single quoted: `['topAttrKey'].['subAttrKey']`)
 
 You can fall back to a secondary attribute, which allows you to map multiple account types into the same user id namespace: 
-- `oauth.fallback.username.claim` (e.g.: "client_id", for nested attributes use '.')
+- `oauth.fallback.username.claim` (e.g.: "client_id", for nested attributes use `[topAttrKey].[subAttrKey]`. Claim names can also be single quoted: `['topAttrKey'].['subAttrKey']`)
 - `oauth.fallback.username.prefix` (e.g.: "client-account-")
 
 If `oauth.username.claim` is specified but value does not exist in the Introspection Endpoint response, then `oauth.fallback.username.claim` is used. If value for that doesn't exist either, the exception is thrown.
@@ -985,7 +985,7 @@ Audience is sent to the Token Endpoint when obtaining the access token.
 
 For debug purposes you may want to properly configure which JWT token attribute contains the user id of the account used to obtain the access token:
 
-- `oauth.username.claim` (e.g.: "preferred_username", for nested attributes use '.')
+- `oauth.username.claim` (e.g.: "preferred_username", for nested attributes use `[topAttrKey].[subAttrKey]`. Claim names can also be single quoted: `['topAttrKey'].['subAttrKey']`)
 
 This does not affect how Kafka client is presented to the Kafka Broker.
 The broker performs user id extraction from the token once again or it uses the Introspection Endpoint or the User Info Endpoint to get the user id.

--- a/README.md
+++ b/README.md
@@ -316,12 +316,12 @@ If the configured `oauth.client.id` is `kafka`, the following are valid examples
 
 JWT tokens contain unique user identification in `sub` claim. However, this is often a long number or a UUID, but we usually prefer to use human-readable usernames, which may also be present in JWT token.
 Use `oauth.username.claim` to map the claim (attribute) where the value you want to use as user id is stored:
-- `oauth.username.claim` (e.g.: "preferred_username")
+- `oauth.username.claim` (e.g.: "preferred_username", for nested attributes use '.')
 
 If `oauth.username.claim` is specified the value of that claim is used instead, but if not set, the automatic fallback claim is the `sub` claim.
 
 You can specify the secondary claim to fall back to, which allows you to map multiple account types into the same principal namespace: 
-- `oauth.fallback.username.claim` (e.g.: "client_id")
+- `oauth.fallback.username.claim` (e.g.: "client_id", for nested attributes use '.')
 - `oauth.fallback.username.prefix` (e.g.: "client-account-")
 
 If `oauth.username.claim` is specified but value does not exist in the token, then `oauth.fallback.username.claim` is used. If value for that doesn't exist either, the exception is thrown.
@@ -400,10 +400,10 @@ Introspection Endpoint may or may not return identifying information which we co
 If the information is available we attempt to extract the user id from Introspection Endpoint response.
 
 Use `oauth.username.claim` to map the attribute where the user id is stored:
-- `oauth.username.claim` (e.g.: "preferred_username")
+- `oauth.username.claim` (e.g.: "preferred_username", for nested attributes use '.')
 
 You can fall back to a secondary attribute, which allows you to map multiple account types into the same user id namespace: 
-- `oauth.fallback.username.claim` (e.g.: "client_id")
+- `oauth.fallback.username.claim` (e.g.: "client_id", for nested attributes use '.')
 - `oauth.fallback.username.prefix` (e.g.: "client-account-")
 
 If `oauth.username.claim` is specified but value does not exist in the Introspection Endpoint response, then `oauth.fallback.username.claim` is used. If value for that doesn't exist either, the exception is thrown.
@@ -985,7 +985,7 @@ Audience is sent to the Token Endpoint when obtaining the access token.
 
 For debug purposes you may want to properly configure which JWT token attribute contains the user id of the account used to obtain the access token:
 
-- `oauth.username.claim` (e.g.: "preferred_username")
+- `oauth.username.claim` (e.g.: "preferred_username", for nested attributes use '.')
 
 This does not affect how Kafka client is presented to the Kafka Broker.
 The broker performs user id extraction from the token once again or it uses the Introspection Endpoint or the User Info Endpoint to get the user id.

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/JSONUtil.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/JSONUtil.java
@@ -112,6 +112,9 @@ public class JSONUtil {
      * @return Value of the specific claim as String or null if claim not present
      */
     public static String getClaimFromJWT(JsonNode node, String... path) {
+        if (path.length == 0) {
+            return null;
+        }
         for (String p: path) {
             node = node.get(p);
             if (node == null) {

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/PrincipalExtractor.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/PrincipalExtractor.java
@@ -10,7 +10,7 @@ import static io.strimzi.kafka.oauth.common.JSONUtil.getClaimFromJWT;
 
 /**
  * An object with logic for extracting a principal name (i.e. a user id) from a JWT token.
- *
+ * <p>
  * First a claim configured as <code>usernameClaim</code> is looked up.
  * If not found the claim configured as <code>fallbackUsernameClaim</code> is looked up. If that one is found and if
  * the <code>fallbackUsernamePrefix</code> is configured prefix the found value with the prefix, otherwise not.
@@ -29,7 +29,7 @@ public class PrincipalExtractor {
     /**
      * Create a new instance
      *
-     * @param usernameClaim Attribute name for an attribute containing the user id to lookup first
+     * @param usernameClaim Attribute name for an attribute containing the user id to lookup first. Use '.' to refer to nested child objects.
      * @param fallbackUsernameClaim Attribute name for an attribute containg the user id to lookup as a fallback
      * @param fallbackUsernamePrefix A prefix to prepend to the value of the fallback attribute value if set
      */
@@ -49,13 +49,13 @@ public class PrincipalExtractor {
         String result;
 
         if (usernameClaim != null) {
-            result = getClaimFromJWT(json, usernameClaim);
+            result = getClaimFromJWT(usernameClaim, json);
             if (result != null) {
                 return result;
             }
 
             if (fallbackUsernameClaim != null) {
-                result = getClaimFromJWT(json, fallbackUsernameClaim);
+                result = getClaimFromJWT(fallbackUsernameClaim, json);
                 if (result != null) {
                     return fallbackUsernamePrefix == null ? result : fallbackUsernamePrefix + result;
                 }

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/PrincipalExtractor.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/PrincipalExtractor.java
@@ -26,7 +26,7 @@ import static io.strimzi.kafka.oauth.common.JSONUtil.getClaimFromJWT;
  * A JsonPath query is resolved relative to JSON object containing info to identify user
  * (a JWT payload, a response from Introspection Endpoint or a response from User Info Endpoint).
  * <p>
- * For more on JsonPath syntax {@see https://github.com/json-path/JsonPath}.
+ * For more on JsonPath syntax see https://github.com/json-path/JsonPath.
  * <p>
  * Examples of claim specification:
  * <pre>
@@ -141,7 +141,7 @@ public class PrincipalExtractor {
      * targeting a nested attribute. </li>
      * <li>Otherwise, it is interpreted as a top level attribute name.</li>
      * </ul>
-     * For more on JsonPath syntax {@see https://github.com/json-path/JsonPath}.
+     * For more on JsonPath syntax see https://github.com/json-path/JsonPath.
      * <p>
      * Examples of claim specification:
      * <pre>

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/jsonpath/JsonPathQuery.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/jsonpath/JsonPathQuery.java
@@ -90,7 +90,7 @@ public class JsonPathQuery {
         try {
             this.matcher = new Matcher(ctx, query, false);
         } catch (JsonPathException e) {
-            throw new JsonPathQueryException("Failed to parse filter query: \"" + query + "\"", e);
+            throw new JsonPathQueryException("Failed to parse JsonPath query: \"" + query + "\"", e);
         }
     }
 

--- a/oauth-common/src/test/java/io/strimzi/kafka/oauth/validator/PrincipalExtractorTest.java
+++ b/oauth-common/src/test/java/io/strimzi/kafka/oauth/validator/PrincipalExtractorTest.java
@@ -5,30 +5,117 @@
 package io.strimzi.kafka.oauth.validator;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import io.strimzi.kafka.oauth.common.JSONUtil;
 import io.strimzi.kafka.oauth.common.PrincipalExtractor;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.io.IOException;
+
+import static io.strimzi.kafka.oauth.common.JSONUtil.readJSON;
+
 public class PrincipalExtractorTest {
 
     @Test
-    public void testNestedClaim() {
+    public void testUsernameClaim() throws IOException {
 
-        ObjectNode json = JSONUtil.newObjectNode();
-        ObjectNode current = json.putObject("oauth");
-        current = current.putObject("username");
-        current.put("claim", "user1");
-        current.put("fallbackClaim", "fallbackUser1");
+        ObjectNode json = readJSON("{ " +
+                "\"sub\": \"u123456\", " +
+                "\"userId\": \"alice\", " +
+                "\"user.id\": \"alice-123456\", " +
+                "\"userInfo\": {\"id\": \"alice@example.com\" }, " +
+                "\"user.info\": {\"sub.id\": \"alice-123456@example.com\"}" +
+                "}", ObjectNode.class);
 
-        PrincipalExtractor extractor = new PrincipalExtractor("oauth.username.claim", null, null);
-        String principal = extractor.getPrincipal(json);
+        // 'userId' claim exists and is used as primary
+        PrincipalExtractor extractor = new PrincipalExtractor("userId", null, null);
+        Assert.assertEquals("'userId' top level works as primary", "alice", extractor.getPrincipal(json));
 
-        Assert.assertEquals("principal == user1", "user1", principal);
+        // 'userId' claim exists and is used as fallback
+        extractor = new PrincipalExtractor("nonexisting", "userId", null);
+        Assert.assertEquals("'userId' top level works as fallback", "alice", extractor.getPrincipal(json));
 
-        extractor = new PrincipalExtractor("oauth.username.id", "oauth.username.fallbackClaim", null);
-        principal = extractor.getPrincipal(json);
+        // 'userInfo.id' top level claim (not nested) does not exist
+        extractor = new PrincipalExtractor("userInfo.id", null, null);
+        Assert.assertNull("'userInfo.id' top level does not exist", extractor.getPrincipal(json));
 
-        Assert.assertEquals("fallback principal == fallbackUser1", "fallbackUser1", principal);
+        // 'userInfo.id' top level claim (not nested) does not exist
+        extractor = new PrincipalExtractor("nonexisting", "userInfo.id", null);
+        Assert.assertNull("'userInfo.id' top level does not exist", extractor.getPrincipal(json));
+
+        // 'user.id' top level claim (not nested) exists and is used as primary
+        extractor = new PrincipalExtractor("user.id", null, null);
+        Assert.assertEquals("'user.id' top level works as primary", "alice-123456", extractor.getPrincipal(json));
+
+        // 'user.id' top level claim (not nested) exists and is used as fallback
+        extractor = new PrincipalExtractor("nonexisting", "user.id", null);
+        Assert.assertEquals("'user.id' top level works as fallback", "alice-123456", extractor.getPrincipal(json));
+
+        // 'user.id' top level claim (not nested) exists and is used as primary
+        extractor = new PrincipalExtractor("[user.id]", null, null);
+        Assert.assertEquals("[user.id] top level works as primary", "alice-123456", extractor.getPrincipal(json));
+
+        // 'user.id' top level claim (not nested) exists and is used as fallback
+        extractor = new PrincipalExtractor("nonexisting", "[user.id]", null);
+        Assert.assertEquals("[user.id] top level works as fallback", "alice-123456", extractor.getPrincipal(json));
+
+        // "'user.id'" top level claim (not nested) DOES NOT exist - notice quotes which are taken literally
+        extractor = new PrincipalExtractor("'user.id'", null, null);
+        Assert.assertNull("\"'user.id'\" (single-quoted) top level does not exist", extractor.getPrincipal(json));
+
+        // "'user.id'" top level claim (not nested) DOES NOT exist - notice quotes which are taken literally
+        extractor = new PrincipalExtractor("nonexisting", "'user.id'", null);
+        Assert.assertNull("\"'user.id'\" (single-quoted) top level does not exist", extractor.getPrincipal(json));
+
+        // 'user.info' top level claim exists, and 'sub.id' nested underneath exists and is used as primary
+        extractor = new PrincipalExtractor("[user.info].[sub.id]", null, null);
+        Assert.assertEquals("[user.info] top level, [sub.id] sub works as primary", "alice-123456@example.com", extractor.getPrincipal(json));
+
+        // 'user.info' top level claim exists, but ' sub.id' does not exist - note the leading space
+        extractor = new PrincipalExtractor("[ user.info] .[' sub.id']", null, null);
+        Assert.assertNull("[ user.info] top level exists, [' sub.id'] does not exist (note the space within quotes)", extractor.getPrincipal(json));
+
+        // 'user.info' top level claim exists, and 'sub.id' nested sub-claim exists and is used as a fallback
+        extractor = new PrincipalExtractor("nonexisting", "[user.info] .  [ sub.id  ]", null);
+        Assert.assertEquals("[user.info] .  [ sub.id ] works as fallback", "alice-123456@example.com", extractor.getPrincipal(json));
+
+        // 'user.info' top level claim exists, and 'sub.id' nested underneath exists and is used as primary
+        extractor = new PrincipalExtractor("['user.info'] . [ 'sub.id' ]", null, null);
+        Assert.assertEquals("['user.info'] . [ 'sub.id' ] works as primary", "alice-123456@example.com", extractor.getPrincipal(json));
+
+        // 'user.info' top level claim exists, and 'sub.id' nested underneath exists and is used as fallback
+        extractor = new PrincipalExtractor("nonexisting", "  [    'user.info'] . ['sub.id'     ]", null);
+        Assert.assertEquals("  [    'user.info'] . ['sub.id'     ] works as primary", "alice-123456@example.com", extractor.getPrincipal(json));
+
+
+        extractor = new PrincipalExtractor("nonexisting", "nonexisting", null);
+        Assert.assertNull("Non-existing claim", extractor.getPrincipal(json));
+
+        // No closing ]
+        try {
+            new PrincipalExtractor("[user.id", "nonexisting", null);
+            Assert.fail("Should have failed");
+        } catch (IllegalArgumentException e) {
+            Assert.assertTrue("Failed to parse username claim spec: '[user.id' (Missing ']')", e.toString().contains("Failed to parse username claim spec: '[user.id' (Missing ']')"));
+        }
+
+        // no dot between claim names
+        try {
+            new PrincipalExtractor("[user.info][user.id]", "nonexisting", null);
+            Assert.fail("Should have failed");
+        } catch (Exception e) {
+            Assert.assertTrue("Failed to parse usename claim spec: '[user.info][user.id]' (Missing '.' at position: 11)", e.toString().contains("Failed to parse usename claim spec: '[user.info][user.id]' (Missing '.' at position: 11)"));
+        }
+
+        // once you start using [] you should use them consistently
+        try {
+            new PrincipalExtractor("[user.info].id", "nonexisting", null);
+            Assert.fail("Should have failed");
+        } catch (Exception e) {
+            Assert.assertTrue("Failed to parse username claim spec: '[user.info].id' (Missing '[' at position:12)", e.toString().contains("Failed to parse username claim spec: '[user.info].id' (Missing '[' at position:12)"));
+        }
+
+        // 'user.id]' top level claim does not exist
+        extractor = new PrincipalExtractor("user.id]", "nonexisting", null);
+        Assert.assertNull("'user.id]' top level claim does not exist (note the ending square bracket)", extractor.getPrincipal(json));
     }
 }

--- a/oauth-common/src/test/java/io/strimzi/kafka/oauth/validator/PrincipalExtractorTest.java
+++ b/oauth-common/src/test/java/io/strimzi/kafka/oauth/validator/PrincipalExtractorTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017-2023, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.kafka.oauth.validator;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.strimzi.kafka.oauth.common.JSONUtil;
+import io.strimzi.kafka.oauth.common.PrincipalExtractor;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class PrincipalExtractorTest {
+
+    @Test
+    public void testNestedClaim() {
+
+        ObjectNode json = JSONUtil.newObjectNode();
+        ObjectNode current = json.putObject("oauth");
+        current = current.putObject("username");
+        current.put("claim", "user1");
+        current.put("fallbackClaim", "fallbackUser1");
+
+        PrincipalExtractor extractor = new PrincipalExtractor("oauth.username.claim", null, null);
+        String principal = extractor.getPrincipal(json);
+
+        Assert.assertEquals("principal == user1", "user1", principal);
+
+        extractor = new PrincipalExtractor("oauth.username.id", "oauth.username.fallbackClaim", null);
+        principal = extractor.getPrincipal(json);
+
+        Assert.assertEquals("fallback principal == fallbackUser1", "fallbackUser1", principal);
+    }
+}

--- a/oauth-common/src/test/java/io/strimzi/kafka/oauth/validator/PrincipalExtractorTest.java
+++ b/oauth-common/src/test/java/io/strimzi/kafka/oauth/validator/PrincipalExtractorTest.java
@@ -5,7 +5,9 @@
 package io.strimzi.kafka.oauth.validator;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.jayway.jsonpath.InvalidPathException;
 import io.strimzi.kafka.oauth.common.PrincipalExtractor;
+import io.strimzi.kafka.oauth.jsonpath.JsonPathQueryException;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -22,126 +24,122 @@ public class PrincipalExtractorTest {
                 "\"sub\": \"u123456\", " +
                 "\"userId\": \"alice\", " +
                 "\"user.id\": \"alice-123456\", " +
+                "\"'user.id'\": \"quoted-alice-123456\", " +
+                "\"$user.id\": \"$alice\", " +
+                "\"$$user.id\": \"$$alice\", " +
+                "\"$.user.id\": \"$.alice\", " +
                 "\"userInfo\": {\"id\": \"alice@example.com\" }, " +
                 "\"user.info\": {\"sub.id\": \"alice-123456@example.com\"}, " +
                 "\"foo'bar\": \"alice-in-wonderland\", " +
-                "\"uname[1\": \"white-rabbit\"" +
+                "\"uname[1\": \"white-rabbit\" " +
                 "}", ObjectNode.class);
 
-        // 'userId' claim exists and is used as primary
-        PrincipalExtractor extractor = new PrincipalExtractor("userId", null, null);
-        Assert.assertEquals("'userId' top level works as primary", "alice", extractor.getPrincipal(json));
+        String[] claimSpec = {
+            // top-level userId attribute
+            "userId", "alice",
+            // top-level userInfo attribute (a misconfiguration as you hit the nested object in test json)
+            // Should we log a warning and display a matched object rather than just return null (the result is failed authentication anyway)?
+            "userInfo", null,
+            // top-level userInfo.id attribute (no match)
+            "userInfo.id", null,
+            // nested id attribute under userInfo top-level attribute
+            "['userInfo']['id']", "alice@example.com",
+            // nested id attribute under userInfo top-level attribute
+            "['userInfo']id", "alice@example.com",
+            // nested id attribute under userInfo top-level attribute
+            "['userInfo'].id", "alice@example.com",
+            // nested id attribute under userInfo top-level attribute
+            "[ 'userInfo' ][ 'id' ]", "alice@example.com",
+            // nested id attribute under userInfo top-level attribute
+            "[ 'userInfo' ].[ 'id' ]", "alice@example.com",
+            // nested sub.id attribute under user.info top-level attribute
+            "['user.info']['sub.id']", "alice-123456@example.com",
+            // user.id top-level attribute
+            "user.id", "alice-123456",
+            // user.id top level attribute
+            "['user.id']", "alice-123456",
+            // $user.id top-level attribute
+            "$user.id", "$alice",
+            // $user.id top-level attribute
+            "['$user.id']", "$alice",
+            // $$user.id top-level attribute
+            "$$user.id", "$$alice",
+            // 'user.id' top-level attribute (quotes are part of the attribute name)
+            "'user.id'", "quoted-alice-123456",
+            // $['user.id'] top-level attribute (dollar, square brackets and quotes are part of the attribute name, no match)
+            "$['user.id']", null,
+            // uname[1 top-level attribute
+            "['uname[1']", "white-rabbit",
+            // uname]1 top-level attribute (no match)
+            "['uname]1']", null,
+            // user.id] top-level attribute (closing square bracket is part of the attribute name, no match)
+            "user.id]", null,
+            // foo'bar top-level attribute
+            "foo'bar", "alice-in-wonderland",
+            // foo'bar top-level attribute
+            "['foo\\'bar']", "alice-in-wonderland",
+            // baz attribute nested under bar, nested under top-level attribute foo (no match)
+            "['foo']bar['baz']", null,
+            // nested id attribute under user.info top level attribute (no match)
+            "['user.info'].id", null,
+            // nested sub.id attribute under user.info top-level attribute
+            "['user.info'].['sub.id']", "alice-123456@example.com",
+            // 'user.id' top-level attribute (quotes are part of the attribute name)
+            "['\\'user.id\\'']", "quoted-alice-123456",
+            // top-level $.user.id attribute
+            "$.user.id", "$.alice",
+            // top-level $.user.id attribute
+            "['$.user.id']", "$.alice",
+        };
 
-        // 'userId' claim exists and is used as fallback
-        extractor = new PrincipalExtractor("nonexisting", "userId", null);
-        Assert.assertEquals("'userId' top level works as fallback", "alice", extractor.getPrincipal(json));
+        String[] claimSpecError = {
+            // square brackets but no single quotes
+            "[user.id]",
+            // square brackets but no single quotes
+            "[user.info][sub.id]",
+            // opening square bracket but no single quote
+            "[user.id",
+            // opening square bracket but no single quote
+            "[user.info].id",
+            // opening square bracket but no single quote
+            "[foo].bar[baz]",
+            // third square bracket segment has no single quotes
+            "['foo']bar[baz]",
+            // ending single quote can only be followed by a closing square bracket
+            "['foo'bar]",
+            // ending single quote can only be followed by a closing square bracket (inner quote not escaped)
+            "['foo'bar']",
+            // ending single quote can only be followed by a closing square bracket (inner quotes not escaped)
+            "[''user.id'']",
+            // there should be no space between ] and [, only optional dot (.)
+            "[ 'userInfo' ] [ 'id' ]"
+        };
 
-        // 'userInfo.id' top level claim (not nested) does not exist
-        extractor = new PrincipalExtractor("userInfo.id", null, null);
-        Assert.assertNull("'userInfo.id' top level does not exist", extractor.getPrincipal(json));
+        for (int i = 0; i < claimSpec.length; i++) {
+            String query = claimSpec[i];
+            String expected = claimSpec[++i];
 
-        // 'userInfo.id' top level claim (not nested) does not exist
-        extractor = new PrincipalExtractor("nonexisting", "userInfo.id", null);
-        Assert.assertNull("'userInfo.id' top level does not exist", extractor.getPrincipal(json));
+            try {
+                PrincipalExtractor extractor = new PrincipalExtractor(query, null, null);
+                Assert.assertEquals(query + " top level works as primary", expected, extractor.getPrincipal(json));
 
-        // 'user.id' top level claim (not nested) exists and is used as primary
-        extractor = new PrincipalExtractor("user.id", null, null);
-        Assert.assertEquals("'user.id' top level works as primary", "alice-123456", extractor.getPrincipal(json));
-
-        // 'user.id' top level claim (not nested) exists and is used as fallback
-        extractor = new PrincipalExtractor("nonexisting", "user.id", null);
-        Assert.assertEquals("'user.id' top level works as fallback", "alice-123456", extractor.getPrincipal(json));
-
-        // 'user.id' top level claim (not nested) exists and is used as primary
-        extractor = new PrincipalExtractor("[user.id]", null, null);
-        Assert.assertEquals("[user.id] top level works as primary", "alice-123456", extractor.getPrincipal(json));
-
-        // 'user.id' top level claim (not nested) exists and is used as fallback
-        extractor = new PrincipalExtractor("nonexisting", "[user.id]", null);
-        Assert.assertEquals("[user.id] top level works as fallback", "alice-123456", extractor.getPrincipal(json));
-
-        // "'user.id'" top level claim (not nested) DOES NOT exist - notice quotes which are taken literally
-        extractor = new PrincipalExtractor("'user.id'", null, null);
-        Assert.assertNull("\"'user.id'\" (single-quoted) top level does not exist", extractor.getPrincipal(json));
-
-        // "'user.id'" top level claim (not nested) DOES NOT exist - notice quotes which are taken literally
-        extractor = new PrincipalExtractor("nonexisting", "'user.id'", null);
-        Assert.assertNull("\"'user.id'\" (single-quoted) top level does not exist", extractor.getPrincipal(json));
-
-        // 'user.info' top level claim exists, and 'sub.id' nested underneath exists and is used as primary
-        extractor = new PrincipalExtractor("[user.info].[sub.id]", null, null);
-        Assert.assertEquals("[user.info] top level, [sub.id] sub works as primary", "alice-123456@example.com", extractor.getPrincipal(json));
-
-        // 'user.info' top level claim exists, but ' sub.id' does not exist - note the leading space
-        extractor = new PrincipalExtractor("[ user.info] .[' sub.id']", null, null);
-        Assert.assertNull("[ user.info] top level exists, [' sub.id'] does not exist (note the space within quotes)", extractor.getPrincipal(json));
-
-        // 'user.info' top level claim exists, and 'sub.id' nested sub-claim exists and is used as a fallback
-        extractor = new PrincipalExtractor("nonexisting", "[user.info] .  [ sub.id  ]", null);
-        Assert.assertEquals("[user.info] .  [ sub.id ] works as fallback", "alice-123456@example.com", extractor.getPrincipal(json));
-
-        // 'user.info' top level claim exists, and 'sub.id' nested underneath exists and is used as primary
-        extractor = new PrincipalExtractor("['user.info'] . [ 'sub.id' ]", null, null);
-        Assert.assertEquals("['user.info'] . [ 'sub.id' ] works as primary", "alice-123456@example.com", extractor.getPrincipal(json));
-
-        // 'user.info' top level claim exists, and 'sub.id' nested underneath exists and is used as fallback
-        extractor = new PrincipalExtractor("nonexisting", "  [    'user.info'] . ['sub.id'     ]", null);
-        Assert.assertEquals("  [    'user.info'] . ['sub.id'     ] works as primary", "alice-123456@example.com", extractor.getPrincipal(json));
-
-
-        extractor = new PrincipalExtractor("nonexisting", "nonexisting", null);
-        Assert.assertNull("Non-existing claim", extractor.getPrincipal(json));
-
-        // No closing ]
-        try {
-            new PrincipalExtractor("[user.id", "nonexisting", null);
-            Assert.fail("Should have failed");
-        } catch (IllegalArgumentException e) {
-            Assert.assertTrue("Failed to parse username claim spec: '[user.id' (Missing ']')", e.toString().contains("Failed to parse username claim spec: '[user.id' (Missing ']')"));
+                extractor = new PrincipalExtractor("nonexisting", query, null);
+                Assert.assertEquals(query + " top level works as fallback", expected, extractor.getPrincipal(json));
+            } catch (Exception e) {
+                throw new RuntimeException("Unexpected error while testing: " + query + " expecting it to return: " + expected, e);
+            }
         }
 
-        // no dot between claim names
-        try {
-            new PrincipalExtractor("[user.info][user.id]", "nonexisting", null);
-            Assert.fail("Should have failed");
-        } catch (IllegalArgumentException e) {
-            Assert.assertTrue("Failed to parse username claim spec: '[user.info][user.id]' (Missing '.' at position: 11)", e.toString().contains("Failed to parse username claim spec: '[user.info][user.id]' (Missing '.' at position: 11)"));
+        for (int i = 0; i < claimSpecError.length; i++) {
+            String query = claimSpecError[i];
+            try {
+                PrincipalExtractor extractor = new PrincipalExtractor(query, "nonexisting", null);
+                extractor.getPrincipal(json);
+                Assert.fail("Should have failed");
+            } catch (JsonPathQueryException e) {
+                Assert.assertTrue("Cause instanceof InvalidPathException", e.getCause() instanceof InvalidPathException);
+                // ignored
+            }
         }
-
-        // once you start using [] you should use them consistently
-        try {
-            new PrincipalExtractor("[user.info].id", "nonexisting", null);
-            Assert.fail("Should have failed");
-        } catch (IllegalArgumentException e) {
-            Assert.assertTrue("Failed to parse username claim spec: '[user.info].id' (Missing '[' at position:12)", e.toString().contains("Failed to parse username claim spec: '[user.info].id' (Missing '[' at position:12)"));
-        }
-
-        // 'user.id]' top level claim does not exist
-        extractor = new PrincipalExtractor("user.id]", "nonexisting", null);
-        Assert.assertNull("'user.id]' top level claim does not exist (note the ending square bracket)", extractor.getPrincipal(json));
-
-        // '[foo].bar[baz]'
-        try {
-            extractor = new PrincipalExtractor("[foo].bar[baz]", "nonexisting", null);
-            Assert.fail("Should have failed");
-        } catch (IllegalArgumentException e) {
-            Assert.assertTrue("Failed to parse username claim spec: '[foo].bar[baz]' (Expected '[' at position: 6)", e.toString().contains("Failed to parse username claim spec: '[foo].bar[baz]' (Expected '[' at position: 6)"));
-        }
-
-        // ['foo'bar]
-        try {
-            extractor = new PrincipalExtractor("['foo'bar]", "nonexisting", null);
-            Assert.fail("Should have failed");
-        } catch (IllegalArgumentException e) {
-            Assert.assertTrue("Failed to parse username claim spec: missing ending quote [']: 'foo'bar", e.toString().contains("Failed to parse username claim spec: missing ending quote [']: 'foo'bar"));
-        }
-
-        // ['foo'bar']
-        extractor = new PrincipalExtractor("['foo'bar']", "nonexisting", null);
-        Assert.assertEquals("['foo'bar'] works as primary", "alice-in-wonderland", extractor.getPrincipal(json));
-
-        // ['uname[1']
-        extractor = new PrincipalExtractor("['uname[1']", "nonexisting", null);
-        Assert.assertEquals("['uname[1'] works as primary", "white-rabbit", extractor.getPrincipal(json));
     }
 }

--- a/oauth-server/src/main/java/io/strimzi/kafka/oauth/server/JaasServerOauthValidatorCallbackHandler.java
+++ b/oauth-server/src/main/java/io/strimzi/kafka/oauth/server/JaasServerOauthValidatorCallbackHandler.java
@@ -138,9 +138,9 @@ import static io.strimzi.kafka.oauth.common.TokenIntrospection.debugLogJWT;
  * <ul>
  * <li><em>oauth.username.claim</em> The attribute key that should be used to extract the user id. If not set `sub` attribute is used.<br>
  * The attribute key refers to the JWT token claim when fast local validation is used, or to attribute in the response by introspection endpoint when introspection based validation is used.
- * For nested attributes use '.'. It has no default value.</li>
+ * For nested attributes use '[topAttrKey].[subAttrKey]'. Claim names can also be single quoted: ['topAttrKey'].['subAttrKey']. It has no default value.</li>
  * <li><em>oauth.fallback.username.claim</em> The fallback username claim to be used for the user id if the attribute key specified by `oauth.username.claim` <br>
- * is not present. This is useful when `client_credentials` authentication only results in the client id being provided in another claim. For nested attributes use '.'.
+ * is not present. This is useful when `client_credentials` authentication only results in the client id being provided in another claim. For nested attributes same rules apply as for `oauth.username.claim`.
  * <li><em>oauth.fallback.username.prefix</em> The prefix to use with the value of <em>oauth.fallback.username.claim</em> to construct the user id.  <br>
  * This only takes effect if <em>oauth.fallback.username.claim</em> is <em>true</em>, and the value is present for the claim.
  * Mapping usernames and client ids into the same user id space is useful in preventing name collisions.</li>

--- a/oauth-server/src/main/java/io/strimzi/kafka/oauth/server/JaasServerOauthValidatorCallbackHandler.java
+++ b/oauth-server/src/main/java/io/strimzi/kafka/oauth/server/JaasServerOauthValidatorCallbackHandler.java
@@ -137,9 +137,10 @@ import static io.strimzi.kafka.oauth.common.TokenIntrospection.debugLogJWT;
  * Common optional <em>sasl.jaas.config</em> configuration:
  * <ul>
  * <li><em>oauth.username.claim</em> The attribute key that should be used to extract the user id. If not set `sub` attribute is used.<br>
- * The attribute key refers to the JWT token claim when fast local validation is used, or to attribute in the response by introspection endpoint when introspection based validation is used. It has no default value.</li>
+ * The attribute key refers to the JWT token claim when fast local validation is used, or to attribute in the response by introspection endpoint when introspection based validation is used.
+ * For nested attributes use '.'. It has no default value.</li>
  * <li><em>oauth.fallback.username.claim</em> The fallback username claim to be used for the user id if the attribute key specified by `oauth.username.claim` <br>
- * is not present. This is useful when `client_credentials` authentication only results in the client id being provided in another claim.
+ * is not present. This is useful when `client_credentials` authentication only results in the client id being provided in another claim. For nested attributes use '.'.
  * <li><em>oauth.fallback.username.prefix</em> The prefix to use with the value of <em>oauth.fallback.username.claim</em> to construct the user id.  <br>
  * This only takes effect if <em>oauth.fallback.username.claim</em> is <em>true</em>, and the value is present for the claim.
  * Mapping usernames and client ids into the same user id space is useful in preventing name collisions.</li>


### PR DESCRIPTION
When extracting a user id from JWT token by using `oauth.username.claim` or `oauth.fallback.username.claim` it only worked for top level attributes, not for nested attributes. For example, by configuring: `"oauth.username.claim=auth.userid"`, and given a JWT token:
```
{
    ...
   "auth": {
      "userid": "alice"
   }
}
```
Extraction would not find 'userid' key under top level 'auth' object, rather it was looking for 'auth.userid' top level key.

This PR adds an option to use JsonPath to target nested attributes.
If the claim specification starts with an opening square bracket '[', it is interpreted as a JsonPath query.
Otherwise, it is interpreted as a top level attribute name.

```
userId                    ... use top level attribute named 'userId'
user.id                   ... use top level attribute named 'user.id'
$userid                   ... use top level attribute named '$userid'
['userInfo'].id           ... use nested attribute 'id' under 'userInfo' top level attribute
['user.info']['user.id']  ... use nested attribute 'user.id' under 'user.info' top level attribute
['user.info'].['user.id'] ... use nested attribute 'user.id' under 'user.info' top level attribute (optional dot)
```
