### PR TITLE
Fix nullpointer that occurs when OAuthKafkaPrincipalBuilder is used with Kerberos listener

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ jobs:
         - hydra
         - hydra-jwt
         - mockoauth
+        - kerberos
       apt:
         packages:
         - maven
@@ -26,6 +27,7 @@ jobs:
         - hydra
         - hydra-jwt
         - mockoauth
+        - kerberos
       apt:
         packages:
         - maven
@@ -43,6 +45,7 @@ addons:
   - hydra
   - hydra-jwt
   - mockoauth
+  - kerberos
 env:
   global:
   - PULL_REQUEST=${TRAVIS_PULL_REQUEST}

--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -2,7 +2,7 @@
 set -e
 
 clearDockerEnv() {
-  docker rm -f kafka zookeeper keycloak keycloak-import hydra hydra-import hydra-jwt hydra-jwt-import || true
+  docker rm -f kafka zookeeper keycloak keycloak-import hydra hydra-import hydra-jwt hydra-jwt-import kerberos || true
   DOCKER_TEST_NETWORKS=$(docker network ls | grep test | awk '{print $1}')
   [ "$DOCKER_TEST_NETWORKS" != "" ] && docker network rm $DOCKER_TEST_NETWORKS
 }

--- a/testsuite/README.md
+++ b/testsuite/README.md
@@ -20,6 +20,7 @@ Then, you have to add some entries to your `/etc/hosts` file:
     127.0.0.1            hydra-jwt
     127.0.0.1            kafka
     127.0.0.1            mockoauth
+    127.0.0.1			 kerberos
 
 That's needed for host resolution, because Kafka brokers and Kafka clients connecting to Keycloak / Hydra have to use the 
 same hostname to ensure compatibility of generated access tokens.

--- a/testsuite/docker/kerberos/Dockerfile
+++ b/testsuite/docker/kerberos/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu
+FROM ubuntu:22.04
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update -y && apt-get install -y krb5-kdc krb5-admin-server
 

--- a/testsuite/docker/kerberos/Dockerfile
+++ b/testsuite/docker/kerberos/Dockerfile
@@ -1,0 +1,10 @@
+FROM ubuntu
+
+RUN apt-get update -y && apt-get install -y krb5-kdc krb5-admin-server
+
+EXPOSE 88 749
+
+ADD ./config.sh /config.sh
+
+ENTRYPOINT ["/config.sh"]
+

--- a/testsuite/docker/kerberos/Dockerfile
+++ b/testsuite/docker/kerberos/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu
 
-RUN apt-get update -y && apt-get install -y krb5-kdc krb5-admin-server
+RUN DEBIAN_FRONTEND=noninteractive apt-get update -y && apt-get install -y krb5-kdc krb5-admin-server
 
 EXPOSE 88 749
 

