### PR TITLE
oath-client handler class refactoring

### DIFF
--- a/oauth-client/src/main/java/io/strimzi/kafka/oauth/client/JaasClientOauthLoginCallbackHandler.java
+++ b/oauth-client/src/main/java/io/strimzi/kafka/oauth/client/JaasClientOauthLoginCallbackHandler.java
@@ -84,12 +84,10 @@ public class JaasClientOauthLoginCallbackHandler implements AuthenticateCallback
             throw new IllegalArgumentException("Unexpected SASL mechanism: " + saslMechanism);
         }
 
-        jaasConfigEntries
-                .forEach(entry -> {
-                    Properties p = new Properties();
-                    p.putAll(entry.getOptions());
-                    config = new ClientConfig(p);
-                });
+        AppConfigurationEntry entry = jaasConfigEntries.getFirst();
+        Properties p = new Properties();
+        p.putAll(entry.getOptions());
+        config = new ClientConfig(p);
 
         final String token = config.getValue(ClientConfig.OAUTH_ACCESS_TOKEN);
         final String tokenLocation = config.getValue(ClientConfig.OAUTH_ACCESS_TOKEN_LOCATION);

--- a/oauth-client/src/main/java/io/strimzi/kafka/oauth/client/JaasClientOauthLoginCallbackHandler.java
+++ b/oauth-client/src/main/java/io/strimzi/kafka/oauth/client/JaasClientOauthLoginCallbackHandler.java
@@ -84,7 +84,7 @@ public class JaasClientOauthLoginCallbackHandler implements AuthenticateCallback
             throw new IllegalArgumentException("Unexpected SASL mechanism: " + saslMechanism);
         }
 
-        AppConfigurationEntry entry = jaasConfigEntries.getFirst();
+        AppConfigurationEntry entry = jaasConfigEntries.get(0);
         Properties p = new Properties();
         p.putAll(entry.getOptions());
         config = new ClientConfig(p);

--- a/oauth-client/src/main/java/io/strimzi/kafka/oauth/client/JaasClientOauthLoginCallbackHandler.java
+++ b/oauth-client/src/main/java/io/strimzi/kafka/oauth/client/JaasClientOauthLoginCallbackHandler.java
@@ -4,20 +4,14 @@
  */
 package io.strimzi.kafka.oauth.client;
 
-import io.strimzi.kafka.oauth.client.metrics.ClientAuthenticationSensorKeyProducer;
-import io.strimzi.kafka.oauth.client.metrics.ClientHttpSensorKeyProducer;
+import io.strimzi.kafka.oauth.client.metrics.ClientMetricsHandler;
+import io.strimzi.kafka.oauth.client.metrics.ClientUtils;
 import io.strimzi.kafka.oauth.common.Config;
 import io.strimzi.kafka.oauth.common.ConfigException;
 import io.strimzi.kafka.oauth.common.ConfigUtil;
-import io.strimzi.kafka.oauth.common.MetricsHandler;
 import io.strimzi.kafka.oauth.common.PrincipalExtractor;
 import io.strimzi.kafka.oauth.common.TokenInfo;
 import io.strimzi.kafka.oauth.common.TokenProvider;
-import io.strimzi.kafka.oauth.common.FileBasedTokenProvider;
-import io.strimzi.kafka.oauth.common.StaticTokenProvider;
-import io.strimzi.kafka.oauth.metrics.SensorKeyProducer;
-import io.strimzi.kafka.oauth.services.OAuthMetrics;
-import io.strimzi.kafka.oauth.services.Services;
 import org.apache.kafka.common.security.auth.AuthenticateCallbackHandler;
 import org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule;
 import org.apache.kafka.common.security.oauthbearer.OAuthBearerToken;
@@ -55,8 +49,6 @@ public class JaasClientOauthLoginCallbackHandler implements AuthenticateCallback
 
     private static final Logger LOG = LoggerFactory.getLogger(JaasClientOauthLoginCallbackHandler.class);
 
-    private ClientConfig config = new ClientConfig();
-
     private String clientId;
     private String clientSecret;
     private String clientAssertionType;
@@ -68,26 +60,23 @@ public class JaasClientOauthLoginCallbackHandler implements AuthenticateCallback
     private String scope;
     private String audience;
     private URI tokenEndpoint;
-
     private boolean isJwt;
     private int maxTokenExpirySeconds;
     private PrincipalExtractor principalExtractor;
-
     private SSLSocketFactory socketFactory;
     private HostnameVerifier hostnameVerifier;
-
     private int connectTimeout;
     private int readTimeout;
     private int retries;
     private long retryPauseMillis;
-
-    private boolean enableMetrics;
-    private OAuthMetrics metrics;
-    private SensorKeyProducer authSensorKeyProducer;
-    private SensorKeyProducer tokenSensorKeyProducer;
-
-    private final ClientMetricsHandler authenticatorMetrics = new ClientMetricsHandler();
     private boolean includeAcceptHeader;
