### PR TITLE
A test and a fix for #260 - Int overrun parsing EXP and IAT from JWT token

### DIFF
--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/TokenInfo.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/TokenInfo.java
@@ -85,8 +85,8 @@ public class TokenInfo {
                 payload.has(SCOPE) ? payload.get(SCOPE).asText() : null,
                 principal,
                 groups,
-                payload.has(IAT) ? payload.get(IAT).asInt(0) * 1000L : 0L,
-                payload.get(EXP).asInt(0) * 1000L);
+                payload.has(IAT) ? payload.get(IAT).asLong(0) * 1000L : 0L,
+                payload.get(EXP).asLong(0) * 1000L);
 
         if (!(payload instanceof ObjectNode)) {
             throw new IllegalArgumentException("Unexpected JSON Node type (not ObjectNode): " + payload.getClass());

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/TokenIntrospection.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/TokenIntrospection.java
@@ -78,7 +78,7 @@ public class TokenIntrospection {
             if (expires == null) {
                 log.debug("Access token has no expiry set.");
             } else {
-                log.debug("Access token expires at (UTC): " + (expires.isNumber() ? (LocalDateTime.ofEpochSecond(expires.asInt(), 0, ZoneOffset.UTC).format(DateTimeFormatter.ISO_DATE_TIME)) : ("invalid value: [" + expires.asText() + "]")));
+                log.debug("Access token expires at (UTC): " + (expires.isNumber() ? (LocalDateTime.ofEpochSecond(expires.asLong(), 0, ZoneOffset.UTC).format(DateTimeFormatter.ISO_DATE_TIME)) : ("invalid value: [" + expires.asText() + "]")));
             }
         } catch (Exception e) {
             log.debug("[IGNORED] Failed to parse JWT token's payload", e);

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/validator/JWTSignatureValidator.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/validator/JWTSignatureValidator.java
@@ -476,7 +476,7 @@ public class JWTSignatureValidator implements TokenValidator {
         if (exp == null) {
             throw new TokenValidationException("Token validation failed: Expiry not set");
         }
-        long expiresMillis = exp.asInt(0) * 1000L;
+        long expiresMillis = exp.asLong(0) * 1000L;
         if (System.currentTimeMillis() > expiresMillis) {
             throw new TokenExpiredException("Token expired at: " + expiresMillis + " (" +
                     TimeUtil.formatIsoDateTimeUTC(expiresMillis) + " UTC)");

--- a/testsuite/mockoauth-tests/src/test/java/io/strimzi/testsuite/oauth/MockOAuthTests.java
+++ b/testsuite/mockoauth-tests/src/test/java/io/strimzi/testsuite/oauth/MockOAuthTests.java
@@ -13,6 +13,7 @@ import io.strimzi.testsuite.oauth.mockoauth.ConnectTimeoutTests;
 import io.strimzi.testsuite.oauth.mockoauth.JWKSKeyUseTest;
 import io.strimzi.testsuite.oauth.mockoauth.JaasClientConfigTest;
 import io.strimzi.testsuite.oauth.mockoauth.JaasServerConfigTest;
+import io.strimzi.testsuite.oauth.mockoauth.JwtExtractTest;
 import io.strimzi.testsuite.oauth.mockoauth.KeycloakAuthorizerTest;
 import io.strimzi.testsuite.oauth.mockoauth.PasswordAuthAndPrincipalExtractionTest;
 import io.strimzi.testsuite.oauth.mockoauth.RetriesTests;
@@ -86,6 +87,9 @@ public class MockOAuthTests {
 
             logStart("JWKSKeyUseTest :: JWKS KeyUse Test");
             new JWKSKeyUseTest().doTest();
+
+            logStart("JwtExtractTest :: JWT 'exp' attribute overflow Test");
+            new JwtExtractTest().doTest();
 
             logStart("JaasClientConfigTest :: Client Configuration Tests");
             new JaasClientConfigTest().doTest();

--- a/testsuite/mockoauth-tests/src/test/java/io/strimzi/testsuite/oauth/mockoauth/JwtExtractTest.java
+++ b/testsuite/mockoauth-tests/src/test/java/io/strimzi/testsuite/oauth/mockoauth/JwtExtractTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2017-2021, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.testsuite.oauth.mockoauth;
+
+import java.util.HashMap;
+import io.strimzi.kafka.oauth.common.PrincipalExtractor;
+import io.strimzi.kafka.oauth.common.SSLUtil;
+import io.strimzi.kafka.oauth.common.TokenIntrospection;
+import io.strimzi.kafka.oauth.services.Services;
+import io.strimzi.kafka.oauth.validator.JWTSignatureValidator;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.net.ssl.SSLSocketFactory;
+import java.util.Collections;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static io.strimzi.kafka.oauth.common.OAuthAuthenticator.urlencode;
+import static io.strimzi.testsuite.oauth.mockoauth.Common.changeAuthServerMode;
+import static io.strimzi.testsuite.oauth.mockoauth.Common.createOAuthClient;
+import static io.strimzi.testsuite.oauth.mockoauth.Common.getProjectRoot;
+import static io.strimzi.testsuite.oauth.mockoauth.Common.loginWithClientSecretAndExtraAttrs;
+
+public class JwtExtractTest {
+
+    private static final Logger log = LoggerFactory.getLogger(JWKSKeyUseTest.class);
+
+    public void doTest() throws Exception {
+        testExpiresAtOverflow();
+    }
+
+    public void testExpiresAtOverflow() throws Exception {
+        Services.configure(Collections.emptyMap());
+
+        changeAuthServerMode("jwks", "MODE_JWKS_RSA_WITH_SIG_USE");
+        changeAuthServerMode("token", "MODE_200");
+
+        String testClient = "testclient";
+        String testSecret = "testsecret";
+        createOAuthClient(testClient, testSecret);
+
+        String projectRoot = getProjectRoot();
+        String trustStorePath = projectRoot + "/../docker/certificates/ca-truststore.p12";
+        String trustStorePass = "changeit";
+
+        SSLSocketFactory sslFactory = SSLUtil.createSSLFactory(
+                trustStorePath, null, trustStorePass, null, null);
+
+        JWTSignatureValidator validator = createTokenValidator("enforceKeyUse", sslFactory, false);
+
+        Map<String, String> extraAttrs = new HashMap<>();
+        extraAttrs.put("EXP", Long.toString(Integer.MAX_VALUE + 1L));
+        String extraAttrsString = extraAttrs.entrySet()
+                .stream()
+                .map(entry -> entry.getKey() + "=" + urlencode(entry.getValue()))
+                .collect(Collectors.joining("&"));
+
+        // Now get a new token
+        String accessToken = loginWithClientSecretAndExtraAttrs(
+                "https://mockoauth:8090/token",
+                testClient,
+                testSecret,
+                trustStorePath,
+                trustStorePass,
+                extraAttrsString);
+
+        TokenIntrospection.debugLogJWT(log, accessToken);
+
+        // and try to validate it
+        // The overflow bug triggers a TokenExpiredException
+        validator.validate(accessToken);
+    }
+
+    private static JWTSignatureValidator createTokenValidator(String validatorId, SSLSocketFactory sslFactory, boolean ignoreKeyUse) {
+        return new JWTSignatureValidator(validatorId,
+                null,
+                null,
+                null,
+                "https://mockoauth:8090/jwks",
+                sslFactory,
+                null,
+                new PrincipalExtractor(),
+                null,
+                null,
+                "https://mockoauth:8090",
+                30,
+                0,
+                300,
+                ignoreKeyUse,
+                false,
+                null,
+                null,
+                60,
+                60,
+                true,
+                true,
+                true);
+    }
+}


### PR DESCRIPTION
This PR fixes https://github.com/strimzi/strimzi-kafka-oauth/issues/260