### PR TITLE
chore: Update jackson to 2.15.2

### DIFF
--- a/examples/docker/spring/pom.xml
+++ b/examples/docker/spring/pom.xml
@@ -41,12 +41,12 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>2.14.2</version>
+                <version>2.15.2</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-core</artifactId>
-                <version>2.14.2</version>
+                <version>2.15.2</version>
             </dependency>
             <dependency>
                 <groupId>org.bouncycastle</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -104,8 +104,8 @@
         <spotbugs.version>4.7.3</spotbugs.version>
         <sonatype.nexus.staging>1.6.3</sonatype.nexus.staging>
         <kafka.version>3.5.0</kafka.version>
-        <jackson.version>2.14.2</jackson.version>
-        <jackson.databind.version>2.14.2</jackson.databind.version>
+        <jackson.version>2.15.2</jackson.version>
+        <jackson.databind.version>2.15.2</jackson.databind.version>
         <jsonpath.version>2.8.0</jsonpath.version>
         <junit.version>4.13.2</junit.version>
         <slf4j.version>1.7.36</slf4j.version>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -44,7 +44,7 @@
         <testcontainers.version>1.17.3</testcontainers.version>
         <version.junit>4.13.2</version.junit>
         <spotbugs.version>4.7.0</spotbugs.version>
-        <jackson.annotation.version>2.14.2</jackson.annotation.version>
+        <jackson.annotation.version>2.15.2</jackson.annotation.version>
         <strimzi-oauth.version>1.0.0-SNAPSHOT</strimzi-oauth.version>
         <checkstyle.dir>..</checkstyle.dir>
 


### PR DESCRIPTION
Update jackson to 2.15.2 in main pom.xml and pom.xmls of test-suite and spring example

This PR mirrors the Jackson updates that were done in [strimzi-kafka-operator](https://github.com/strimzi/strimzi-kafka-operator/pull/8856) and [strimzi-kafka-bridge](https://github.com/strimzi/strimzi-kafka-bridge/pull/822)