+    private final ClientMetricsHandler authenticatorMetrics;
+    private final ClientUtils clientUtils;
+    private ClientConfig config;
+    public JaasClientOauthLoginCallbackHandler(ClientUtils clientUtils, ClientMetricsHandler authenticatorMetrics) {
+        this.clientUtils = clientUtils;
+        this.authenticatorMetrics = authenticatorMetrics;
+    }
 
     @Override
     public void configure(Map<String, ?> configs, String saslMechanism, List<AppConfigurationEntry> jaasConfigEntries) {
@@ -95,15 +84,16 @@ public class JaasClientOauthLoginCallbackHandler implements AuthenticateCallback
             throw new IllegalArgumentException("Unexpected SASL mechanism: " + saslMechanism);
         }
 
-        for (AppConfigurationEntry e: jaasConfigEntries) {
-            Properties p = new Properties();
-            p.putAll(e.getOptions());
-            config = new ClientConfig(p);
-        }
+        jaasConfigEntries
+                .forEach(entry -> {
+                    Properties p = new Properties();
+                    p.putAll(entry.getOptions());
+                    config = new ClientConfig(p);
+                });
 
         final String token = config.getValue(ClientConfig.OAUTH_ACCESS_TOKEN);
         final String tokenLocation = config.getValue(ClientConfig.OAUTH_ACCESS_TOKEN_LOCATION);
-        tokenProvider = configureAccessTokenProvider(token, tokenLocation);
+        tokenProvider = clientUtils.configureAccessTokenProvider(token, tokenLocation);
 
         if (token == null && tokenLocation == null) {
             String endpoint = config.getValue(ClientConfig.OAUTH_TOKEN_ENDPOINT_URI);
@@ -120,16 +110,17 @@ public class JaasClientOauthLoginCallbackHandler implements AuthenticateCallback
             }
         }
 
+
         final String refreshToken = config.getValue(ClientConfig.OAUTH_REFRESH_TOKEN);
         final String refreshTokenLocation = config.getValue(ClientConfig.OAUTH_REFRESH_TOKEN_LOCATION);
-        refreshTokenProvider = configureRefreshTokenProvider(refreshToken, refreshTokenLocation);
+        refreshTokenProvider = clientUtils.configureRefreshTokenProvider(refreshToken, refreshTokenLocation);
 
         clientId = config.getValue(Config.OAUTH_CLIENT_ID);
         clientSecret = config.getValue(Config.OAUTH_CLIENT_SECRET);
 
         final String clientAssertion = config.getValue(ClientConfig.OAUTH_CLIENT_ASSERTION);
         final String clientAssertionLocation = config.getValue(ClientConfig.OAUTH_CLIENT_ASSERTION_LOCATION);
-        clientAssertionProvider = configureClientAssertionTokenProvider(clientAssertion, clientAssertionLocation);
+        clientAssertionProvider = clientUtils.configureClientAssertionTokenProvider(clientAssertion, clientAssertionLocation);
 
         clientAssertionType = config.getValue(ClientConfig.OAUTH_CLIENT_ASSERTION_TYPE, "urn:ietf:params:oauth:client-assertion-type:jwt-bearer");
 
@@ -142,10 +133,11 @@ public class JaasClientOauthLoginCallbackHandler implements AuthenticateCallback
         hostnameVerifier = ConfigUtil.createHostnameVerifier(config);
         connectTimeout = getConnectTimeout(config);
         readTimeout = getReadTimeout(config);
-        retries = getHttpRetries(config);
-        retryPauseMillis = getHttpRetryPauseMillis(config, retries);
+        retries = clientUtils.getHttpRetries(config);
+        retryPauseMillis = clientUtils.getHttpRetryPauseMillis(config, retries);
         includeAcceptHeader = config.getValueAsBoolean(Config.OAUTH_INCLUDE_ACCEPT_HEADER, true);
-        checkConfiguration();
+
+        clientUtils.checkConfiguration(refreshTokenProvider, username, tokenProvider, clientId, clientAssertionProvider, password, clientSecret);
 
         principalExtractor = new PrincipalExtractor(
                 config.getValue(Config.OAUTH_USERNAME_CLAIM),
@@ -163,7 +155,7 @@ public class JaasClientOauthLoginCallbackHandler implements AuthenticateCallback
             throw new ConfigException("Invalid value configured for '" + ClientConfig.OAUTH_MAX_TOKEN_EXPIRY_SECONDS + "': " + maxTokenExpirySeconds + " (should be at least 60)");
         }
 
-        String configId = configureMetrics(configs);
+        String configId = authenticatorMetrics.configureMetrics(configs, this.config, this.tokenEndpoint);
 
         if (LOG.isDebugEnabled()) {
             LOG.debug("Configured JaasClientOauthLoginCallbackHandler:"
@@ -189,137 +181,11 @@ public class JaasClientOauthLoginCallbackHandler implements AuthenticateCallback
                     + "\n    readTimeout: " + readTimeout
                     + "\n    retries: " + retries
                     + "\n    retryPauseMillis: " + retryPauseMillis
-                    + "\n    enableMetrics: " + enableMetrics
+                    + "\n    enableMetrics: " + authenticatorMetrics.isEnableMetrics()
                     + "\n    includeAcceptHeader: " + includeAcceptHeader);
         }
     }
 
