### PR TITLE
Oauth client assertion support

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,9 +147,7 @@ This is true for configuring the server side of the Kafka Broker, as well as for
 The authentication configuration specific to the Strimzi Kafka OAuth can be specified as part of JAAS configuration in the form of JAAS parameter values. 
 The authorization configuration for `KeycloakAuthorizer` is specified as `server.properties` key-value pairs.
 Both authentication and authorization configuration specific to Strimzi Kafka OAuth can also be set as ENV vars, or as Java system properties.
-The limitation here is that authentication configuration specified in this manner can not be listener-scoped. 
-
-Note that property-values starting with `env:` are interpreted as references to existing ENV vars.
+The limitation here is that authentication configuration specified in this manner can not be listener-scoped.
 
 ### Configuring the Kafka Broker authentication
 

--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ The authorization configuration for `KeycloakAuthorizer` is specified as `server
 Both authentication and authorization configuration specific to Strimzi Kafka OAuth can also be set as ENV vars, or as Java system properties.
 The limitation here is that authentication configuration specified in this manner can not be listener-scoped. 
 
+Note that property-values starting with `env:` are interpreted as references to existing ENV vars.
+
 ### Configuring the Kafka Broker authentication
 
 Note: Strimzi Kafka OAuth can not be used for Kafka Broker to Zookeeper authentication. It only supports Kafka Client to Kafka Broker authentication (including inter-broker communication).
@@ -926,19 +928,46 @@ Strimzi Kafka OAuth supports four ways to configure authentication on the client
 
 #### Client Credentials
 
-The first is to specify the client ID and secret configured on the authorization server specifically for the individual client deployment. This is also called `client credentials grant`.
+The first is to specify Client Credentials. This requires that a client is configured on the authorization server specifically for the individual client deployment. This is also called `client credentials grant`.
 
 This is achieved by specifying the following:
 - `oauth.client.id` (e.g.: "my-client")
+
+together with one of authentication options below 
+
+When client starts to establish the connection with the Kafka Broker it will first obtain an access token from the configured Token Endpoint, authenticating with the configured client ID and configured authentication option using client_credentials grant type.
+
+##### Option 1: Using a Client Secret 
+
+Specify the client secret.
+
 - `oauth.client.secret` (e.g.: "my-client-secret")
 
-When client starts to establish the connection with the Kafka Broker it will first obtain an access token from the configured Token Endpoint, authenticating with the configured client ID and secret using client_credentials grant type.
+##### Option 2: Using a Client Assertion (a.k.a. private_key_jwt)
+
+Specify the client assertion (JWT token) either directly through
+
+- `oauth.client.assertion`
+
+or pointing to a file on the filesystem
+
+- `oauth.client.assertion.location`
+
+the exact type of the token must also be communicated to the token endpoint and defaults to `urn:ietf:params:oauth:client-assertion-type:jwt-bearer`. 
+
+This can be overridden using property
+
+-  `oauth.client.assertion.type` (i.e. use `urn:ietf:params:oauth:client-assertion-type:saml2-bearer` for SAML 2 tokens)
 
 #### Refresh Token
 
-The second way is to manually obtain and set a refresh token:
+The second way is to manually obtain and set a refresh token either directly through
 
 - `oauth.refresh.token`
+
+or pointing to a file on the filesystem
+
+- `oauth.refresh.token.location`
 
 When using this approach you are not limited to OAuth2 client_credentials grant type for obtaining a token.
 You can use a password grant type and authenticate as an individual user, rather than a client application.
@@ -948,9 +977,13 @@ When client starts to establish the connection with the Kafka Broker it will fir
 
 #### Access Token
 
-The third way is to manually obtain and set an access token:
+The third way is to manually obtain and set an access token either directly through:
 
 - `oauth.access.token`
+
+or pointing to a file on the filesystem
+
+- `oauth.access.token.location`
 
 Access tokens are supposed to be short-lived in order to prevent unauthorized access if the token leaks.
 It is up to you, your environment, and how you plan to run your Kafka client application to consider if using long-lived access tokens is appropriate.

--- a/README.md
+++ b/README.md
@@ -953,7 +953,9 @@ or pointing to a file on the filesystem
 
 - `oauth.client.assertion.location`
 
-the exact type of the token must also be communicated to the token endpoint and defaults to `urn:ietf:params:oauth:client-assertion-type:jwt-bearer` (which is specified in RFC-7523). 
+The file contains secrets in plain text and should have proper permissions set - not readable by others.
+
+The exact type of the token must also be communicated to the token endpoint and defaults to `urn:ietf:params:oauth:client-assertion-type:jwt-bearer` (which is specified in RFC-7523). 
 
 This can be overridden using property
 
@@ -968,6 +970,8 @@ The second way is to manually obtain and set a refresh token either directly thr
 or pointing to a file on the filesystem
 
 - `oauth.refresh.token.location`
+
+The file contains secrets in plain text and should have proper permissions set - not readable by others.
 
 When using this approach you are not limited to OAuth2 client_credentials grant type for obtaining a token.
 You can use a password grant type and authenticate as an individual user, rather than a client application.
@@ -984,6 +988,8 @@ The third way is to manually obtain and set an access token either directly thro
 or pointing to a file on the filesystem
 
 - `oauth.access.token.location`
+
+The file contains secrets in plain text and should have proper permissions set - not readable by others.
 
 Access tokens are supposed to be short-lived in order to prevent unauthorized access if the token leaks.
 It is up to you, your environment, and how you plan to run your Kafka client application to consider if using long-lived access tokens is appropriate.

--- a/README.md
+++ b/README.md
@@ -933,7 +933,7 @@ The first is to specify Client Credentials. This requires that a client is confi
 This is achieved by specifying the following:
 - `oauth.client.id` (e.g.: "my-client")
 
-together with one of authentication options below 
+together with one of authentication options below.
 
 When client starts to establish the connection with the Kafka Broker it will first obtain an access token from the configured Token Endpoint, authenticating with the configured client ID and configured authentication option using client_credentials grant type.
 
@@ -953,11 +953,11 @@ or pointing to a file on the filesystem
 
 - `oauth.client.assertion.location`
 
-the exact type of the token must also be communicated to the token endpoint and defaults to `urn:ietf:params:oauth:client-assertion-type:jwt-bearer`. 
+the exact type of the token must also be communicated to the token endpoint and defaults to `urn:ietf:params:oauth:client-assertion-type:jwt-bearer` (which is specified in RFC-7523). 
 
 This can be overridden using property
 
--  `oauth.client.assertion.type` (i.e. use `urn:ietf:params:oauth:client-assertion-type:saml2-bearer` for SAML 2 tokens)
+-  `oauth.client.assertion.type` (i.e. use `urn:ietf:params:oauth:client-assertion-type:saml2-bearer`, specified in RFC-7522, for SAML 2 tokens)
 
 #### Refresh Token
 

--- a/examples/consumer/src/main/java/io/strimzi/examples/consumer/ExampleConsumer.java
+++ b/examples/consumer/src/main/java/io/strimzi/examples/consumer/ExampleConsumer.java
@@ -52,8 +52,9 @@ public class ExampleConsumer {
 
         defaults.setProperty(ClientConfig.OAUTH_TOKEN_ENDPOINT_URI, tokenEndpointUri);
 
-        //  By defaut this client uses preconfigured clientId and secret to authenticate.
-        //  You can set OAUTH_ACCESS_TOKEN or OAUTH_REFRESH_TOKEN to override default authentication.
+        //  By default, this client uses preconfigured clientId and secret to authenticate.
+        //  You can set OAUTH_ACCESS_TOKEN(_LOCATION) or OAUTH_REFRESH_TOKEN(_LOCATION)
+        //  or OAUTH_CLIENT_ASSERTION(_LOCATION) to override default authentication behavior.
         //
         //  If access token is configured, it is passed directly to Kafka broker
         //  If refresh token is configured, it is used in conjunction with clientId and secret
@@ -64,7 +65,12 @@ public class ExampleConsumer {
 
         if (accessToken == null) {
             defaults.setProperty(Config.OAUTH_CLIENT_ID, "kafka-consumer-client");
+
+            // use a secret for client_credentials authentication
             defaults.setProperty(Config.OAUTH_CLIENT_SECRET, "kafka-consumer-client-secret");
+
+            // use private_key_jwt for client_credentials authentication
+            //defaults.setProperty(ClientConfig.OAUTH_CLIENT_ASSERTION, "jwt-signed-by-trusted-key");
         }
 
         // Use 'preferred_username' rather than 'sub' for principal name

--- a/oauth-client/src/main/java/io/strimzi/kafka/oauth/client/ClientConfig.java
+++ b/oauth-client/src/main/java/io/strimzi/kafka/oauth/client/ClientConfig.java
@@ -17,9 +17,19 @@ public class ClientConfig extends Config {
     public static final String OAUTH_ACCESS_TOKEN = "oauth.access.token";
 
     /**
+     * "oauth.access.token.location"
+     */
+    public static final String OAUTH_ACCESS_TOKEN_LOCATION = "oauth.access.token.location";
+
+    /**
      * "oauth.refresh.token"
      */
     public static final String OAUTH_REFRESH_TOKEN = "oauth.refresh.token";
+
+    /**
+     * "oauth.refresh.token.location"
+     */
+    public static final String OAUTH_REFRESH_TOKEN_LOCATION = "oauth.refresh.token.location";
 
     /**
      * "oauth.token.endpoint.uri"
@@ -40,6 +50,21 @@ public class ClientConfig extends Config {
      * "oauth.password.grant.password"
      */
     public static final String OAUTH_PASSWORD_GRANT_PASSWORD = "oauth.password.grant.password";
+
+    /**
+     * "oauth.client.assertion"
+     */
+    public static final String OAUTH_CLIENT_ASSERTION = "oauth.client.assertion";
+
+    /**
+     * "oauth.client.assertion.location"
+     */
+    public static final String OAUTH_CLIENT_ASSERTION_LOCATION = "oauth.client.assertion.location";
+
+    /**
+     * "oauth.client.assertion.type"
+     */
+    public static final String OAUTH_CLIENT_ASSERTION_TYPE = "oauth.client.assertion.type";
 
     /**
      * Create a new instance

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/Config.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/Config.java
@@ -150,9 +150,6 @@ public class Config {
      * </pre>
      * If not, it checks if env variable with name equal to key exists.
      *
-     * if the value contains the 'env:' prefix the rest of the value is treated as a reference to an env variable
-     * and the value is dereferenced to the value of the environment variable
-     *
      * Ultimately, it checks the defaults passed at Config object construction time.
      * <p>
      * If no configuration is found for key, it returns the fallback value.
@@ -168,29 +165,26 @@ public class Config {
 
         // try system properties first
         String result = System.getProperty(key, null);
-
-        if (result == null) {
-            // try env properties
-            result = System.getenv(toEnvName(key));
+        if (result != null) {
+            return result;
         }
 
-        if (result == null) {
-            // try env property by key name (without converting with toEnvName())
-            result = System.getenv(key);
+        // try env properties
+        result = System.getenv(toEnvName(key));
+        if (result != null) {
+            return result;
         }
 
-        if (result == null && defaults != null) {
-            // try default properties and if all else fails return fallback value
+        // try env property by key name (without converting with toEnvName())
+        result = System.getenv(key);
+        if (result != null) {
+            return result;
+        }
+
+        // try default properties and if all else fails return fallback value
+        if (defaults != null) {
             Object val = defaults.get(key);
             result = val != null ? String.valueOf(val) : null;
-        }
-
-        if (result != null && result.startsWith("env:")) {
-            // try reference to environment variable
-            final String envResult = System.getenv(result.substring(4));
-            if (envResult != null) {
-                result = envResult;
-            }
         }
 
         return result != null ? result : fallback;

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/Config.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/Config.java
@@ -149,6 +149,10 @@ public class Config {
      *   key.toUpperCase().replace('-', '_').replace('.', '_');
      * </pre>
      * If not, it checks if env variable with name equal to key exists.
+     *
+     * if the value contains the 'env:' prefix the rest of the value is treated as a reference to an env variable
+     * and the value is dereferenced to the value of the environment variable
+     *
      * Ultimately, it checks the defaults passed at Config object construction time.
      * <p>
      * If no configuration is found for key, it returns the fallback value.
@@ -164,26 +168,29 @@ public class Config {
 
         // try system properties first
         String result = System.getProperty(key, null);
-        if (result != null) {
-            return result;
+
+        if (result == null) {
+            // try env properties
+            result = System.getenv(toEnvName(key));
         }
 
-        // try env properties
-        result = System.getenv(toEnvName(key));
-        if (result != null) {
-            return result;
+        if (result == null) {
+            // try env property by key name (without converting with toEnvName())
+            result = System.getenv(key);
         }
 
-        // try env property by key name (without converting with toEnvName())
-        result = System.getenv(key);
-        if (result != null) {
-            return result;
-        }
-
-        // try default properties and if all else fails return fallback value
-        if (defaults != null) {
+        if (result == null && defaults != null) {
+            // try default properties and if all else fails return fallback value
             Object val = defaults.get(key);
             result = val != null ? String.valueOf(val) : null;
+        }
+
+        if (result != null && result.startsWith("env:")) {
+            // try reference to environment variable
+            final String envResult = System.getenv(result.substring(4));
+            if (envResult != null) {
+                result = envResult;
+            }
         }
 
         return result != null ? result : fallback;

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/FileBasedTokenProvider.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/FileBasedTokenProvider.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017-2023, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.kafka.oauth.common;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * A TokenProvider that uses a file as a token source.
+ * The content of the file is fully read and returned every time a {@link io.strimzi.kafka.oauth.common.FileBasedTokenProvider#token()} method is called.
+ */
+public class FileBasedTokenProvider implements TokenProvider {
+
+    private static final Logger log = LoggerFactory.getLogger(io.strimzi.kafka.oauth.common.FileBasedTokenProvider.class);
+
+    private final Path filePath;
+
+    /**
+     * Create a new instance that refers to a specified file as a token source.
+     *
+     * @param tokenFilePath A path to a file containing a token
+     * @throws IllegalArgumentException if the specified tokenFilePath does not exist or is not a regular file
+     */
+    public FileBasedTokenProvider(final String tokenFilePath) {
+        this.filePath = Paths.get(tokenFilePath);
+
+        try {
+            if (!IOUtil.isFileAccessLimitedToOwner(filePath)) {
+                log.warn("Permissions on token file should only give access to owner [{}]", filePath);
+            }
+        } catch (IllegalArgumentException e) {
+            // received when file does not exist. re-throw an exception
+            throw e;
+        } catch (Exception e) {
+            log.warn("Failed to check permissions on token file [{}]:", filePath, e);
+        }
+    }
+
+    @Override
+    public String token() {
+        try {
+            return new String(Files.readAllBytes(filePath), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+}

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/OAuthAuthenticator.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/OAuthAuthenticator.java
@@ -221,7 +221,7 @@ public class OAuthAuthenticator {
      * @throws IOException If the request to the authorization server has failed
      * @throws IllegalStateException If the response from the authorization server could not be handled
      */
-     @SuppressWarnings("checkstyle:ParameterNumber")
+    @SuppressWarnings("checkstyle:ParameterNumber")
     public static TokenInfo loginWithClientAssertion(URI tokenEndpointUrl, SSLSocketFactory socketFactory,
                                                      HostnameVerifier hostnameVerifier,
                                                      String clientId, String clientAssertion, String clientAssertionType, boolean isJwt,

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/OAuthAuthenticator.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/OAuthAuthenticator.java
@@ -182,19 +182,24 @@ public class OAuthAuthenticator {
      * @param principalExtractor A PrincipalExtractor to use to determine the principal (user id)
      * @param scope A scope to request when authenticating
      * @param audience An 'audience' attribute to set on the request when authenticating
-     * @param includeAcceptHeader Should we skip sending the Accept header when making outbound http requests
      * @return A TokenInfo with access token and information extracted from it
      * @throws IOException If the request to the authorization server has failed
      * @throws IllegalStateException If the response from the authorization server could not be handled
      */
     @SuppressWarnings("checkstyle:ParameterNumber")
-    public static TokenInfo loginWithClientAssertion(URI tokenEndpointUrl, SSLSocketFactory socketFactory,
+    public static TokenInfo loginWithClientAssertion(URI tokenEndpointUrl,
+                                                     SSLSocketFactory socketFactory,
                                                      HostnameVerifier hostnameVerifier,
-                                                     String clientId, String clientAssertion, String clientAssertionType, boolean isJwt,
-                                                     PrincipalExtractor principalExtractor, String scope, String audience, boolean includeAcceptHeader) throws IOException {
+                                                     String clientId,
+                                                     String clientAssertion,
+                                                     String clientAssertionType,
+                                                     boolean isJwt,
+                                                     PrincipalExtractor principalExtractor,
+                                                     String scope,
+                                                     String audience) throws IOException {
 
         return loginWithClientAssertion(tokenEndpointUrl, socketFactory, hostnameVerifier,
-                clientId, clientAssertion, clientAssertionType, isJwt, principalExtractor, scope, audience, HttpUtil.DEFAULT_CONNECT_TIMEOUT, HttpUtil.DEFAULT_READ_TIMEOUT, null, 0, 0, includeAcceptHeader);
+                clientId, clientAssertion, clientAssertionType, isJwt, principalExtractor, scope, audience, HttpUtil.DEFAULT_CONNECT_TIMEOUT, HttpUtil.DEFAULT_READ_TIMEOUT, null, 0, 0, true);
     }
 
     /**
@@ -222,11 +227,22 @@ public class OAuthAuthenticator {
      * @throws IllegalStateException If the response from the authorization server could not be handled
      */
     @SuppressWarnings("checkstyle:ParameterNumber")
-    public static TokenInfo loginWithClientAssertion(URI tokenEndpointUrl, SSLSocketFactory socketFactory,
+    public static TokenInfo loginWithClientAssertion(URI tokenEndpointUrl,
+                                                     SSLSocketFactory socketFactory,
                                                      HostnameVerifier hostnameVerifier,
-                                                     String clientId, String clientAssertion, String clientAssertionType, boolean isJwt,
-                                                     PrincipalExtractor principalExtractor, String scope, String audience,
-                                                     int connectTimeout, int readTimeout, MetricsHandler metrics, int retries, long retryPauseMillis, boolean includeAcceptHeader) throws IOException {
+                                                     String clientId,
+                                                     String clientAssertion,
+                                                     String clientAssertionType,
+                                                     boolean isJwt,
+                                                     PrincipalExtractor principalExtractor,
+                                                     String scope,
+                                                     String audience,
+                                                     int connectTimeout,
+                                                     int readTimeout,
+                                                     MetricsHandler metrics,
+                                                     int retries,
+                                                     long retryPauseMillis,
+                                                     boolean includeAcceptHeader) throws IOException {
         if (log.isDebugEnabled()) {
             log.debug("loginWithClientAssertion() - tokenEndpointUrl: {}, clientId: {}, clientAssertion: {}, clientAssertionType: {}, scope: {}, audience: {}, connectTimeout: {}, readTimeout: {}, retries: {}, retryPauseMillis: {}",
                     tokenEndpointUrl, clientId, mask(clientAssertion), clientAssertionType, scope, audience, connectTimeout, readTimeout, retries, retryPauseMillis);

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/StaticTokenProvider.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/StaticTokenProvider.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017-2023, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+
+package io.strimzi.kafka.oauth.common;
+
+/**
+ * A TokenProvider that contains an immutable token that is returned every time a {@link io.strimzi.kafka.oauth.common.StaticTokenProvider#token()} method is called.
+ */
+public class StaticTokenProvider implements TokenProvider {
+    private final String token;
+
+    /**
+     * Create a new instance with a token that never changes
+     *
+     * @param token A token
+     */
+    public StaticTokenProvider(final String token) {
+        this.token = token;
+    }
+
+    @Override
+    public String token() {
+        return token;
+    }
+}

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/TokenProvider.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/TokenProvider.java
@@ -10,13 +10,29 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+/**
+ * A contract for a class that provides a token
+ */
 public interface TokenProvider {
 
+    /**
+     * Get a token
+     *
+     * @return A token
+     */
     String token();
 
+    /**
+     * A TokenProvider that contains an immutable token that is returned every time a {@link StaticTokenProvider#token()} method is called.
+     */
     class StaticTokenProvider implements TokenProvider {
         private final String token;
 
+        /**
+         * Create a new instance with a token that never changes
+         *
+         * @param token A token
+         */
         public StaticTokenProvider(final String token) {
             this.token = token;
         }
@@ -27,9 +43,18 @@ public interface TokenProvider {
         }
     }
 
+    /**
+     * A TokenProvider that uses a file as a token source.
+     * The content of the file is fully read and returned every time a {@link FileBasedTokenProvider#token()} method is called.
+     */
     class FileBasedTokenProvider implements TokenProvider {
         private final Path filePath;
 
+        /**
+         * Create a new instance that refers to a specified file as a token source.
+         *
+         * @param tokenFilePath A path to a file containing a token
+         */
         public FileBasedTokenProvider(final String tokenFilePath) {
             this.filePath = Paths.get(tokenFilePath);
             if (!filePath.toFile().exists()) {

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/TokenProvider.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/TokenProvider.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017-2019, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.kafka.oauth.common;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public interface TokenProvider {
+
+    String token();
+
+    class StaticTokenProvider implements TokenProvider {
+        private final String token;
+
+        public StaticTokenProvider(final String token) {
+            this.token = token;
+        }
+
+        @Override
+        public String token() {
+            return token;
+        }
+    }
+
+    class FileBasedTokenProvider implements TokenProvider {
+        private final Path filePath;
+
+        public FileBasedTokenProvider(final String tokenFilePath) {
+            this.filePath = Paths.get(tokenFilePath);
+            if (!filePath.toFile().exists()) {
+                throw new IllegalArgumentException("file '" + filePath + "' does not exist!");
+            }
+            if (!filePath.toFile().isFile()) {
+                throw new IllegalArgumentException("'" + filePath + "' does not point to a file!");
+            }
+        }
+
+        @Override
+        public String token() {
+            try {
+                return new String(Files.readAllBytes(filePath), StandardCharsets.UTF_8);
+            } catch (IOException e) {
+                throw new IllegalStateException(e);
+            }
+        }
+    }
+}

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/TokenProvider.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/TokenProvider.java
@@ -1,14 +1,8 @@
 /*
- * Copyright 2017-2019, Strimzi authors.
+ * Copyright 2017-2023, Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
 package io.strimzi.kafka.oauth.common;
-
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 
 /**
  * A contract for a class that provides a token
@@ -22,56 +16,4 @@ public interface TokenProvider {
      */
     String token();
 
-    /**
-     * A TokenProvider that contains an immutable token that is returned every time a {@link StaticTokenProvider#token()} method is called.
-     */
-    class StaticTokenProvider implements TokenProvider {
-        private final String token;
-
-        /**
-         * Create a new instance with a token that never changes
-         *
-         * @param token A token
-         */
-        public StaticTokenProvider(final String token) {
-            this.token = token;
-        }
-
-        @Override
-        public String token() {
-            return token;
-        }
-    }
-
-    /**
-     * A TokenProvider that uses a file as a token source.
-     * The content of the file is fully read and returned every time a {@link FileBasedTokenProvider#token()} method is called.
-     */
-    class FileBasedTokenProvider implements TokenProvider {
-        private final Path filePath;
-
-        /**
-         * Create a new instance that refers to a specified file as a token source.
-         *
-         * @param tokenFilePath A path to a file containing a token
-         */
-        public FileBasedTokenProvider(final String tokenFilePath) {
-            this.filePath = Paths.get(tokenFilePath);
-            if (!filePath.toFile().exists()) {
-                throw new IllegalArgumentException("file '" + filePath + "' does not exist!");
-            }
-            if (!filePath.toFile().isFile()) {
-                throw new IllegalArgumentException("'" + filePath + "' does not point to a file!");
-            }
-        }
-
-        @Override
-        public String token() {
-            try {
-                return new String(Files.readAllBytes(filePath), StandardCharsets.UTF_8);
-            } catch (IOException e) {
-                throw new IllegalStateException(e);
-            }
-        }
-    }
 }

--- a/oauth-common/src/test/java/io/strimzi/kafka/oauth/common/FilePermissionsTest.java
+++ b/oauth-common/src/test/java/io/strimzi/kafka/oauth/common/FilePermissionsTest.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
+import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.attribute.FileAttribute;
@@ -20,17 +21,19 @@ import java.nio.file.attribute.AclEntry;
 import java.nio.file.attribute.AclEntryType;
 import java.nio.file.attribute.AclFileAttributeView;
 import java.nio.file.attribute.UserPrincipal;
+import java.util.Arrays;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Set;
 
 import static io.strimzi.kafka.oauth.common.IOUtil.isFileAccessLimitedToOwner;
+import static java.nio.file.Files.createSymbolicLink;
 
 public class FilePermissionsTest {
 
     @Test
     public void filePermissionCheckTest() throws Exception {
-        // if file does not exist there is nothing to check
+
         String filePath = "target/test1.txt";
         Path file = Paths.get(filePath);
         Assert.assertFalse("File should not yet exist", Files.exists(file));
@@ -53,6 +56,48 @@ public class FilePermissionsTest {
             try {
                 Files.delete(file);
             } catch (Exception ignored) {
+            }
+        }
+    }
+
+    @Test
+    public void filePermissionWithSymlinksCheckTest() throws Exception {
+
+        FileSystem fs = FileSystems.getDefault();
+        Set<String> supportedViews = fs.supportedFileAttributeViews();
+        if (supportedViews.contains("posix")) {
+
+            String filePath = "target/test1.txt";
+            Path file = Paths.get(filePath);
+            Assert.assertFalse("File should not yet exist", Files.exists(file));
+
+            // also check that symlinks don't exist
+            Path link1File = Paths.get("target/link1");
+            Path link2File = Paths.get("target/link2");
+            Assert.assertFalse("Link1 should not yet exist", Files.exists(link1File, LinkOption.NOFOLLOW_LINKS));
+            Assert.assertFalse("Link2 should not yet exist", Files.exists(link2File, LinkOption.NOFOLLOW_LINKS));
+
+            try {
+                createSymbolicLink(link1File, file.getFileName());
+                createSymbolicLink(link2File, link1File.getFileName());
+
+                // This part of the test only works in posix compatible environment
+                // Create a file
+                createFile(file, false);
+                Assert.assertFalse("File should be accessible to group and others", isFileAccessLimitedToOwner(link2File));
+
+                Files.delete(file);
+
+                createFile(file, true);
+                Assert.assertTrue("File should NOT be accessible to group and others", isFileAccessLimitedToOwner(file));
+
+            } finally {
+                for (Path f: Arrays.asList(file, link1File, link2File)) {
+                    try {
+                        Files.delete(f);
+                    } catch (Exception ignored) {
+                    }
+                }
             }
         }
     }

--- a/oauth-common/src/test/java/io/strimzi/kafka/oauth/common/FilePermissionsTest.java
+++ b/oauth-common/src/test/java/io/strimzi/kafka/oauth/common/FilePermissionsTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2017-2023, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.kafka.oauth.common;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.attribute.FileAttribute;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+
+public class FilePermissionsTest {
+
+    @Test
+    public void filePermissionCheckTest() throws IOException {
+        // if file does not exist there is nothing to check
+        String filePath = "target/test1.txt";
+        Path file = Paths.get(filePath);
+        Assert.assertFalse("File should not yet exist", Files.exists(file));
+
+        try {
+            // Create a file
+            createFile(file, false);
+            Assert.assertFalse("File should be accessible to group and others", checkFileAccessLimitedToOwner(file));
+
+            Files.delete(file);
+            createFile(file, true);
+            Assert.assertTrue("File should not be accessible to group and others", checkFileAccessLimitedToOwner(file));
+        } finally {
+            Files.delete(file);
+        }
+    }
+
+    private void createFile(Path file, boolean isPrivate) throws IOException {
+        FileSystem fs = FileSystems.getDefault();
+        Set<String> supportedViews = fs.supportedFileAttributeViews();
+        if (supportedViews.contains("posix")) {
+            FileAttribute<Set<PosixFilePermission>> fileAttrs = PosixFilePermissions.asFileAttribute(
+                            PosixFilePermissions.fromString(isPrivate ? "rw-------" : "rw-r--r--"));
+
+            Files.createFile(file, fileAttrs);
+        } else {
+            throw new RuntimeException("Not a POSIX compatible filesystem: " + fs);
+        }
+    }
+
+
+    /**
+     * Check that there are zero permissions for group and others
+     *
+     * @param file Path object representing an existing file to check file permissions for
+     * @return <code>true</code> if file permissions limit access to this file to the owner
+     * @throws IllegalArgumentException if file doesn't exist or is not a regular file (not a directory)
+     * @throws UnsupportedOperationException if filesystem doesn't support POSIX file permissions
+     * @throws IOException if an I/O error occurs
+     */
+    public static boolean checkFileAccessLimitedToOwner(Path file) throws IOException {
+        if (!Files.exists(file)) {
+            throw new IllegalArgumentException("No such file: " + file.toAbsolutePath());
+        }
+        if (!Files.isRegularFile(file)) {
+            throw new IllegalArgumentException("File is not a regular file: " + file.toAbsolutePath());
+        }
+
+        Set<PosixFilePermission> perms = Files.getPosixFilePermissions(file);
+        List<PosixFilePermission> disallowed = Arrays.asList(
+                PosixFilePermission.GROUP_READ, PosixFilePermission.GROUP_WRITE, PosixFilePermission.GROUP_EXECUTE,
+                PosixFilePermission.OTHERS_READ, PosixFilePermission.OTHERS_WRITE, PosixFilePermission.OTHERS_EXECUTE);
+
+        // afterwards 'perms' will only contain disallowed permissions if any are present
+        perms.retainAll(disallowed);
+        return perms.isEmpty();
+    }
+}

--- a/oauth-common/src/test/java/io/strimzi/kafka/oauth/common/HttpUtilTimeoutTest.java
+++ b/oauth-common/src/test/java/io/strimzi/kafka/oauth/common/HttpUtilTimeoutTest.java
@@ -78,7 +78,7 @@ public class HttpUtilTimeoutTest {
                 Assert.fail("Should fail with SocketTimeoutException");
             } catch (SocketTimeoutException e) {
                 long diff = System.currentTimeMillis() - start;
-                Assert.assertTrue("Unexpected error: " + e, e.toString().contains("Read timed out"));
+                Assert.assertTrue("Unexpected error: " + e, e.toString().contains("ead timed out"));
                 Assert.assertTrue("Unexpected diff: " + diff, diff >= timeout * 1000 && diff < timeout * 1000 + 1000);
             }
 
@@ -108,7 +108,7 @@ public class HttpUtilTimeoutTest {
                 Assert.fail("Should fail with SocketTimeoutException");
             } catch (SocketTimeoutException e) {
                 long diff = System.currentTimeMillis() - start;
-                Assert.assertTrue("Unexpected error: " + e, e.toString().contains("Read timed out"));
+                Assert.assertTrue("Unexpected error: " + e, e.toString().contains("ead timed out"));
                 Assert.assertTrue("Unexpected diff: " + diff, diff >= timeout * 1000 && diff < timeout * 1000 + 1000);
             }
 

--- a/oauth-common/src/test/java/io/strimzi/kafka/oauth/common/TokenProviderTest.java
+++ b/oauth-common/src/test/java/io/strimzi/kafka/oauth/common/TokenProviderTest.java
@@ -16,9 +16,7 @@ public class TokenProviderTest {
 
     @Test
     public void testStaticTokenProvider() {
-
         final TokenProvider staticTokenProvider = new StaticTokenProvider("test-token");
-
         Assert.assertEquals(staticTokenProvider.token(), "test-token");
     }
 
@@ -37,21 +35,21 @@ public class TokenProviderTest {
     }
 
     @Test
-    public void testFileBasedTokenProvider_fileDoesNotExist() {
+    public void testFileBasedTokenProviderWhenFileDoesNotExist() {
         try {
-            final TokenProvider fileBasedTokenProvider = new FileBasedTokenProvider("/invalid-file-path");
+            new FileBasedTokenProvider("invalid-file-path");
             Assert.fail("failed to test for file type");
 
         } catch (IllegalArgumentException e) {
-            Assert.assertEquals("No such file: /invalid-file-path", e.getMessage());
+            Assert.assertTrue("No such file ...", e.getMessage().contains("No such file"));
         }
     }
 
     @Test
-    public void testFileBasedTokenProvider_fileIsDir() {
+    public void testFileBasedTokenProviderWhenFileIsDir() {
         String tempDir = new File(System.getProperty("java.io.tmpdir")).getAbsolutePath();
         try {
-            final TokenProvider fileBasedTokenProvider = new FileBasedTokenProvider(tempDir);
+            new FileBasedTokenProvider(tempDir);
             Assert.fail("failed to test for file existence");
 
         } catch (IllegalArgumentException e) {
@@ -60,7 +58,7 @@ public class TokenProviderTest {
     }
 
     @Test
-    public void testFileBasedTokenProvider_fileRemoved() throws IOException {
+    public void testFileBasedTokenProviderWhenFileRemoved() throws IOException {
         final File tempFile = File.createTempFile("test-token-", ".jwt");
         Files.write(tempFile.toPath(), "some-test-value".getBytes(StandardCharsets.UTF_8));
 

--- a/oauth-common/src/test/java/io/strimzi/kafka/oauth/common/TokenProviderTest.java
+++ b/oauth-common/src/test/java/io/strimzi/kafka/oauth/common/TokenProviderTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2017-2022, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.kafka.oauth.common;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+
+public class TokenProviderTest {
+
+    @Test
+    public void testStaticTokenProvider() {
+
+        final TokenProvider staticTokenProvider = new TokenProvider.StaticTokenProvider("test-token");
+
+        Assert.assertEquals(staticTokenProvider.token(), "test-token");
+    }
+
+    @Test
+    public void testFileBasedTokenProvider() throws IOException {
+        final File tempFile = File.createTempFile("test-token-", ".jwt");
+        Files.write(tempFile.toPath(), "some-test-value".getBytes(StandardCharsets.UTF_8));
+
+        final TokenProvider fileBasedTokenProvider = new TokenProvider.FileBasedTokenProvider(tempFile.getPath());
+
+        final String tokenValueFromFile = fileBasedTokenProvider.token();
+        final boolean delete = tempFile.delete();
+
+        Assert.assertEquals("some-test-value", tokenValueFromFile);
+        Assert.assertTrue(delete);
+    }
+
+    @Test
+    public void testFileBasedTokenProvider_fileDoesNotExist() {
+        try {
+            final TokenProvider fileBasedTokenProvider = new TokenProvider.FileBasedTokenProvider("/invalid-file-path");
+            Assert.fail("failed to test for file type");
+
+        } catch (IllegalArgumentException e) {
+            Assert.assertEquals("file '/invalid-file-path' does not exist!", e.getMessage());
+        }
+    }
+
+    @Test
+    public void testFileBasedTokenProvider_fileIsDir() {
+        String tempDir = new File(System.getProperty("java.io.tmpdir")).getAbsolutePath();
+        try {
+            final TokenProvider fileBasedTokenProvider = new TokenProvider.FileBasedTokenProvider(tempDir);
+            Assert.fail("failed to test for file existence");
+
+        } catch (IllegalArgumentException e) {
+            Assert.assertEquals("'" + tempDir + "' does not point to a file!", e.getMessage());
+        }
+    }
+
+    @Test
+    public void testFileBasedTokenProvider_fileRemoved() throws IOException {
+        final File tempFile = File.createTempFile("test-token-", ".jwt");
+        Files.write(tempFile.toPath(), "some-test-value".getBytes(StandardCharsets.UTF_8));
+
+        final TokenProvider fileBasedTokenProvider = new TokenProvider.FileBasedTokenProvider(tempFile.getPath());
+
+        final boolean delete = tempFile.delete();
+        Assert.assertTrue(delete);
+
+        try {
+            fileBasedTokenProvider.token();
+            Assert.fail("this should not be possible");
+
+        } catch (IllegalStateException e) {
+            Assert.assertTrue(e.getCause() instanceof IOException);
+        }
+    }
+}

--- a/oauth-common/src/test/java/io/strimzi/kafka/oauth/common/TokenProviderTest.java
+++ b/oauth-common/src/test/java/io/strimzi/kafka/oauth/common/TokenProviderTest.java
@@ -17,7 +17,7 @@ public class TokenProviderTest {
     @Test
     public void testStaticTokenProvider() {
 
-        final TokenProvider staticTokenProvider = new TokenProvider.StaticTokenProvider("test-token");
+        final TokenProvider staticTokenProvider = new StaticTokenProvider("test-token");
 
         Assert.assertEquals(staticTokenProvider.token(), "test-token");
     }
@@ -27,7 +27,7 @@ public class TokenProviderTest {
         final File tempFile = File.createTempFile("test-token-", ".jwt");
         Files.write(tempFile.toPath(), "some-test-value".getBytes(StandardCharsets.UTF_8));
 
-        final TokenProvider fileBasedTokenProvider = new TokenProvider.FileBasedTokenProvider(tempFile.getPath());
+        final TokenProvider fileBasedTokenProvider = new FileBasedTokenProvider(tempFile.getPath());
 
         final String tokenValueFromFile = fileBasedTokenProvider.token();
         final boolean delete = tempFile.delete();
@@ -39,11 +39,11 @@ public class TokenProviderTest {
     @Test
     public void testFileBasedTokenProvider_fileDoesNotExist() {
         try {
-            final TokenProvider fileBasedTokenProvider = new TokenProvider.FileBasedTokenProvider("/invalid-file-path");
+            final TokenProvider fileBasedTokenProvider = new FileBasedTokenProvider("/invalid-file-path");
             Assert.fail("failed to test for file type");
 
         } catch (IllegalArgumentException e) {
-            Assert.assertEquals("file '/invalid-file-path' does not exist!", e.getMessage());
+            Assert.assertEquals("No such file: /invalid-file-path", e.getMessage());
         }
     }
 
@@ -51,11 +51,11 @@ public class TokenProviderTest {
     public void testFileBasedTokenProvider_fileIsDir() {
         String tempDir = new File(System.getProperty("java.io.tmpdir")).getAbsolutePath();
         try {
-            final TokenProvider fileBasedTokenProvider = new TokenProvider.FileBasedTokenProvider(tempDir);
+            final TokenProvider fileBasedTokenProvider = new FileBasedTokenProvider(tempDir);
             Assert.fail("failed to test for file existence");
 
         } catch (IllegalArgumentException e) {
-            Assert.assertEquals("'" + tempDir + "' does not point to a file!", e.getMessage());
+            Assert.assertEquals("File is not a regular file: " + tempDir, e.getMessage());
         }
     }
 
@@ -64,7 +64,7 @@ public class TokenProviderTest {
         final File tempFile = File.createTempFile("test-token-", ".jwt");
         Files.write(tempFile.toPath(), "some-test-value".getBytes(StandardCharsets.UTF_8));
 
-        final TokenProvider fileBasedTokenProvider = new TokenProvider.FileBasedTokenProvider(tempFile.getPath());
+        final TokenProvider fileBasedTokenProvider = new FileBasedTokenProvider(tempFile.getPath());
 
         final boolean delete = tempFile.delete();
         Assert.assertTrue(delete);

--- a/testsuite/mock-oauth-server/src/main/java/io/strimzi/testsuite/oauth/server/AdminServerRequestHandler.java
+++ b/testsuite/mock-oauth-server/src/main/java/io/strimzi/testsuite/oauth/server/AdminServerRequestHandler.java
@@ -268,9 +268,14 @@ public class AdminServerRequestHandler implements Handler<HttpServerRequest> {
                     }
 
                     String secret = json.getString("secret");
+                    String clientAssertion = json.getString("clientAssertion");
                     if (secret == null) {
-                        sendResponse(req, BAD_REQUEST, "Required attribute 'secret' is null or missing.");
-                        return;
+                        if (clientAssertion == null) {
+                            sendResponse(req, BAD_REQUEST, "Required attribute 'secret' is null or missing.");
+                            return;
+                        } else {
+                            secret = clientAssertion;
+                        }
                     }
 
                     verticle.createOrUpdateClient(clientId, secret);

--- a/testsuite/mock-oauth-server/src/main/java/io/strimzi/testsuite/oauth/server/MockOAuthServerMainVerticle.java
+++ b/testsuite/mock-oauth-server/src/main/java/io/strimzi/testsuite/oauth/server/MockOAuthServerMainVerticle.java
@@ -141,6 +141,7 @@ public class MockOAuthServerMainVerticle extends AbstractVerticle {
 
     private final Map<String, String> clients = new HashMap<>();
     private final Map<String, UserInfo> users = new HashMap<>();
+    private final Map<String, RefreshTokenInfo> refreshTokens = new HashMap<>();
     private final Set<String> revokedTokens = new HashSet<>();
 
     private final Map<String, JsonArray> grants = new HashMap<>();
@@ -300,6 +301,14 @@ public class MockOAuthServerMainVerticle extends AbstractVerticle {
 
     Map<String, UserInfo> getUsers() {
         return Collections.unmodifiableMap(users);
+    }
+
+    void createRefreshToken(String token, RefreshTokenInfo info) {
+        refreshTokens.put(token, info);
+    }
+
+    Map<String, RefreshTokenInfo> getRefreshTokens() {
+        return Collections.unmodifiableMap(refreshTokens);
     }
 
     void revokeToken(String token) {

--- a/testsuite/mock-oauth-server/src/main/java/io/strimzi/testsuite/oauth/server/RefreshTokenInfo.java
+++ b/testsuite/mock-oauth-server/src/main/java/io/strimzi/testsuite/oauth/server/RefreshTokenInfo.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2017-2023, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.testsuite.oauth.server;
+
+public class RefreshTokenInfo {
+    final String clientId;
+    final String username;
+
+    public RefreshTokenInfo(String clientId, String username) {
+        this.clientId = clientId;
+        this.username = username;
+    }
+}

--- a/testsuite/mockoauth-tests/docker-compose.yml
+++ b/testsuite/mockoauth-tests/docker-compose.yml
@@ -68,7 +68,7 @@ services:
       - KAFKA_LISTENER_NAME_INTROSPECT_OAUTHBEARER_SASL_SERVER_CALLBACK_HANDLER_CLASS=io.strimzi.kafka.oauth.server.JaasServerOauthValidatorCallbackHandler
       #- KAFKA_LISTENER_NAME_INTROSPECT_OAUTHBEARER_SASL_LOGIN_CALLBACK_HANDLER_CLASS=io.strimzi.kafka.oauth.client.JaasClientOauthLoginCallbackHandler
 
-      - KAFKA_LISTENER_NAME_JWT_OAUTHBEARER_SASL_JAAS_CONFIG=org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required    oauth.config.id=\"JWT\"    oauth.fail.fast=\"false\"    oauth.jwks.endpoint.uri=\"https://mockoauth:8090/jwks\"    oauth.jwks.refresh.seconds=\"10\"    oauth.valid.issuer.uri=\"https://mockoauth:8090\"    unsecuredLoginStringClaim_sub=\"admin\" ;
+      - KAFKA_LISTENER_NAME_JWT_OAUTHBEARER_SASL_JAAS_CONFIG=org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required    oauth.config.id=\"JWT\"    oauth.fail.fast=\"false\"    oauth.jwks.endpoint.uri=\"https://mockoauth:8090/jwks\"    oauth.jwks.refresh.seconds=\"10\"    oauth.valid.issuer.uri=\"https://mockoauth:8090\"    oauth.check.access.token.type=\"false\"    unsecuredLoginStringClaim_sub=\"admin\" ;
       - KAFKA_LISTENER_NAME_JWT_OAUTHBEARER_SASL_SERVER_CALLBACK_HANDLER_CLASS=io.strimzi.kafka.oauth.server.JaasServerOauthValidatorCallbackHandler
 
       - KAFKA_LISTENER_NAME_JWTPLAIN_SASL_ENABLED_MECHANISMS=OAUTHBEARER,PLAIN

--- a/testsuite/mockoauth-tests/src/test/java/io/strimzi/testsuite/oauth/MockOAuthTests.java
+++ b/testsuite/mockoauth-tests/src/test/java/io/strimzi/testsuite/oauth/MockOAuthTests.java
@@ -61,6 +61,9 @@ public class MockOAuthTests {
             String kafkaContainer = environment.getContainerByServiceName("kafka_1").get().getContainerInfo().getName().substring(1);
             System.out.println("See log at: " + new File("target/test.log").getAbsolutePath());
 
+            // MetricsTest has to be the first as it relies on initial configuration and behaviour of mockoauth
+            //   JWKS endpoint is expected to return 404
+            //   Subsequent tests can change that, but it takes some seconds for Kafka to retry fetching JWKS keys
             logStart("MetricsTest :: Basic Metrics Tests");
             new MetricsTest().doTest();
 

--- a/testsuite/mockoauth-tests/src/test/java/io/strimzi/testsuite/oauth/MockOAuthTests.java
+++ b/testsuite/mockoauth-tests/src/test/java/io/strimzi/testsuite/oauth/MockOAuthTests.java
@@ -8,13 +8,14 @@ import io.strimzi.testsuite.oauth.common.TestContainersLogCollector;
 import io.strimzi.testsuite.oauth.common.TestContainersWatcher;
 import io.strimzi.testsuite.oauth.mockoauth.JaasServerConfigTest;
 import io.strimzi.testsuite.oauth.mockoauth.metrics.MetricsTest;
+import io.strimzi.testsuite.oauth.mockoauth.ClientAssertionAuthTest;
 import io.strimzi.testsuite.oauth.mockoauth.ConnectTimeoutTests;
 import io.strimzi.testsuite.oauth.mockoauth.JWKSKeyUseTest;
 import io.strimzi.testsuite.oauth.mockoauth.JaasClientConfigTest;
 import io.strimzi.testsuite.oauth.mockoauth.KeycloakAuthorizerTest;
 import io.strimzi.testsuite.oauth.mockoauth.PasswordAuthTest;
-
 import io.strimzi.testsuite.oauth.mockoauth.RetriesTests;
+
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -83,6 +84,9 @@ public class MockOAuthTests {
 
             // Keycloak authorizer tests
             new KeycloakAuthorizerTest().doTests();
+
+            logStart("ClientAssertionAuthTest :: Client Assertion Tests");
+            new ClientAssertionAuthTest().doTest();
 
         } catch (Throwable e) {
             log.error("Exception has occurred: ", e);

--- a/testsuite/mockoauth-tests/src/test/java/io/strimzi/testsuite/oauth/mockoauth/ClientAssertionAuthTest.java
+++ b/testsuite/mockoauth-tests/src/test/java/io/strimzi/testsuite/oauth/mockoauth/ClientAssertionAuthTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2017-2022, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.testsuite.oauth.mockoauth;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.strimzi.kafka.oauth.common.HttpException;
+import io.strimzi.kafka.oauth.common.HttpUtil;
+import io.strimzi.kafka.oauth.common.OAuthAuthenticator;
+import io.strimzi.kafka.oauth.common.SSLUtil;
+import io.strimzi.kafka.oauth.common.TokenInfo;
+import io.strimzi.kafka.oauth.common.TokenIntrospection;
+import org.junit.Assert;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.net.ssl.SSLSocketFactory;
+import java.net.URI;
+
+import static io.strimzi.testsuite.oauth.mockoauth.Common.WWW_FORM_CONTENT_TYPE;
+import static io.strimzi.testsuite.oauth.mockoauth.Common.changeAuthServerMode;
+import static io.strimzi.testsuite.oauth.mockoauth.Common.createOAuthClient;
+import static io.strimzi.testsuite.oauth.mockoauth.Common.createOAuthClientWithAssertion;
+
+public class ClientAssertionAuthTest {
+
+    private static final Logger log = LoggerFactory.getLogger(ClientAssertionAuthTest.class);
+
+    public void doTest() throws Exception {
+
+        changeAuthServerMode("token", "MODE_200");
+        changeAuthServerMode("introspect", "MODE_200");
+
+        // create a client for resource server
+        String clientSrv = "appserver";
+        String clientSrvSecret = "appserver-secret";
+        createOAuthClient(clientSrv, clientSrvSecret);
+
+        // create a client client2
+        String client2 = "client2";
+        String client2Assertion = "client2-assertion";
+        createOAuthClientWithAssertion(client2, client2Assertion);
+
+        String projectRoot = Common.getProjectRoot();
+        SSLSocketFactory sslFactory = SSLUtil.createSSLFactory(
+                projectRoot + "/../docker/certificates/ca-truststore.p12", null, "changeit", null, null);
+
+        try {
+            // Use client_credentials to authenticate with wrong client_assertion
+            TokenInfo tokenInfo = OAuthAuthenticator.loginWithClientAssertion(
+                    URI.create("https://mockoauth:8090/token"),
+                    sslFactory,
+                    null,
+                    client2,
+                    "bad-client-assertion",
+                    "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+                    true,
+                    null,
+                    null,
+                    null);
+
+            Assert.fail("Should have failed with 401");
+        } catch (HttpException e) {
+            Assert.assertEquals("Expected status 401", 401, e.getStatus());
+        }
+
+        // Use client_credentials to authenticate with correct client_assertion
+        TokenInfo tokenInfo = OAuthAuthenticator.loginWithClientAssertion(
+                URI.create("https://mockoauth:8090/token"),
+                sslFactory,
+                null,
+                client2,
+                client2Assertion,
+                "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+                true,
+                null,
+                null,
+                null);
+
+        String token = tokenInfo.token();
+        Assert.assertNotNull(token);
+
+        TokenIntrospection.debugLogJWT(log, token);
+
+        // introspect the token using the introspection endpoint
+        ObjectNode json = HttpUtil.post(URI.create("https://mockoauth:8090/introspect"), sslFactory, null,
+                "Basic " + OAuthAuthenticator.base64encode(clientSrv + ':' + clientSrvSecret), WWW_FORM_CONTENT_TYPE, "token=" + token, ObjectNode.class);
+
+        log.info("Got introspection endpoint response: " + json);
+        Assert.assertTrue("Token active", json.get("active").asBoolean());
+        Assert.assertEquals("Introspection endpoint response contains `client_id`", client2, json.get("client_id") != null ? json.get("client_id").asText() : null);
+        Assert.assertNull("Introspection endpoint response does not contain `username`", json.get("username"));
+    }
+}

--- a/testsuite/mockoauth-tests/src/test/java/io/strimzi/testsuite/oauth/mockoauth/ClientAssertionAuthTest.java
+++ b/testsuite/mockoauth-tests/src/test/java/io/strimzi/testsuite/oauth/mockoauth/ClientAssertionAuthTest.java
@@ -31,6 +31,7 @@ public class ClientAssertionAuthTest {
 
         changeAuthServerMode("token", "MODE_200");
         changeAuthServerMode("introspect", "MODE_200");
+        changeAuthServerMode("jwks", "MODE_200");
 
         // create a client for resource server
         String clientSrv = "appserver";
@@ -61,8 +62,10 @@ public class ClientAssertionAuthTest {
                     null);
 
             Assert.fail("Should have failed with 401");
-        } catch (HttpException e) {
-            Assert.assertEquals("Expected status 401", 401, e.getStatus());
+        } catch (Exception e) {
+            Throwable cause = e.getCause();
+            Assert.assertTrue("Cause is HttpException", cause instanceof HttpException);
+            Assert.assertEquals("Expected status 401", 401, ((HttpException) cause).getStatus());
         }
 
         // Use client_credentials to authenticate with correct client_assertion

--- a/testsuite/mockoauth-tests/src/test/java/io/strimzi/testsuite/oauth/mockoauth/Common.java
+++ b/testsuite/mockoauth-tests/src/test/java/io/strimzi/testsuite/oauth/mockoauth/Common.java
@@ -106,9 +106,26 @@ public class Common {
         return tokenInfo.token();
     }
 
+    static String loginWithUsernameForRefreshToken(String tokenEndpointUri, String username, String password, String clientId, String truststorePath, String truststorePass) throws IOException {
+
+        JsonNode result = HttpUtil.post(URI.create(tokenEndpointUri),
+                SSLUtil.createSSLFactory(truststorePath, null, truststorePass, null, null),
+                null,
+                null,
+                WWW_FORM_CONTENT_TYPE,
+                "grant_type=password&username=" + username + "&password=" + password + "&client_id=" + clientId,
+                JsonNode.class);
+
+        JsonNode token = result.get("refresh_token");
+        if (token == null) {
+            throw new IllegalStateException("Invalid response from authorization server: no refresh_token");
+        }
+        return token.asText();
+    }
+
     /**
      * Get response from prometheus endpoint as a map of key:value pairs
-     * We expect the response to be a 'well formed' key=value document in the sense that each line contains a '=' sign
+     * We expect the response to be a 'well-formed' key=value document in the sense that each line contains a '=' sign
      *
      * @param metricsEndpointUri The endpoint used to fetch metrics
      * @return Metrics object

--- a/testsuite/mockoauth-tests/src/test/java/io/strimzi/testsuite/oauth/mockoauth/Common.java
+++ b/testsuite/mockoauth-tests/src/test/java/io/strimzi/testsuite/oauth/mockoauth/Common.java
@@ -178,6 +178,13 @@ public class Common {
                 "{\"clientId\": \"" + clientId + "\", \"secret\": \"" + secret + "\"}", String.class);
     }
 
+    public static void createOAuthClientWithAssertion(String clientId, String clientAssertion) throws IOException {
+        HttpUtil.post(URI.create("http://mockoauth:8091/admin/clients"),
+                null,
+                "application/json",
+                "{\"clientId\": \"" + clientId + "\", \"clientAssertion\": \"" + clientAssertion + "\"}", String.class);
+    }
+
     public static void createOAuthUser(String username, String password) throws IOException {
         HttpUtil.post(URI.create("http://mockoauth:8091/admin/users"),
                 null,

--- a/testsuite/mockoauth-tests/src/test/java/io/strimzi/testsuite/oauth/mockoauth/PasswordAuthTest.java
+++ b/testsuite/mockoauth-tests/src/test/java/io/strimzi/testsuite/oauth/mockoauth/PasswordAuthTest.java
@@ -48,7 +48,6 @@ public class PasswordAuthTest {
         String user1Pass = "user1-password";
         createOAuthUser(user1, user1Pass);
 
-        // authenticate user against token endpoint with the wrong password
         String projectRoot = Common.getProjectRoot();
         SSLSocketFactory sslFactory = SSLUtil.createSSLFactory(
                 projectRoot + "/../docker/certificates/ca-truststore.p12", null, "changeit", null, null);
@@ -138,6 +137,5 @@ public class PasswordAuthTest {
         Assert.assertTrue("Token active", json.get("active").asBoolean());
         Assert.assertEquals("Introspection endpoint response contains `client_id`", client1, json.get("client_id") != null ? json.get("client_id").asText() : null);
         Assert.assertNull("Introspection endpoint response does not contain `username`", json.get("username"));
-
     }
 }


### PR DESCRIPTION
This PR adds support for Kafka clients to obtain an access token by authenticating to the authorization server with client assertion as specified by https://www.rfc-editor.org/rfc/rfc7523 and https://www.rfc-editor.org/rfc/rfc7521. The assertion can be provided by an external mechanism and available as a file on the file system or it can be explicitly set through OAuth configuration before running the Kafka client.

In addition, the static access token or refresh token can now be provided as a file on the local filesystem.

The following new configuration options have been added by this PR:
- `oauth.client.assertion`
- `oauth.client.assertion.location`
- `oauth.client.assertion.type`
- `oauth.refresh.token.location`
- `oauth.access.token.location`
