### PR TITLE
Remove Java 8 support + move the testsuite from Travis to Azure

### DIFF
--- a/.azure/templates/jobs/build_java.yaml
+++ b/.azure/templates/jobs/build_java.yaml
@@ -21,6 +21,7 @@ jobs:
     variables:
       MVN_CACHE_FOLDER: $(HOME)/.m2/repository
       MVN_ARGS: '-e -V -B'
+      MVN_EXTRA_ARGS: '--no-transfer-progress'
     # Pipeline steps
     steps:
       # Get cached Maven repository
@@ -35,11 +36,15 @@ jobs:
           BRANCH: $(Build.SourceBranch)
           TESTCONTAINERS_RYUK_DISABLED: "TRUE"
           TESTCONTAINERS_CHECKS_DISABLE: "TRUE"
-          MVN_ARGS: "-e -V -B"
       - bash: "mvn ${MVN_ARGS} spotbugs:check"
         displayName: "Spotbugs"
-        env:
-          MVN_ARGS: "-e -V -B"
+      - bash: "mvn ${MVN_ARGS} clean install -f examples/docker ${MVN_EXTRA_ARGS}"
+        displayName: "Test Examples"
+      - bash: |
+          cd examples/docker
+          ./spring/test-spring.sh
+        displayName: "Test Spring Example"
+        condition: and(succeeded(), eq(variables['jdk_version'], '17'))
       - bash: |
           echo "127.0.0.1 keycloak" | sudo tee -a /etc/hosts
           echo "127.0.0.1 hydra" | sudo tee -a /etc/hosts
@@ -54,10 +59,11 @@ jobs:
           sudo curl -L "https://github.com/docker/compose/releases/latest/download/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
           sudo chmod +x /usr/local/bin/docker-compose
         displayName: 'Install Docker Compose'
-      - bash: "mvn install -f testsuite"
-        displayName: "Run Testsuite"
-        env:
-          MVN_ARGS: "-e -V -B"
+      - bash: "mvn ${MVN_ARGS} test-compile spotbugs:check -f testsuite"
+        displayName: "Testsuite Compile & Spotbugs"
+      - bash: "mvn ${MVN_ARGS} install -f testsuite ${MVN_EXTRA_ARGS}"
+        displayName: "Testsuite Run"
+        condition: succeeded()
       # We have to TAR the target directory to maintain the permissions of
       # the files which would otherwise change when downloading the artifact
       - bash: tar -cvpf target.tar ./target

--- a/.azure/templates/jobs/build_java.yaml
+++ b/.azure/templates/jobs/build_java.yaml
@@ -50,6 +50,10 @@ jobs:
           echo "Modified /etc/hosts:"
           cat /etc/hosts
         displayName: "Modify /etc/hosts"
+      - script: |
+          sudo curl -L "https://github.com/docker/compose/releases/latest/download/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+          sudo chmod +x /usr/local/bin/docker-compose
+          displayName: 'Install Docker Compose'
       - bash: "mvn install -f testsuite"
         displayName: "Run Testsuite"
         env:

--- a/.azure/templates/jobs/build_java.yaml
+++ b/.azure/templates/jobs/build_java.yaml
@@ -4,14 +4,10 @@ jobs:
     # Strategy for the job
     strategy:
       matrix:
-        'java-8':
-          image: 'Ubuntu-22.04'
-          jdk_version: '8'
-          main_build: 'true'
         'java-11':
           image: 'Ubuntu-22.04'
           jdk_version: '11'
-          main_build: 'false'
+          main_build: 'true'
         'java-17':
           image: 'Ubuntu-22.04'
           jdk_version: '17'
@@ -42,6 +38,20 @@ jobs:
           MVN_ARGS: "-e -V -B"
       - bash: "mvn ${MVN_ARGS} spotbugs:check"
         displayName: "Spotbugs"
+        env:
+          MVN_ARGS: "-e -V -B"
+      - bash: |
+          echo "127.0.0.1 keycloak" | sudo tee -a /etc/hosts
+          echo "127.0.0.1 hydra" | sudo tee -a /etc/hosts
+          echo "127.0.0.1 hydra-jwt" | sudo tee -a /etc/hosts
+          echo "127.0.0.1 kafka" | sudo tee -a /etc/hosts
+          echo "127.0.0.1 mockoauth" | sudo tee -a /etc/hosts
+          echo "127.0.0.1 kerberos" | sudo tee -a /etc/hosts
+          echo "Modified /etc/hosts:"
+          cat /etc/hosts
+        displayName: "Modify /etc/hosts"
+      - bash: "mvn install -f testsuite"
+        displayName: "Run Testsuite"
         env:
           MVN_ARGS: "-e -V -B"
       # We have to TAR the target directory to maintain the permissions of