--- a/testsuite/docker/kerberos/config.sh
+++ b/testsuite/docker/kerberos/config.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+
+[[ "TRACE" ]] && set -x
+
+: ${REALM:=KERBEROS}
+: ${DOMAIN_REALM:=kerberos}
+: ${KERB_MASTER_KEY:=masterkey}
+: ${KERB_ADMIN_USER:=admin}
+: ${KERB_ADMIN_PASS:=admin}
+: ${KAFKA_USER:=kafka}
+: ${KAFKA_HOST:=kafka}
+: ${KAFKA_CLIENT_USER:=client}
+
+fix_nameserver() {
+  cat>/etc/resolv.conf<<EOF
+nameserver $NAMESERVER_IP
+search $SEARCH_DOMAINS
+EOF
+}
+
+fix_hostname() {
+  sed -i "/^hosts:/ s/ *files dns/ dns files/" /etc/nsswitch.conf
+}
+
+create_config() {
+  : ${KDC_ADDRESS:=$(hostname -f)}
+
+  cat>/etc/krb5.conf<<EOF
+[logging]
+ default = FILE:/var/log/kerberos/krb5libs.log
+ kdc = FILE:/var/log/kerberos/krb5kdc.log
+ admin_server = FILE:/var/log/kerberos/kadmind.log
+
+[libdefaults]
+ default_realm = $REALM
+ dns_lookup_realm = false
+ dns_lookup_kdc = false
+ ticket_lifetime = 24h
+ renew_lifetime = 7d
+ forwardable = true
+
+[realms]
+ $REALM = {
+  kdc = $KDC_ADDRESS
+  admin_server = $KDC_ADDRESS
+ }
+
+[domain_realm]
+ .$DOMAIN_REALM = $REALM
+ $DOMAIN_REALM = $REALM
+EOF
+}
+
+create_db() {
+  kdb5_util -P $KERB_MASTER_KEY -r $REALM create -s
+}
+
+start_kdc() {
+  service krb5-kdc start
+  service krb5-admin-server start
+}
+
+restart_kdc() {
+  service krb5-kdc restart
+  service krb5-admin-server restart
+}
+
+create_admin_user() {
+  kadmin.local -q "addprinc -pw $KERB_ADMIN_PASS $KERB_ADMIN_USER/admin"
+  echo "*/admin@$REALM *" > /etc/krb5kdc/kadm5.acl
+}
+
+create_kafka_user() {
+  kadmin.local -q "addprinc -randkey $KAFKA_HOST/$KAFKA_USER@$REALM"
+  kadmin.local -q "ktadd -k /keytabs/kafka_broker.keytab $KAFKA_HOST/$KAFKA_USER@$REALM"
+  kadmin.local -q "addprinc -randkey $KAFKA_HOST/$KAFKA_CLIENT_USER@$REALM"
+  kadmin.local -q "ktadd -k /keytabs/kafka_client.keytab $KAFKA_HOST/$KAFKA_CLIENT_USER@$REALM"
+  chmod 666 /keytabs/kafka_broker.keytab
+  chmod 666 /keytabs/kafka_client.keytab
+}
+
+
+
+if [ ! -f /kerberos_initialized ]; then
+  mkdir -p /var/log/kerberos
+  create_config
+  create_db
+  create_admin_user
+  create_kafka_user
+  start_kdc
+
+  touch /kerberos_initialized
+else
+  start_kdc
+fi
+
+tail -F /var/log/kerberos/krb5kdc.log

--- a/testsuite/docker/kerberos/kafka_server_jaas.conf
+++ b/testsuite/docker/kerberos/kafka_server_jaas.conf
@@ -1,0 +1,7 @@
+KafkaServer {
+    com.sun.security.auth.module.Krb5LoginModule required
+    useKeyTab=true
+    storeKey=true
+    keyTab="/opt/kafka/keytabs/kafka_broker.keytab"
+    principal="kafka/kafka@KERBEROS";
+};

--- a/testsuite/docker/kerberos/krb5.conf
+++ b/testsuite/docker/kerberos/krb5.conf
@@ -1,0 +1,21 @@
+[logging]
+ default = FILE:/var/log/kerberos/krb5libs.log
+ kdc = FILE:/var/log/kerberos/krb5kdc.log
+ admin_server = FILE:/var/log/kerberos/kadmind.log
+[libdefaults]
+ default_realm = KERBEROS
+ dns_lookup_realm = false
+ dns_lookup_kdc = false
+ ticket_lifetime = 24h
+ renew_lifetime = 7d
+ forwardable = true
+ rdns = false
+ ignore_acceptor_hostname = true
+[realms]
+ KERBEROS = {
+  kdc = kerberos
+  admin_server = kerberos
+ }
+[domain_realm]
+ .kerberos = KERBEROS
+ kerberos = KERBEROS

--- a/testsuite/keycloak-authz-zk-tests/src/test/java/io/strimzi/testsuite/oauth/authz/kraft/KeycloakZKAuthorizationTests.java
+++ b/testsuite/keycloak-authz-zk-tests/src/test/java/io/strimzi/testsuite/oauth/authz/kraft/KeycloakZKAuthorizationTests.java
@@ -116,6 +116,7 @@ public class KeycloakZKAuthorizationTests {
 
         } catch (Throwable e) {
             log.error("Keycloak ZK Authorization Test failed: ", e);
+            e.printStackTrace();
             throw e;
         }
     }