-    private TokenProvider configureAccessTokenProvider(String token, String tokenLocation) {
-        String tokenIgnoredMessage = "Access token location is configured ('" + ClientConfig.OAUTH_ACCESS_TOKEN_LOCATION +
-                "'), access token will be ignored ('" + ClientConfig.OAUTH_ACCESS_TOKEN + "').";
-        String noSuchFileMessage = "Specified access token location is invalid ('" + ClientConfig.OAUTH_ACCESS_TOKEN_LOCATION + "')";
-
-        return configureAnyTokenProvider(token, tokenLocation, tokenIgnoredMessage, noSuchFileMessage);
-    }
-
-    private TokenProvider configureRefreshTokenProvider(String token, String tokenLocation) {
-        String tokenIgnoredMessage = "Refresh token location is configured ('" + ClientConfig.OAUTH_REFRESH_TOKEN_LOCATION +
-                "'), refresh token will be ignored ('" + ClientConfig.OAUTH_REFRESH_TOKEN + "').";
-        String noSuchFileMessage = "Specified refresh token location is invalid ('" + ClientConfig.OAUTH_REFRESH_TOKEN_LOCATION + "')";
-
-        return configureAnyTokenProvider(token, tokenLocation, tokenIgnoredMessage, noSuchFileMessage);
-    }
-
-    private TokenProvider configureClientAssertionTokenProvider(String token, String tokenLocation) {
-        String tokenIgnoredMessage = "Client assertion location is configured ('" + ClientConfig.OAUTH_CLIENT_ASSERTION_LOCATION +
-                "'), client assertion will be ignored ('" + ClientConfig.OAUTH_CLIENT_ASSERTION + "').";
-        String noSuchFileMessage = "Specified client assertion location is invalid ('" + ClientConfig.OAUTH_CLIENT_ASSERTION_LOCATION + "')";
-
-        return configureAnyTokenProvider(token, tokenLocation, tokenIgnoredMessage, noSuchFileMessage);
-    }
-
-    private TokenProvider configureAnyTokenProvider(String token, String tokenLocation, String tokenIgnoredMessage, String noSuchFileMessage) {
-        if (tokenLocation != null) {
-            try {
-                if (token != null) {
-                    LOG.warn(tokenIgnoredMessage);
-                }
-                return new FileBasedTokenProvider(tokenLocation);
-
-            } catch (IllegalArgumentException e) {
-                throw new ConfigException(noSuchFileMessage + ": " + e.getMessage());
-            }
-        }
-        if (token != null) {
-            return new StaticTokenProvider(token);
-        }
-        return null;
-    }
-
-    private int getHttpRetries(ClientConfig config) {
-        int retries = config.getValueAsInt(Config.OAUTH_HTTP_RETRIES, 0);
-        if (retries < 0) {
-            throw new ConfigException("The configured value of 'oauth.http.retries' has to be greater or equal to zero");
-        }
-        return retries;
-    }
-
-    private long getHttpRetryPauseMillis(ClientConfig config, int retries) {
-        long retryPauseMillis = config.getValueAsLong(Config.OAUTH_HTTP_RETRY_PAUSE_MILLIS, 0);
-        if (retries > 0) {
-            if (retryPauseMillis < 0) {
-                retryPauseMillis = 0;
-                LOG.warn("The configured value of '{}' is less than zero and will be ignored", Config.OAUTH_HTTP_RETRY_PAUSE_MILLIS);
-            }
-            if (retryPauseMillis <= 0) {
-                LOG.warn("No pause between http retries configured. Consider setting '{}' to greater than zero to avoid flooding the authorization server with requests.", Config.OAUTH_HTTP_RETRY_PAUSE_MILLIS);
-            }
-        }
-        return retryPauseMillis;
-    }
-
-    private void checkConfiguration() {
-        if (tokenProvider != null) {
-            if (refreshTokenProvider != null) {
-                LOG.warn("Access token is configured ('{}'), refresh token will be ignored ('{}', '{}').",
-                        ClientConfig.OAUTH_ACCESS_TOKEN, ClientConfig.OAUTH_REFRESH_TOKEN, ClientConfig.OAUTH_REFRESH_TOKEN_LOCATION);
-            }
-            if (username != null) {
-                LOG.warn("Access token is configured ('{}'), username will be ignored ('{}').",
-                        ClientConfig.OAUTH_ACCESS_TOKEN, ClientConfig.OAUTH_PASSWORD_GRANT_USERNAME);
-            }
-            if (clientId != null) {
-                LOG.warn("Access token is configured ('{}'), client id will be ignored ('{}').",
-                        ClientConfig.OAUTH_ACCESS_TOKEN, ClientConfig.OAUTH_CLIENT_ID);
-            }
-            if (clientAssertionProvider != null) {
-                LOG.warn("Access token is configured ('{}'), client assertion (location) will be ignored ('{}', '{}').",
-                        ClientConfig.OAUTH_ACCESS_TOKEN, ClientConfig.OAUTH_CLIENT_ASSERTION, ClientConfig.OAUTH_CLIENT_ASSERTION_LOCATION);
-            }
-        } else if (refreshTokenProvider != null) {
-            if (username != null) {
-                LOG.warn("Refresh token is configured ('{}'), username will be ignored ('{}').",
-                        ClientConfig.OAUTH_REFRESH_TOKEN, ClientConfig.OAUTH_PASSWORD_GRANT_USERNAME);
-            }
-        }
-
-        if (tokenProvider == null) {
-            if (clientId == null) {
-                throw new ConfigException("No client id specified ('" + ClientConfig.OAUTH_CLIENT_ID + "')");
-            }
-
-            if (username != null && password == null) {
-                throw new ConfigException("Username configured ('" + ClientConfig.OAUTH_PASSWORD_GRANT_USERNAME
-                        + "') but no password specified ('" + ClientConfig.OAUTH_PASSWORD_GRANT_PASSWORD + "')");
-            }
-
-            if (refreshTokenProvider == null && clientSecret == null && username == null && clientAssertionProvider == null) {
-                throw new ConfigException("No access token or location ('" + ClientConfig.OAUTH_ACCESS_TOKEN
-                        + "', '" + ClientConfig.OAUTH_ACCESS_TOKEN_LOCATION + "'), refresh token or location ('"
-                        + ClientConfig.OAUTH_REFRESH_TOKEN + "', '" + ClientConfig.OAUTH_REFRESH_TOKEN_LOCATION + "'),"
-                        + " client credentials ('" + ClientConfig.OAUTH_CLIENT_SECRET
-                        + "'), user credentials ('" + ClientConfig.OAUTH_PASSWORD_GRANT_USERNAME + "')"
-                        + " or clientAssertion or location ('" + ClientConfig.OAUTH_CLIENT_ASSERTION + "', '"
-                        + ClientConfig.OAUTH_CLIENT_ASSERTION_LOCATION + "') specified");
-            }
-        }
-    }
-
-    private String configureMetrics(Map<String, ?> configs) {
-        String configId = config.getValue(Config.OAUTH_CONFIG_ID, "client");
-        enableMetrics = config.getValueAsBoolean(Config.OAUTH_ENABLE_METRICS, false);
-
-        authSensorKeyProducer = new ClientAuthenticationSensorKeyProducer(configId, tokenEndpoint);
-        tokenSensorKeyProducer = tokenEndpoint != null ? new ClientHttpSensorKeyProducer(configId, tokenEndpoint) : null;
-
-        if (!Services.isAvailable()) {
-            Services.configure(configs);
-        }
-        if (enableMetrics) {
-            metrics = Services.getInstance().getMetrics();
-        }
-        return configId;
-    }
 
     @Override
     public void close() {
@@ -361,9 +227,9 @@ public class JaasClientOauthLoginCallbackHandler implements AuthenticateCallback
                 throw new IllegalStateException("Invalid oauth client configuration - no credentials");
             }
 