--- a/.azure/templates/jobs/build_java.yaml
+++ b/.azure/templates/jobs/build_java.yaml
@@ -53,7 +53,7 @@ jobs:
       - script: |
           sudo curl -L "https://github.com/docker/compose/releases/latest/download/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
           sudo chmod +x /usr/local/bin/docker-compose
-          displayName: 'Install Docker Compose'
+        displayName: 'Install Docker Compose'
       - bash: "mvn install -f testsuite"
         displayName: "Run Testsuite"
         env:

--- a/.azure/templates/jobs/deploy_java.yaml
+++ b/.azure/templates/jobs/deploy_java.yaml
@@ -4,9 +4,9 @@ jobs:
     # Strategy for the job => we deploy the artifacts only from Java 11
     strategy:
       matrix:
-        'java-8':
+        'java-11':
           image: 'Ubuntu-22.04'
-          jdk_version: '8'
+          jdk_version: '11'
           main_build: 'true'
     # Set timeout for jobs
     timeoutInMinutes: 60

--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -11,6 +11,18 @@ exitIfError() {
   [ "$EXIT" != "0" ] && exit $EXIT
 }
 
+# # # # # # # # # # # # # # # # # # # # # # #
+#
+#   These tests are now disabled by default.
+#
+#
+
+if [ "$DISABLED" != "false" ]; then
+  echo "Tests are disabled by default. In order to run them locally set DISABLED=false"
+  echo "Usage: DISABLED=false ./build.sh"
+  exit 0
+fi
+
 arch=$(uname -m)
 echo "Architecture: $arch"
 

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 set -e
 
+# # # # # # # # # # # # # # # # # #
+#
+#  Functions
+#
+# # # # # # # # # # # # # # # # # #
+
 clearDockerEnv() {
   docker rm -f kafka zookeeper keycloak keycloak-import hydra hydra-import hydra-jwt hydra-jwt-import kerberos || true
   DOCKER_TEST_NETWORKS=$(docker network ls | grep test | awk '{print $1}')
@@ -10,6 +16,17 @@ clearDockerEnv() {
 exitIfError() {
   [ "$EXIT" != "0" ] && exit $EXIT
 }
+
+
+# # # # # # # # # # # # # # # # # #
+#
+#  Main
+#
+# # # # # # # # # # # # # # # # # #
+
+export PULL_REQUEST=${PULL_REQUEST:-true}
+export BRANCH=${BRANCH:-main}
+export TAG=${TAG:-latest}
 
 arch=$(uname -m)
 echo "Architecture: $arch"
@@ -22,10 +39,6 @@ if [ "$SKIP_DISABLED" == "" ]; then
   SKIP_DISABLED="true"
 fi
 echo "SKIP_DISABLED: $SKIP_DISABLED"
-
-export PULL_REQUEST=${PULL_REQUEST:-true}
-export BRANCH=${BRANCH:-main}
-export TAG=${TAG:-latest}
 
 if [ "$arch" != 'ppc64le' ] && [ "$arch" != 's390x' ]; then
   export MAVEN_EXTRA_ARGS=--no-transfer-progress

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -11,18 +11,6 @@ exitIfError() {
   [ "$EXIT" != "0" ] && exit $EXIT
 }
 
-# # # # # # # # # # # # # # # # # # # # # # #
-#
-#   These tests are now disabled by default.
-#
-#
-
-if [ "$DISABLED" != "false" ]; then
-  echo "Tests are disabled by default. In order to run them locally set DISABLED=false"
-  echo "Usage: DISABLED=false ./build.sh"
-  exit 0
-fi
-
 arch=$(uname -m)
 echo "Architecture: $arch"
 


### PR DESCRIPTION
This PR implements https://github.com/strimzi/proposals/pull/151 for OAuth repo.

It also removes Java 8 support. The released Maven artifacts will now be built with Java 11.