--- a/testsuite/mockoauth-tests/docker-compose-kerberos.yml
+++ b/testsuite/mockoauth-tests/docker-compose-kerberos.yml
@@ -43,6 +43,9 @@ services:
       - ${PWD}/../docker/kafka/config:/opt/kafka/config/strimzi
       - ${PWD}/../docker/target/kafka/certs:/opt/kafka/config/strimzi/certs
       - ${PWD}/../docker/kafka/scripts:/opt/kafka/strimzi
+      - ${PWD}/../docker/kerberos/krb5.conf:/etc/krb5.conf
+      - ${PWD}/../docker/kerberos/kafka_server_jaas.conf:/opt/kafka/kafka_server_jaas.conf
+      - ${PWD}/../docker/kerberos/keys:/opt/kafka/keytabs
     command:
       - /bin/bash
       - -c
@@ -55,8 +58,8 @@ services:
 
       - KAFKA_BROKER_ID=1
       - KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181
-      - KAFKA_LISTENERS=INTERBROKER://kafka:9091,JWT://kafka:9092,INTROSPECT://kafka:9093,JWTPLAIN://kafka:9094,PLAIN://kafka:9095,INTROSPECTTIMEOUT://kafka:9096,FAILINGINTROSPECT://kafka:9097,FAILINGJWT://kafka:9098
-      - KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=INTERBROKER:PLAINTEXT,JWT:SASL_PLAINTEXT,INTROSPECT:SASL_PLAINTEXT,JWTPLAIN:SASL_PLAINTEXT,PLAIN:SASL_PLAINTEXT,INTROSPECTTIMEOUT:SASL_PLAINTEXT,FAILINGINTROSPECT:SASL_PLAINTEXT,FAILINGJWT:SASL_PLAINTEXT
+      - KAFKA_LISTENERS=INTERBROKER://kafka:9091,JWT://kafka:9092,INTROSPECT://kafka:9093,JWTPLAIN://kafka:9094,PLAIN://kafka:9095,INTROSPECTTIMEOUT://kafka:9096,FAILINGINTROSPECT://kafka:9097,FAILINGJWT://kafka:9098,KERBEROS://kafka:9099
+      - KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=INTERBROKER:PLAINTEXT,JWT:SASL_PLAINTEXT,INTROSPECT:SASL_PLAINTEXT,JWTPLAIN:SASL_PLAINTEXT,PLAIN:SASL_PLAINTEXT,INTROSPECTTIMEOUT:SASL_PLAINTEXT,FAILINGINTROSPECT:SASL_PLAINTEXT,FAILINGJWT:SASL_PLAINTEXT,KERBEROS:SASL_PLAINTEXT
       - KAFKA_SASL_ENABLED_MECHANISMS=OAUTHBEARER
       - KAFKA_INTER_BROKER_LISTENER_NAME=INTERBROKER
 
@@ -120,6 +123,9 @@ services:
       #   The following value will turn into 'strimzi.oauth.metric.reporters=...' in 'strimzi.properties' file
       #   However, that won't work as the value may be filtered to the component that happens to initialise OAuthMetrics
       #- KAFKA_STRIMZI_OAUTH_METRIC_REPORTERS=org.apache.kafka.common.metrics.JmxReporter
+      - KAFKA_LISTENER_NAME_KERBEROS_SASL_KERBEROS_SERVICE_NAME=kafka
+      - KAFKA_LISTENER_NAME_KERBEROS_SASL_ENABLED_MECHANISMS=GSSAPI
+      - KAFKA_OPTS=-Djava.security.krb5.conf=/etc/krb5.conf -Djava.security.auth.login.config=/opt/kafka/kafka_server_jaas.conf
 
   zookeeper:
     image: ${KAFKA_DOCKER_IMAGE}
