### PR TITLE
Fix pushing of artifacts to Nexus

### DIFF
--- a/.azure/scripts/push-to-nexus.sh
+++ b/.azure/scripts/push-to-nexus.sh
@@ -1,16 +1,23 @@
 #!/usr/bin/env bash
 
+set -e
+
 echo "Build reason: ${BUILD_REASON}"
 echo "Source branch: ${BRANCH}"
 
-GPG_TTY=$(tty)
-export GPG_TTY
+function cleanup() {
+  rm -rf signing.gpg
+  gpg --delete-keys
+  gpg --delete-secret-keys
+}
 
-echo "$GPG_SIGNING_KEY" | base64 -d > signing.gpg
+# Run the cleanup on failure / exit
+trap cleanup EXIT
+
+export GPG_TTY=$(tty)
+echo $GPG_SIGNING_KEY | base64 -d > signing.gpg
 gpg --batch --import signing.gpg
 
-GPG_EXECUTABLE=gpg mvn $MVN_ARGS -DskipTests -s ./.azure/scripts/settings.xml -pl '!examples/producer','!examples/consumer' -P ossrh verify deploy
+GPG_EXECUTABLE=gpg mvn $MVN_ARGS -DskipTests -s ./.azure/scripts/settings.xml -P ossrh verify deploy
 
-rm -rf signing.gpg
-gpg --delete-keys
-gpg --delete-secret-keys
+cleanup

--- a/.azure/scripts/push-to-nexus.sh
+++ b/.azure/scripts/push-to-nexus.sh
@@ -18,6 +18,6 @@ export GPG_TTY=$(tty)
 echo $GPG_SIGNING_KEY | base64 -d > signing.gpg
 gpg --batch --import signing.gpg
 
-GPG_EXECUTABLE=gpg mvn $MVN_ARGS -DskipTests -s ./.azure/scripts/settings.xml -P ossrh verify deploy
+GPG_EXECUTABLE=gpg mvn $MVN_ARGS -DskipTests -s ./.azure/scripts/settings.xml -pl '!examples/producer','!examples/consumer' -P ossrh verify deploy
 
 cleanup

--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
         <maven.checkstyle.version>3.2.1</maven.checkstyle.version>
         <maven.resources.version>3.3.0</maven.resources.version>
         <spotbugs.version>4.7.3</spotbugs.version>
-        <sonatype.nexus.staging>1.6.3</sonatype.nexus.staging>
+        <sonatype.nexus.staging>1.7.0</sonatype.nexus.staging>
         <kafka.version>3.7.0</kafka.version>
         <jackson.version>2.15.3</jackson.version>
         <jackson.databind.version>2.15.3</jackson.databind.version>


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Some changes at Sonatype broker the way we push the JAR artifacts to Sonatype Nexus. This PR fixes it by updating the Sonatype plugin. It also updates the script we use for it to make it fail in case of problems.