-            addSuccessTime(requestStartTime);
+            authenticatorMetrics.addSuccessTime(requestStartTime);
         } catch (Throwable t) {
-            addErrorTime(t, requestStartTime);
+            authenticatorMetrics.addErrorTime(t, requestStartTime);
             throw t;
         }
 
@@ -401,32 +267,6 @@ public class JaasClientOauthLoginCallbackHandler implements AuthenticateCallback
         });
     }
 
-    private void addSuccessTime(long startTimeMs) {
-        if (enableMetrics) {
-            metrics.addTime(authSensorKeyProducer.successKey(), System.currentTimeMillis() - startTimeMs);
-        }
-    }
 
-    private void addErrorTime(Throwable e, long startTimeMs) {
-        if (enableMetrics) {
-            metrics.addTime(authSensorKeyProducer.errorKey(e), System.currentTimeMillis() - startTimeMs);
-        }
-    }
 
-    class ClientMetricsHandler implements MetricsHandler {
-
-        @Override
-        public void addSuccessRequestTime(long millis) {
-            if (enableMetrics) {
-                metrics.addTime(tokenSensorKeyProducer.successKey(), millis);
-            }
-        }
-
-        @Override
-        public void addErrorRequestTime(Throwable e, long millis) {
-            if (enableMetrics) {
-                metrics.addTime(tokenSensorKeyProducer.errorKey(e), millis);
-            }
-        }
-    }
 }

--- a/oauth-client/src/main/java/io/strimzi/kafka/oauth/client/JaasClientOauthLoginCallbackHandler.java
+++ b/oauth-client/src/main/java/io/strimzi/kafka/oauth/client/JaasClientOauthLoginCallbackHandler.java
@@ -72,10 +72,14 @@ public class JaasClientOauthLoginCallbackHandler implements AuthenticateCallback
     private boolean includeAcceptHeader;
     private final ClientMetricsHandler authenticatorMetrics;
     private final ClientUtils clientUtils;
