### PR TITLE
Remove exclusion of json-path transitive from kafka-oauth-client

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Copy the following jars into your Kafka `libs` directory:
     oauth-client/target/kafka-oauth-client-*.jar
     oauth-common/target/lib/nimbus-jose-jwt-*.jar
 
-If you want to use custom claim checking, also copy the following:
+If you want to use custom claim checking, or json-path based principal extraction from JWT tokens, also copy the following:
 
     oauth-server/target/lib/json-path-*.jar
     oauth-server/target/lib/json-smart-*.jar

--- a/oauth-client/pom.xml
+++ b/oauth-client/pom.xml
@@ -15,12 +15,6 @@
         <dependency>
             <groupId>io.strimzi</groupId>
             <artifactId>kafka-oauth-common</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.jayway.jsonpath</groupId>
-                    <artifactId>json-path</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
This PR Addresses https://github.com/strimzi/strimzi-kafka-oauth/issues/209