### PR TITLE
Update Jayway Json-Path to 2.9.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
         <kafka.version>3.6.0</kafka.version>
         <jackson.version>2.15.2</jackson.version>
         <jackson.databind.version>2.15.2</jackson.databind.version>
-        <jsonpath.version>2.8.0</jsonpath.version>
+        <jsonpath.version>2.9.0</jsonpath.version>
         <junit.version>4.13.2</junit.version>
         <slf4j.version>1.7.36</slf4j.version>
         <mockito.version>3.12.4</mockito.version>


### PR DESCRIPTION
This PR updates the Jayway Json-Path dependency to 2.9.0 to address CVE-2023-51074.