@@ -127,9 +133,24 @@ services:
       - "2181:2181"
     volumes:
       - ${PWD}/../docker/zookeeper/scripts:/opt/kafka/strimzi
+      - ${PWD}/../docker/kafka/kerberos/keys:/keytabs
     command:
       - /bin/bash
       - -c
       - cd /opt/kafka/strimzi && ./start.sh
     environment:
       - LOG_DIR=/tmp/logs
+  kerberos:
+    build: ${PWD}/../docker/kerberos
+    hostname: 'kerberos'
+    environment:
+      - REALM=KERBEROS
+      - DOMAIN_REALM=kerberos
+      - KERB_MASTER_KEY=masterkey
+      - KERB_ADMIN_USER=admin
+      - KERB_ADMIN_PASS=admin
+    volumes:
+      - ${PWD}/../docker/kerberos/keys:/keytabs
+    ports:
+      - "749:749"
+      - "88:88/udp"

--- a/testsuite/mockoauth-tests/docker-compose.yml
+++ b/testsuite/mockoauth-tests/docker-compose.yml
@@ -33,6 +33,7 @@ services:
       - "9096:9096"
       - "9097:9097"
       - "9098:9098"
+      - "9099:9099"
       - "9404:9404"
 
       # Debug port
@@ -42,9 +43,13 @@ services:
       - ${PWD}/../docker/kafka/config:/opt/kafka/config/strimzi
       - ${PWD}/../docker/target/kafka/certs:/opt/kafka/config/strimzi/certs
       - ${PWD}/../docker/kafka/scripts:/opt/kafka/strimzi
+      - ${PWD}/../docker/kerberos/krb5.conf:/etc/krb5.conf
+      - ${PWD}/../docker/kerberos/kafka_server_jaas.conf:/opt/kafka/kafka_server_jaas.conf
+      - ${PWD}/../docker/kerberos/keys:/opt/kafka/keytabs
     command:
       - /bin/bash
       - -c
+        #- sleep 10000
       - cd /opt/kafka/strimzi && ./start_no_wait.sh
     environment:
       #- KAFKA_DEBUG=y
@@ -53,8 +58,8 @@ services:
 
       - KAFKA_BROKER_ID=1
       - KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181
-      - KAFKA_LISTENERS=INTERBROKER://kafka:9091,JWT://kafka:9092,INTROSPECT://kafka:9093,JWTPLAIN://kafka:9094,PLAIN://kafka:9095,INTROSPECTTIMEOUT://kafka:9096,FAILINGINTROSPECT://kafka:9097,FAILINGJWT://kafka:9098
-      - KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=INTERBROKER:PLAINTEXT,JWT:SASL_PLAINTEXT,INTROSPECT:SASL_PLAINTEXT,JWTPLAIN:SASL_PLAINTEXT,PLAIN:SASL_PLAINTEXT,INTROSPECTTIMEOUT:SASL_PLAINTEXT,FAILINGINTROSPECT:SASL_PLAINTEXT,FAILINGJWT:SASL_PLAINTEXT
+      - KAFKA_LISTENERS=INTERBROKER://kafka:9091,JWT://kafka:9092,INTROSPECT://kafka:9093,JWTPLAIN://kafka:9094,PLAIN://kafka:9095,INTROSPECTTIMEOUT://kafka:9096,FAILINGINTROSPECT://kafka:9097,FAILINGJWT://kafka:9098,KERBEROS://kafka:9099
+      - KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=INTERBROKER:PLAINTEXT,JWT:SASL_PLAINTEXT,INTROSPECT:SASL_PLAINTEXT,JWTPLAIN:SASL_PLAINTEXT,PLAIN:SASL_PLAINTEXT,INTROSPECTTIMEOUT:SASL_PLAINTEXT,FAILINGINTROSPECT:SASL_PLAINTEXT,FAILINGJWT:SASL_PLAINTEXT,KERBEROS:SASL_PLAINTEXT
       - KAFKA_SASL_ENABLED_MECHANISMS=OAUTHBEARER
       - KAFKA_INTER_BROKER_LISTENER_NAME=INTERBROKER
 