-    private ClientConfig config;
-    public JaasClientOauthLoginCallbackHandler(ClientUtils clientUtils, ClientMetricsHandler authenticatorMetrics) {
-        this.clientUtils = clientUtils;
-        this.authenticatorMetrics = authenticatorMetrics;
+
+    /**
+     * Constructs a new JaasClientOauthLoginCallbackHandler.
+     * Initializes the necessary utilities and metrics handler.
+     */
+    public JaasClientOauthLoginCallbackHandler() {
+        this.clientUtils = new ClientUtils();
+        this.authenticatorMetrics = new ClientMetricsHandler();
     }
 
     @Override
@@ -87,7 +91,7 @@ public class JaasClientOauthLoginCallbackHandler implements AuthenticateCallback
         AppConfigurationEntry entry = jaasConfigEntries.get(0);
         Properties p = new Properties();
         p.putAll(entry.getOptions());
-        config = new ClientConfig(p);
+        ClientConfig config = new ClientConfig(p);
 
         final String token = config.getValue(ClientConfig.OAUTH_ACCESS_TOKEN);
         final String tokenLocation = config.getValue(ClientConfig.OAUTH_ACCESS_TOKEN_LOCATION);
@@ -153,7 +157,7 @@ public class JaasClientOauthLoginCallbackHandler implements AuthenticateCallback
             throw new ConfigException("Invalid value configured for '" + ClientConfig.OAUTH_MAX_TOKEN_EXPIRY_SECONDS + "': " + maxTokenExpirySeconds + " (should be at least 60)");
         }
 
