### PR TITLE
Bump json-smart version to 2.5.2

### DIFF
--- a/.azure/templates/jobs/deploy_java.yaml
+++ b/.azure/templates/jobs/deploy_java.yaml
@@ -4,7 +4,7 @@ jobs:
     # Strategy for the job => we deploy the artifacts only from Java 11
     strategy:
       matrix:
-        'java-11':
+        'java-17':
           image: 'Ubuntu-22.04'
           jdk_version: '17'
           main_build: 'true'

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,14 @@
 Release Notes
 =============
 
+0.16.1
+------
+
+### Override json-smart version to 2.5.2 to address CVE-2024-57699 warnings
+
+`net.minidev:json-smart` is a transitive dependency pulled in by `com.jayway.jsonpath:json-path`. There is a PR open at JsonPath project https://github.com/json-path/JsonPath/pull/1030
+Once the new version of JsonPath is released, with the fixed dependency, we can remove the override.
+
 0.16.0
 ------
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -19,6 +19,12 @@ All the components are built with Java 11 bytecode compatibility except `kafka-o
 Since Zookeeper mode is no longer supported, the ACL authorizer delegation only works if the Kafka node runs in KRaft mode.
 If `KeycloakAuthorizer` is deployed to Kafka running in Zookeeper mode, and `strimzi.authorization.delegate.to.kafka.acl` is set to `true`, the broker will fail to start.
 
+Kafka 4.x users should upgrade to this OAuth version (0.16.0). Kafka 3.x users can also use this OAuth version in both Kraft or Zookeeper mode, but if they use `KeycloakAuthorizer` with ACL delegation, that will not work in Zookeeper mode.
+
+### Added a test and a fix for 'Overflow parsing timestamps in oauth JWTs as 32 bit int'
+
+See [#260](https://github.com/strimzi/strimzi-kafka-oauth/issues/260)
+
 0.15.0
 ------
 

--- a/pom.xml
+++ b/pom.xml
@@ -114,6 +114,7 @@
         <jackson.version>2.15.3</jackson.version>
         <jackson.databind.version>2.15.3</jackson.databind.version>
         <jsonpath.version>2.9.0</jsonpath.version>
+        <jsonsmart.version>2.5.2</jsonsmart.version>
         <junit.version>4.13.2</junit.version>
         <slf4j.version>1.7.36</slf4j.version>
         <mockito.version>3.12.4</mockito.version>
@@ -207,6 +208,12 @@
                 <groupId>com.jayway.jsonpath</groupId>
                 <artifactId>json-path</artifactId>
                 <version>${jsonpath.version}</version>
+            </dependency>
+            <!-- Transitive override to address CVE-2024-57699. Remove in the future. -->
+            <dependency>
+                <groupId>net.minidev</groupId>
+                <artifactId>json-smart</artifactId>
+                <version>${jsonsmart.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.nimbusds</groupId>


### PR DESCRIPTION
`json-smart` is being pulled in transitively by JsonPath project and flagged by CVE scanners for CVE-2024-57699 warning. Even though we don't think we are affected due to how we use JsonPath, the fact that scanners flag the dependency makes users nervous.

This is a temporary override, to be removed once a new version of JsonPath is released.
See: https://github.com/json-path/JsonPath/pull/1030 