@@ -118,6 +123,9 @@ services:
       #   The following value will turn into 'strimzi.oauth.metric.reporters=...' in 'strimzi.properties' file
       #   However, that won't work as the value may be filtered to the component that happens to initialise OAuthMetrics
       #- KAFKA_STRIMZI_OAUTH_METRIC_REPORTERS=org.apache.kafka.common.metrics.JmxReporter
+      - KAFKA_LISTENER_NAME_KERBEROS_SASL_KERBEROS_SERVICE_NAME=kafka
+      - KAFKA_LISTENER_NAME_KERBEROS_SASL_ENABLED_MECHANISMS=GSSAPI
+      - KAFKA_OPTS=-Djava.security.krb5.conf=/etc/krb5.conf -Djava.security.auth.login.config=/opt/kafka/kafka_server_jaas.conf
 
   zookeeper:
     image: ${KAFKA_DOCKER_IMAGE}
@@ -125,9 +133,24 @@ services:
       - "2181:2181"
     volumes:
       - ${PWD}/../docker/zookeeper/scripts:/opt/kafka/strimzi
+      - ${PWD}/../docker/kafka/kerberos/keys:/keytabs
     command:
       - /bin/bash
       - -c
       - cd /opt/kafka/strimzi && ./start.sh
     environment:
       - LOG_DIR=/tmp/logs
+  kerberos:
+    build: ${PWD}/../docker/kerberos
+    hostname: 'kerberos'
+    environment:
+      - REALM=KERBEROS
+      - DOMAIN_REALM=kerberos
+      - KERB_MASTER_KEY=masterkey
+      - KERB_ADMIN_USER=admin
+      - KERB_ADMIN_PASS=admin
+    volumes:
+      - ${PWD}/../docker/kerberos/keys:/keytabs
+    ports:
+      - "749:749"
+      - "88:88/udp"

--- a/testsuite/mockoauth-tests/src/test/java/io/strimzi/testsuite/oauth/MockOAuthTests.java
+++ b/testsuite/mockoauth-tests/src/test/java/io/strimzi/testsuite/oauth/MockOAuthTests.java
@@ -16,6 +16,7 @@ import io.strimzi.testsuite.oauth.mockoauth.JaasClientConfigTest;
 import io.strimzi.testsuite.oauth.mockoauth.KeycloakAuthorizerTest;
 import io.strimzi.testsuite.oauth.mockoauth.PasswordAuthTest;
 import io.strimzi.testsuite.oauth.mockoauth.RetriesTests;