-        String configId = authenticatorMetrics.configureMetrics(configs, this.config, this.tokenEndpoint);
+        String configId = authenticatorMetrics.configureMetrics(configs, config, this.tokenEndpoint);
 
         if (LOG.isDebugEnabled()) {
             LOG.debug("Configured JaasClientOauthLoginCallbackHandler:"

--- a/oauth-client/src/main/java/io/strimzi/kafka/oauth/client/JaasClientOauthLoginCallbackHandler.java
+++ b/oauth-client/src/main/java/io/strimzi/kafka/oauth/client/JaasClientOauthLoginCallbackHandler.java
@@ -73,6 +73,8 @@ public class JaasClientOauthLoginCallbackHandler implements AuthenticateCallback
     private final ClientMetricsHandler authenticatorMetrics;
     private final ClientUtils clientUtils;
 
+    private ClientConfig config;
+
     /**
      * Constructs a new JaasClientOauthLoginCallbackHandler.
      * Initializes the necessary utilities and metrics handler.
@@ -88,10 +90,11 @@ public class JaasClientOauthLoginCallbackHandler implements AuthenticateCallback
             throw new IllegalArgumentException("Unexpected SASL mechanism: " + saslMechanism);
         }
 
-        AppConfigurationEntry entry = jaasConfigEntries.get(0);
-        Properties p = new Properties();
-        p.putAll(entry.getOptions());
-        ClientConfig config = new ClientConfig(p);
+        jaasConfigEntries.forEach(entry -> {
+            Properties p = new Properties();
+            p.putAll(entry.getOptions());
+            config = new ClientConfig(p);
+        });
 
         final String token = config.getValue(ClientConfig.OAUTH_ACCESS_TOKEN);
         final String tokenLocation = config.getValue(ClientConfig.OAUTH_ACCESS_TOKEN_LOCATION);

--- a/oauth-client/src/main/java/io/strimzi/kafka/oauth/client/metrics/ClientMetricsHandler.java
+++ b/oauth-client/src/main/java/io/strimzi/kafka/oauth/client/metrics/ClientMetricsHandler.java
@@ -1,0 +1,96 @@
+package io.strimzi.kafka.oauth.client.metrics;
+
+import io.strimzi.kafka.oauth.client.ClientConfig;
+import io.strimzi.kafka.oauth.common.Config;
+import io.strimzi.kafka.oauth.common.MetricsHandler;
+import io.strimzi.kafka.oauth.metrics.SensorKeyProducer;
+import io.strimzi.kafka.oauth.services.OAuthMetrics;
+import io.strimzi.kafka.oauth.services.Services;
+
+import java.net.URI;
+import java.util.Map;
+
+public class ClientMetricsHandler implements MetricsHandler {
+    private boolean enableMetrics;
+    private OAuthMetrics metrics;
+    private SensorKeyProducer authSensorKeyProducer;
+    private SensorKeyProducer tokenSensorKeyProducer;
+
+
+    /**
+     * Records the time taken for a successful request and adds it to the metrics, if enabled.
+     *
+     * @param millis The time taken for the successful request in milliseconds.
+     */
+    @Override
+    public void addSuccessRequestTime(long millis) {
+        if (enableMetrics) {
+            metrics.addTime(tokenSensorKeyProducer.successKey(), millis);
+        }
+    }
+
+    /**
+     * Records the time taken for a request resulting in an error and adds it to the metrics, if enabled.
+     *
+     * @param e      The Throwable representing the error.
+     * @param millis The time taken for the request resulting in an error in milliseconds.
+     */
+    @Override
+    public void addErrorRequestTime(Throwable e, long millis) {
+        if (enableMetrics) {
+            metrics.addTime(tokenSensorKeyProducer.errorKey(e), millis);
+        }
+    }
+
+    /**
+     * Configures metrics based on the provided configurations and initializes necessary components.
+     *
+     * @param configs        The configurations for the metrics.
+     * @param config         The client configuration.
+     * @param tokenEndpoint  The URI of the token endpoint.
+     * @return The identifier of the client configuration.
+     */
+    public String configureMetrics(Map<String, ?> configs, ClientConfig config, URI tokenEndpoint) {
+        String configId = config.getValue(Config.OAUTH_CONFIG_ID, "client");
+        enableMetrics = config.getValueAsBoolean(Config.OAUTH_ENABLE_METRICS, false);
+
+        authSensorKeyProducer = new ClientAuthenticationSensorKeyProducer(configId, tokenEndpoint);
+        tokenSensorKeyProducer = tokenEndpoint != null ? new ClientHttpSensorKeyProducer(configId, tokenEndpoint) : null;
+
+        if (!Services.isAvailable()) {
+            Services.configure(configs);
+        }
+        if (enableMetrics) {
+            metrics = Services.getInstance().getMetrics();
+        }
+        return configId;
+    }
+
+    /**
+     * Records the time taken for a successful authentication request and adds it to the metrics, if enabled.
+     *
+     * @param startTimeMs The start time of the authentication request in milliseconds.
+     */
+    public void addSuccessTime(long startTimeMs) {
+        if (enableMetrics) {
+            metrics.addTime(authSensorKeyProducer.successKey(), System.currentTimeMillis() - startTimeMs);
+        }
+    }
+
+    /**
+     * Records the time taken for an authentication request resulting in an error and adds it to the metrics, if enabled.
+     *
+     * @param e           The Throwable representing the error.
+     * @param startTimeMs The start time of the authentication request in milliseconds.
+     */
+    public void addErrorTime(Throwable e, long startTimeMs) {
+        if (enableMetrics) {
+            metrics.addTime(authSensorKeyProducer.errorKey(e), System.currentTimeMillis() - startTimeMs);
+        }
+    }
+
+
+    public boolean isEnableMetrics() {
+        return enableMetrics;
+    }
+}

--- a/oauth-client/src/main/java/io/strimzi/kafka/oauth/client/metrics/ClientMetricsHandler.java
+++ b/oauth-client/src/main/java/io/strimzi/kafka/oauth/client/metrics/ClientMetricsHandler.java
@@ -15,6 +15,10 @@ import io.strimzi.kafka.oauth.services.Services;
 import java.net.URI;
 import java.util.Map;
 
+/**
+ * Handler for client metrics.
+ * This class implements the MetricsHandler interface.
+ */
 public class ClientMetricsHandler implements MetricsHandler {
     private boolean enableMetrics;
     private OAuthMetrics metrics;
@@ -94,7 +98,11 @@ public class ClientMetricsHandler implements MetricsHandler {
         }
     }
 
-
+    /**
+     * Checks if metrics are enabled.
+     *
+     * @return {@code true} if metrics are enabled, {@code false} otherwise.
+     */
     public boolean isEnableMetrics() {
         return enableMetrics;
     }

--- a/oauth-client/src/main/java/io/strimzi/kafka/oauth/client/metrics/ClientMetricsHandler.java
+++ b/oauth-client/src/main/java/io/strimzi/kafka/oauth/client/metrics/ClientMetricsHandler.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2017-2019, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+
 package io.strimzi.kafka.oauth.client.metrics;
 
 import io.strimzi.kafka.oauth.client.ClientConfig;

--- a/oauth-client/src/main/java/io/strimzi/kafka/oauth/client/metrics/ClientUtils.java
+++ b/oauth-client/src/main/java/io/strimzi/kafka/oauth/client/metrics/ClientUtils.java
@@ -1,0 +1,179 @@
+package io.strimzi.kafka.oauth.client.metrics;
+
+import io.strimzi.kafka.oauth.client.ClientConfig;
+import io.strimzi.kafka.oauth.common.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ClientUtils {
+    private static final Logger LOG = LoggerFactory.getLogger(ClientUtils.class);
+
+    /**
+     * Configures an access token provider using the provided token and token location.
+     *
+     * @param token          The access token string.
+     * @param tokenLocation  The location of the access token.
+     * @return A TokenProvider instance configured with the provided token and location.
+     */
+    public TokenProvider configureAccessTokenProvider(String token, String tokenLocation) {
+        String tokenIgnoredMessage = "Access token location is configured ('" + ClientConfig.OAUTH_ACCESS_TOKEN_LOCATION +
+                "'), access token will be ignored ('" + ClientConfig.OAUTH_ACCESS_TOKEN + "').";
+        String noSuchFileMessage = "Specified access token location is invalid ('" + ClientConfig.OAUTH_ACCESS_TOKEN_LOCATION + "')";
+
+        return configureAnyTokenProvider(token, tokenLocation, tokenIgnoredMessage, noSuchFileMessage);
+    }
+
+    /**
+     * Configures a refresh token provider using the provided token and token location.
+     *
+     * @param token          The refresh token string.
+     * @param tokenLocation  The location of the refresh token.
+     * @return A TokenProvider instance configured with the provided token and location.
+     */
+    public TokenProvider configureRefreshTokenProvider(String token, String tokenLocation) {
+        String tokenIgnoredMessage = "Refresh token location is configured ('" + ClientConfig.OAUTH_REFRESH_TOKEN_LOCATION +
+                "'), refresh token will be ignored ('" + ClientConfig.OAUTH_REFRESH_TOKEN + "').";
+        String noSuchFileMessage = "Specified refresh token location is invalid ('" + ClientConfig.OAUTH_REFRESH_TOKEN_LOCATION + "')";
+
+        return configureAnyTokenProvider(token, tokenLocation, tokenIgnoredMessage, noSuchFileMessage);
+    }
+
+    /**
+     * Configures a client assertion token provider using the provided token and token location.
+     *
+     * @param token          The client assertion token string.
+     * @param tokenLocation  The location of the client assertion token.
+     * @return A TokenProvider instance configured with the provided token and location.
+     */
+    public TokenProvider configureClientAssertionTokenProvider(String token, String tokenLocation) {
+        String tokenIgnoredMessage = "Client assertion location is configured ('" + ClientConfig.OAUTH_CLIENT_ASSERTION_LOCATION +
+                "'), client assertion will be ignored ('" + ClientConfig.OAUTH_CLIENT_ASSERTION + "').";
+        String noSuchFileMessage = "Specified client assertion location is invalid ('" + ClientConfig.OAUTH_CLIENT_ASSERTION_LOCATION + "')";
+
+        return configureAnyTokenProvider(token, tokenLocation, tokenIgnoredMessage, noSuchFileMessage);
+    }
+
+    /**
+     * Configures any token provider based on the provided token, token location, and messages.
+     *
+     * @param token              The token string.
+     * @param tokenLocation      The location of the token.
+     * @param tokenIgnoredMessage  The message indicating the token is ignored.
+     * @param noSuchFileMessage  The message indicating an invalid file location.
+     * @return A TokenProvider instance configured accordingly.
+     * @throws ConfigException If the specified token location is invalid.
+     */
+    public TokenProvider configureAnyTokenProvider(String token, String tokenLocation, String tokenIgnoredMessage, String noSuchFileMessage) {
+        if (token != null) {
+            return new StaticTokenProvider(token);
+        } else {
+            LOG.warn(tokenIgnoredMessage);
+            FileBasedTokenProvider returnValue = null;
+            if (tokenLocation != null) {
+                try {
+                    returnValue = new FileBasedTokenProvider(tokenLocation);
+                } catch (IllegalArgumentException e) {
+                    throw new ConfigException(noSuchFileMessage + ": " + e.getMessage());
+                }
+            }
+            return returnValue;
+        }
+    }
+
+    /**
+     * Gets the number of HTTP retries configured in the client.
+     *
+     * @param config  The client configuration.
+     * @return The number of HTTP retries.
+     * @throws ConfigException If the configured number of retries is less than zero.
+     */
+    public int getHttpRetries(ClientConfig config) {
+        int retries = config.getValueAsInt(Config.OAUTH_HTTP_RETRIES, 0);
+        if (retries < 0) {
+            throw new ConfigException("The configured value of 'oauth.http.retries' has to be greater or equal to zero");
+        }
+        return retries;
+    }
+
+    /**
+     * Gets the pause duration between HTTP retries configured in the client.
+     *
+     * @param config   The client configuration.
+     * @param retries  The number of HTTP retries configured.
+     * @return The pause duration between HTTP retries in milliseconds.
+     */
+    public long getHttpRetryPauseMillis(ClientConfig config, int retries) {
+        long retryPauseMillis = config.getValueAsLong(Config.OAUTH_HTTP_RETRY_PAUSE_MILLIS, 0);
+        if (retries > 0) {
+            if (retryPauseMillis < 0) {
+                retryPauseMillis = 0;
+                LOG.warn("The configured value of '{}' is less than zero and will be ignored", Config.OAUTH_HTTP_RETRY_PAUSE_MILLIS);
+            }
+            if (retryPauseMillis <= 0) {
+                LOG.warn("No pause between http retries configured. Consider setting '{}' to greater than zero to avoid flooding the authorization server with requests.", Config.OAUTH_HTTP_RETRY_PAUSE_MILLIS);
+            }
+        }
+        return retryPauseMillis;
+    }
+
+    /**
+     * Checks the configuration for consistency and potential issues.
+     *
+     * @param refreshTokenProvider    The refresh token provider.
+     * @param username                The username for password grant.
+     * @param tokenProvider           The access token provider.
+     * @param clientId                The client ID.
+     * @param clientAssertionProvider The client assertion token provider.
+     * @param password                The password for password grant.
+     * @param clientSecret            The client secret.
+     * @throws ConfigException If the configuration is invalid or inconsistent.
+     */
+    public void checkConfiguration(TokenProvider refreshTokenProvider, String username, TokenProvider tokenProvider, String clientId,
+                                    TokenProvider clientAssertionProvider, String password, String clientSecret) {
+        if (refreshTokenProvider != null) {
+            if (username != null) {
+                LOG.warn("Refresh token is configured ('{}'), username will be ignored ('{}').",
+                        ClientConfig.OAUTH_REFRESH_TOKEN, ClientConfig.OAUTH_PASSWORD_GRANT_USERNAME);
+            }
+        }
+
+        if (tokenProvider != null) {
+            if (refreshTokenProvider != null) {
+                LOG.warn("Access token is configured ('{}'), refresh token will be ignored ('{}', '{}').",
+                        ClientConfig.OAUTH_ACCESS_TOKEN, ClientConfig.OAUTH_REFRESH_TOKEN, ClientConfig.OAUTH_REFRESH_TOKEN_LOCATION);
+            }
+            if (username != null) {
+                LOG.warn("Access token is configured ('{}'), username will be ignored ('{}').",
+                        ClientConfig.OAUTH_ACCESS_TOKEN, ClientConfig.OAUTH_PASSWORD_GRANT_USERNAME);
+            }
+            if (clientId != null) {
+                LOG.warn("Access token is configured ('{}'), client id will be ignored ('{}').",
+                        ClientConfig.OAUTH_ACCESS_TOKEN, ClientConfig.OAUTH_CLIENT_ID);
+            }
+            if (clientAssertionProvider != null) {
+                LOG.warn("Access token is configured ('{}'), client assertion (location) will be ignored ('{}', '{}').",
+                        ClientConfig.OAUTH_ACCESS_TOKEN, ClientConfig.OAUTH_CLIENT_ASSERTION, ClientConfig.OAUTH_CLIENT_ASSERTION_LOCATION);
+            }
+        }  else {
+            if (clientId == null) {
+                throw new ConfigException("No client id specified ('" + ClientConfig.OAUTH_CLIENT_ID + "')");
+            }
+
+            if (username != null && password == null) {
+                throw new ConfigException("Username configured ('" + ClientConfig.OAUTH_PASSWORD_GRANT_USERNAME
+                        + "') but no password specified ('" + ClientConfig.OAUTH_PASSWORD_GRANT_PASSWORD + "')");
+            }
+
+            if (refreshTokenProvider == null && clientSecret == null && username == null && clientAssertionProvider == null) {
+                throw new ConfigException("No access token or location ('" + ClientConfig.OAUTH_ACCESS_TOKEN
+                        + "', '" + ClientConfig.OAUTH_ACCESS_TOKEN_LOCATION + "'), refresh token or location ('"
+                        + ClientConfig.OAUTH_REFRESH_TOKEN + "', '" + ClientConfig.OAUTH_REFRESH_TOKEN_LOCATION + "'),"
+                        + " client credentials ('" + ClientConfig.OAUTH_CLIENT_SECRET
+                        + "'), user credentials ('" + ClientConfig.OAUTH_PASSWORD_GRANT_USERNAME + "')"
+                        + " or clientAssertion or location ('" + ClientConfig.OAUTH_CLIENT_ASSERTION + "', '"
+                        + ClientConfig.OAUTH_CLIENT_ASSERTION_LOCATION + "') specified");
+            }
+
+        }
+    }
+}

--- a/oauth-client/src/main/java/io/strimzi/kafka/oauth/client/metrics/ClientUtils.java
+++ b/oauth-client/src/main/java/io/strimzi/kafka/oauth/client/metrics/ClientUtils.java
@@ -1,7 +1,16 @@
+/*
+ * Copyright 2017-2019, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+
 package io.strimzi.kafka.oauth.client.metrics;
 
 import io.strimzi.kafka.oauth.client.ClientConfig;
-import io.strimzi.kafka.oauth.common.*;
+import io.strimzi.kafka.oauth.common.TokenProvider;
+import io.strimzi.kafka.oauth.common.StaticTokenProvider;
+import io.strimzi.kafka.oauth.common.FileBasedTokenProvider;
+import io.strimzi.kafka.oauth.common.ConfigException;
+import io.strimzi.kafka.oauth.common.Config;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/oauth-client/src/main/java/io/strimzi/kafka/oauth/client/metrics/ClientUtils.java
+++ b/oauth-client/src/main/java/io/strimzi/kafka/oauth/client/metrics/ClientUtils.java
@@ -14,6 +14,9 @@ import io.strimzi.kafka.oauth.common.Config;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Utility class for configuring token providers and handling client metrics.
+ */
 public class ClientUtils {
     private static final Logger LOG = LoggerFactory.getLogger(ClientUtils.class);
 


### PR DESCRIPTION
Refactored the code for better understandability, maintainability and testability by separating concerns via delegating some functions to other classes and injecting them in the main handler class.

Simplified the code logic whereas possible without hurting the general structure much.

Note: Would be great if we could utilise Java 17 to start taking advantage of new "switch" for a more data oriented approach instead of if-else.