### PR TITLE
Properly fix version of json-smart transitive dependency for third parties

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,13 @@
 Release Notes
 =============
 
+0.16.2
+------
+
+### Properly override json-smart version to 2.5.2 to address CVE-2024-57699 warnings
+
+The version override in 0.16.1 was inadequate. It didn't work for third party components using the OAuth components. They would still transitively bring in `net.minidev:json-smart` version 2.5.0.
+
 0.16.1
 ------
 

--- a/oauth-common/pom.xml
+++ b/oauth-common/pom.xml
@@ -39,7 +39,6 @@
         <dependency>
             <groupId>net.minidev</groupId>
             <artifactId>json-smart</artifactId>
-            <version>${jsonsmart.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>

--- a/oauth-common/pom.xml
+++ b/oauth-common/pom.xml
@@ -35,6 +35,12 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <!-- Transitive override to address CVE-2024-57699. Remove in the future. -->
+        <dependency>
+            <groupId>net.minidev</groupId>
+            <artifactId>json-smart</artifactId>
+            <version>${jsonsmart.version}</version>
+        </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -209,6 +209,12 @@
                 <artifactId>json-path</artifactId>
                 <version>${jsonpath.version}</version>
             </dependency>
+            <!-- Transitive override to address CVE-2024-57699. Remove in the future. -->
+            <dependency>
+                <groupId>net.minidev</groupId>
+                <artifactId>json-smart</artifactId>
+                <version>${jsonsmart.version}</version>
+            </dependency>
             <dependency>
                 <groupId>com.nimbusds</groupId>
                 <artifactId>nimbus-jose-jwt</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -209,12 +209,6 @@
                 <artifactId>json-path</artifactId>
                 <version>${jsonpath.version}</version>
             </dependency>
-            <!-- Transitive override to address CVE-2024-57699. Remove in the future. -->
-            <dependency>
-                <groupId>net.minidev</groupId>
-                <artifactId>json-smart</artifactId>
-                <version>${jsonsmart.version}</version>
-            </dependency>
             <dependency>
                 <groupId>com.nimbusds</groupId>
                 <artifactId>nimbus-jose-jwt</artifactId>
@@ -290,6 +284,8 @@
                             <failOnWarning>true</failOnWarning>
                             <ignoredUnusedDeclaredDependencies>
                                 <ignoredUnusedDeclaredDependency>org.slf4j:slf4j-simple:jar</ignoredUnusedDeclaredDependency>
+                                <!-- Added due to transitive override to address CVE-2024-57699. Remove in the future. -->
+                                <ignoredUnusedDeclaredDependency>net.minidev:json-smart:jar</ignoredUnusedDeclaredDependency>
                             </ignoredUnusedDeclaredDependencies>
                         </configuration>
                     </execution>


### PR DESCRIPTION
Proper fix for #265 