+import io.strimzi.testsuite.oauth.mockoauth.KerberosListenerTest;
 
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -40,9 +41,11 @@ public class MockOAuthTests {
     @ClassRule
     public static TestContainersWatcher environment =
             new TestContainersWatcher(new File("docker-compose.yml"))
-                    .withServices("mockoauth", "kafka", "zookeeper")
+                    .withServices("mockoauth", "kerberos", "kafka", "zookeeper")
                     .waitingFor("mockoauth", Wait.forLogMessage(".*Succeeded in deploying verticle.*", 1)
                             .withStartupTimeout(Duration.ofSeconds(180)))
+                    .waitingFor("kerberos", Wait.forLogMessage(".*commencing operation.*", 1)
+                            .withStartupTimeout(Duration.ofSeconds(45)))
                     .waitingFor("kafka", Wait.forLogMessage(".*started \\(kafka.server.KafkaServer\\).*", 1)
                             .withStartupTimeout(Duration.ofSeconds(180)));
 
@@ -94,6 +97,9 @@ public class MockOAuthTests {
 
             logStart("ClientAssertionAuthTest :: Client Assertion Tests");
             new ClientAssertionAuthTest().doTest();
+
+            logStart("KerberosTests :: Test authentication with Kerberos");
+            new KerberosListenerTest().doTests();
 
         } catch (Throwable e) {
             log.error("Exception has occurred: ", e);

--- a/testsuite/mockoauth-tests/src/test/java/io/strimzi/testsuite/oauth/mockoauth/KerberosListenerTest.java
+++ b/testsuite/mockoauth-tests/src/test/java/io/strimzi/testsuite/oauth/mockoauth/KerberosListenerTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2017-2023, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.testsuite.oauth.mockoauth;
+
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.CreateTopicsResult;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.junit.Assert;
+
+import java.io.File;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Properties;
+import java.util.concurrent.ExecutionException;
+
+public class KerberosListenerTest {
+
+    private static final String TOPIC_NAME = "Kerberos-Test-Topic";
+    private static final long CONSUMER_TIMEOUT = 10000L;
+    private static final int MESSAGE_COUNT = 100;
+
+    public void doTests() throws Exception {
+
+        //File krb5 = new File("../docker/kerberos/krb5.conf");
+        //Assert.assertTrue(krb5.exists());
+        //Assert.assertTrue(krb5.canRead());
+
+        File keyTab = new File("../docker/kerberos/keys/kafka_client.keytab");
+        Assert.assertTrue(keyTab.exists());
+        Assert.assertTrue(keyTab.canRead());
+
+        //System.out.println(krb5.getAbsolutePath());
+        //System.setProperty("java.security.krb5.conf", krb5.getAbsolutePath());
+        System.out.println(System.getProperty("java.security.krb5.conf"));
+
+        Properties props = new Properties();
+        props.put("security.protocol", "SASL_PLAINTEXT");
+        props.put("sasl.kerberos.service.name", "kafka");
+        props.put("sasl.jaas.config", "com.sun.security.auth.module.Krb5LoginModule required useKeyTab=true storeKey=true keyTab='../docker/kerberos/keys/kafka_client.keytab' principal='kafka/client@KERBEROS';");
+        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "kafka:9099");
+
+
+        Admin admin = Admin.create(props);
+        CreateTopicsResult result = admin.createTopics(Collections.singleton(new NewTopic(TOPIC_NAME, (short) 1, (short) 1)));
+        try {
+            result.all().get();
+        } catch (Exception e) {
+            Assert.fail("Failed to create topic on Kerberos listener because of " + e.getMessage());
+            e.printStackTrace();
+        }
+
+        Properties producerProps = (Properties) props.clone();
+        producerProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        producerProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+
+        KafkaProducer<String, String> producer = new KafkaProducer<>(producerProps);
+
+        for (int i = 0; i < MESSAGE_COUNT; i++) {
+            try {
+                producer.send(new ProducerRecord<>(TOPIC_NAME, String.format("message_%d", i))).get();
+            } catch (ExecutionException e) {
+                Assert.fail("Failed to produce to Kerberos listener because of " + e.getCause());
+                e.printStackTrace();
+            }
+        }
+
+        Properties consumerProps = (Properties) props.clone();
+        consumerProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        consumerProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        consumerProps.put(ConsumerConfig.GROUP_ID_CONFIG, String.format("kerberos_listener_test_%d", System.currentTimeMillis()));
+
+        KafkaConsumer<String, String> consumer = new KafkaConsumer<>(consumerProps);
+
+        TopicPartition tp = new TopicPartition(TOPIC_NAME, 0);
+        consumer.assign(Collections.singleton(tp));
+        consumer.seekToBeginning(consumer.assignment());
+        long startTime = System.currentTimeMillis();
+
+        int receiveCount = 0;
+
+        while (System.currentTimeMillis() - startTime < CONSUMER_TIMEOUT) {
+            ConsumerRecords<String, String> results = consumer.poll(Duration.ofMillis(300));
+            for (ConsumerRecord<String, String> record : results) {
+                if (record.value().startsWith("message_")) receiveCount++;
+            }
+        }
+        Assert.assertEquals("Kerberos listener consumer should consume all messsages", MESSAGE_COUNT, receiveCount);
+
+    }
+
+}

--- a/testsuite/mockoauth-tests/src/test/java/io/strimzi/testsuite/oauth/mockoauth/KerberosListenerTest.java
+++ b/testsuite/mockoauth-tests/src/test/java/io/strimzi/testsuite/oauth/mockoauth/KerberosListenerTest.java
@@ -33,24 +33,15 @@ public class KerberosListenerTest {
 
     public void doTests() throws Exception {
 
-        //File krb5 = new File("../docker/kerberos/krb5.conf");
-        //Assert.assertTrue(krb5.exists());
-        //Assert.assertTrue(krb5.canRead());
-
         File keyTab = new File("../docker/kerberos/keys/kafka_client.keytab");
         Assert.assertTrue(keyTab.exists());
         Assert.assertTrue(keyTab.canRead());
-
-        //System.out.println(krb5.getAbsolutePath());
-        //System.setProperty("java.security.krb5.conf", krb5.getAbsolutePath());
-        System.out.println(System.getProperty("java.security.krb5.conf"));
 
         Properties props = new Properties();
         props.put("security.protocol", "SASL_PLAINTEXT");
         props.put("sasl.kerberos.service.name", "kafka");
         props.put("sasl.jaas.config", "com.sun.security.auth.module.Krb5LoginModule required useKeyTab=true storeKey=true keyTab='../docker/kerberos/keys/kafka_client.keytab' principal='kafka/client@KERBEROS';");
         props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "kafka:9099");
-
 
         Admin admin = Admin.create(props);
         CreateTopicsResult result = admin.createTopics(Collections.singleton(new NewTopic(TOPIC_NAME, (short) 1, (short) 1)));

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -292,7 +292,7 @@
                     <systemPropertyVariables>
                         <KAFKA_DOCKER_IMAGE>${kafka.docker.image}</KAFKA_DOCKER_IMAGE>
                     </systemPropertyVariables>
-					<argLine>-Djava.security.krb5.conf=${project.basedir}/../docker/kerberos/krb5.conf</argLine>
+                    <argLine>-Djava.security.krb5.conf=${project.basedir}/../docker/kerberos/krb5.conf</argLine>
                 </configuration>
 
             </plugin>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -292,7 +292,9 @@
                     <systemPropertyVariables>
                         <KAFKA_DOCKER_IMAGE>${kafka.docker.image}</KAFKA_DOCKER_IMAGE>
                     </systemPropertyVariables>
+					<argLine>-Djava.security.krb5.conf=${project.basedir}/../docker/kerberos/krb5.conf</argLine>
                 </configuration>
+
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
As described in #208,

The principal builder extends the `DefaultKafkaPrincipalBuilder` but it just passes nulls to the two objects, `SslPrincipalMapper` and `KerberosShortNamer` in the super class constructor. For the first object, some reflection is used to initialize it anyway, but this is not done for the `KerberosShortNamer`. The result is that, if this principal builder is used on a broker that has a listener configured for Kerberos authentication, a null pointer exception is thrown [here](https://github.com/apache/kafka/blob/1073d434ec98e64afca1979cd18d3244b133e688/clients/src/main/java/org/apache/kafka/common/security/authenticator/DefaultKafkaPrincipalBuilder.java#L94) whenever a client tries to authenticate. Since my goal is to add an Oauth listener in-place to an existing Kafka cluster and then begin migrating clients from Kerberos to Oauth, this is a huge problem. As far as I know, there is no way to configure a principal builder for a single listener. 

This PR just uses the existing reflection mechanisms to instantiate the `KerberosShortNamer` in addition to the `SslPrincipalMapper`, by recreating what Kafka does [here](https://github.com/apache/kafka/blob/1073d434ec98e64afca1979cd18d3244b133e688/clients/src/main/java/org/apache/kafka/common/network/SaslChannelBuilder.java#L162-L165) and [here](https://github.com/apache/kafka/blob/1073d434ec98e64afca1979cd18d3244b133e688/clients/src/main/java/org/apache/kafka/common/network/SaslChannelBuilder.java#L294-L297).