### PR TITLE
[release-0.15.x] Move to the Sonatype Central Portal and add release pipeline

### DIFF
--- a/.azure/build-pipeline.yaml
+++ b/.azure/build-pipeline.yaml
@@ -18,7 +18,7 @@ stages:
       - template: 'templates/jobs/build_java.yaml'
   - stage: java_deploy
     displayName: Deploy Java
-    condition: and(succeeded(), or(eq(variables['build.sourceBranch'], 'refs/heads/main'), startsWith(variables['build.sourceBranch'], 'refs/heads/release-')))
+    condition: and(succeeded(), eq(variables['build.sourceBranch'], 'refs/heads/main'))
     jobs:
       - template: 'templates/jobs/deploy_java.yaml'
         parameters:

--- a/.azure/release-pipeline.yaml
+++ b/.azure/release-pipeline.yaml
@@ -1,0 +1,24 @@
+# Triggers
+trigger: none
+pr: none
+
+# Parameters
+parameters:
+  - name: releaseVersion
+    displayName: Release Version
+    type: string
+
+# Stages
+stages:
+  - stage: publish_artifacts
+    displayName: Publish artifacts for ${{ parameters.releaseVersion }}
+    condition: startsWith(variables['build.sourceBranch'], 'refs/heads/release-')
+    jobs:
+      - template: 'templates/jobs/release_artifacts.yaml'
+        parameters:
+          artifactSource: 'current'
+          artifactProject: 'strimzi'
+          artifactPipeline: ''
+          artifactRunVersion: ''
+          artifactRunId: ''
+          releaseVersion: '${{ parameters.releaseVersion }}'

--- a/.azure/release-pipeline.yaml
+++ b/.azure/release-pipeline.yaml
@@ -12,7 +12,8 @@ parameters:
 stages:
   - stage: publish_artifacts
     displayName: Publish artifacts for ${{ parameters.releaseVersion }}
-    condition: startsWith(variables['build.sourceBranch'], 'refs/heads/release-')
+    condition: startsWith(variables['build.sourceBranch'], 'refs/heads/move-to-central-015')
+#    condition: startsWith(variables['build.sourceBranch'], 'refs/heads/release-')
     jobs:
       - template: 'templates/jobs/release_artifacts.yaml'
         parameters:

--- a/.azure/release-pipeline.yaml
+++ b/.azure/release-pipeline.yaml
@@ -12,8 +12,7 @@ parameters:
 stages:
   - stage: publish_artifacts
     displayName: Publish artifacts for ${{ parameters.releaseVersion }}
-    condition: startsWith(variables['build.sourceBranch'], 'refs/heads/move-to-central-015')
-#    condition: startsWith(variables['build.sourceBranch'], 'refs/heads/release-')
+    condition: startsWith(variables['build.sourceBranch'], 'refs/heads/release-')
     jobs:
       - template: 'templates/jobs/release_artifacts.yaml'
         parameters:

--- a/.azure/scripts/push-to-central.sh
+++ b/.azure/scripts/push-to-central.sh
@@ -9,7 +9,7 @@ export GPG_TTY
 echo "$GPG_SIGNING_KEY" | base64 -d > signing.gpg
 gpg --batch --import signing.gpg
 
-GPG_EXECUTABLE=gpg mvn $MVN_ARGS -DskipTests -s ./.azure/scripts/settings.xml -pl '!examples/producer','!examples/consumer' -P ossrh verify deploy
+GPG_EXECUTABLE=gpg mvn $MVN_ARGS -DskipTests -s ./.azure/scripts/settings.xml -pl '!examples/producer','!examples/consumer' -P central deploy
 
 rm -rf signing.gpg
 gpg --delete-keys

--- a/.azure/scripts/settings.xml
+++ b/.azure/scripts/settings.xml
@@ -1,9 +1,9 @@
 <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0">
     <servers>
         <server>
-            <id>ossrh</id>
-            <username>${env.NEXUS_USERNAME}</username>
-            <password>${env.NEXUS_PASSWORD}</password>
+            <id>central</id>
+            <username>${env.CENTRAL_USERNAME}</username>
+            <password>${env.CENTRAL_PASSWORD}</password>
         </server>
     </servers>
 </settings>

--- a/.azure/templates/jobs/deploy_java.yaml
+++ b/.azure/templates/jobs/deploy_java.yaml
@@ -31,13 +31,13 @@ jobs:
           runId: '${{ parameters.artifactRunId }}'
       - bash: tar -xvf target.tar
         displayName: "Untar the target directory"
-      - bash: "./.azure/scripts/push-to-nexus.sh"
+      - bash: "./.azure/scripts/push-to-central.sh"
         env:
           BUILD_REASON: $(Build.Reason)
           BRANCH: $(Build.SourceBranch)
           GPG_PASSPHRASE: $(GPG_PASSPHRASE)
           GPG_SIGNING_KEY: $(GPG_SIGNING_KEY)
-          NEXUS_USERNAME: $(NEXUS_USERNAME)
-          NEXUS_PASSWORD: $(NEXUS_PASSWORD)
+          CENTRAL_USERNAME: $(CENTRAL_USERNAME)
+          CENTRAL_PASSWORD: $(CENTRAL_PASSWORD)
           MVN_ARGS: "-e -V -B"
         displayName: "Deploy Java artifacts"

--- a/.azure/templates/jobs/release_artifacts.yaml
+++ b/.azure/templates/jobs/release_artifacts.yaml
@@ -1,0 +1,33 @@
+jobs:
+- job: 'release_artifacts'
+  displayName: 'Prepare and release artifacts'
+  # Set timeout for jobs
+  timeoutInMinutes: 60
+  # Base system
+  pool:
+    vmImage: 'Ubuntu-22.04'
+  # Pipeline steps
+  steps:
+    # Install Prerequisites
+    - template: '../steps/prerequisites/install_java.yaml'
+
+    # Change the release version
+    - bash: "mvn versions:set -DnewVersion=$(shell echo $(RELEASE_VERSION) | tr a-z A-Z)"
+      displayName: "Configure release version to ${{ parameters.releaseVersion }}"
+      env:
+        RELEASE_VERSION: '${{ parameters.releaseVersion }}'
+
+    - bash: "mvn install -DskipTests"
+      displayName: "Build Java"
+
+    # Deploy to Central
+    - bash: "./.azure/scripts/push-to-central.sh"
+      env:
+        BUILD_REASON: $(Build.Reason)
+        BRANCH: $(Build.SourceBranch)
+        GPG_PASSPHRASE: $(GPG_PASSPHRASE)
+        GPG_SIGNING_KEY: $(GPG_SIGNING_KEY)
+        CENTRAL_USERNAME: $(CENTRAL_USERNAME)
+        CENTRAL_PASSWORD: $(CENTRAL_PASSWORD)
+        MVN_ARGS: "-e -V -B"
+      displayName: "Deploy Java artifacts"

--- a/.azure/templates/jobs/release_artifacts.yaml
+++ b/.azure/templates/jobs/release_artifacts.yaml
@@ -12,7 +12,7 @@ jobs:
     - template: '../steps/prerequisites/install_java.yaml'
 
     # Change the release version
-    - bash: "mvn versions:set -DnewVersion=$(shell echo $(RELEASE_VERSION) | tr a-z A-Z)"
+    - bash: "mvn versions:set -DnewVersion=$(echo $RELEASE_VERSION | tr a-z A-Z)"
       displayName: "Configure release version to ${{ parameters.releaseVersion }}"
       env:
         RELEASE_VERSION: '${{ parameters.releaseVersion }}'

--- a/.azure/templates/steps/prerequisites/install_java.yaml
+++ b/.azure/templates/steps/prerequisites/install_java.yaml
@@ -5,7 +5,7 @@ parameters:
 steps:
   - task: JavaToolInstaller@0
     inputs:
-      versionSpec: $(JDK_VERSION)
+      versionSpec: ${{ parameters.JDK_VERSION }}
       jdkArchitectureOption: 'x64'
       jdkSourceOption: 'PreInstalled'
     displayName: 'Configure Java'

--- a/oauth-client/pom.xml
+++ b/oauth-client/pom.xml
@@ -9,6 +9,7 @@
         <version>0.15.1-SNAPSHOT</version>
     </parent>
 
+    <name>Strimzi Kafka OAuth client</name>
     <artifactId>kafka-oauth-client</artifactId>
 
     <dependencies>

--- a/oauth-common/pom.xml
+++ b/oauth-common/pom.xml
@@ -9,6 +9,7 @@
         <version>0.15.1-SNAPSHOT</version>
     </parent>
 
+    <name>Strimzi Kafka OAuth common utilities</name>
     <artifactId>kafka-oauth-common</artifactId>
 
     <dependencies>

--- a/oauth-keycloak-authorizer/pom.xml
+++ b/oauth-keycloak-authorizer/pom.xml
@@ -9,6 +9,7 @@
         <version>0.15.1-SNAPSHOT</version>
     </parent>
 
+    <name>Strimzi Kafka OAuth Keycloak authorizer</name>
     <artifactId>kafka-oauth-keycloak-authorizer</artifactId>
 
     <dependencies>

--- a/oauth-server-plain/pom.xml
+++ b/oauth-server-plain/pom.xml
@@ -9,6 +9,7 @@
         <version>0.15.1-SNAPSHOT</version>
     </parent>
 
+    <name>Strimzi Kafka OAuth server plain</name>
     <artifactId>kafka-oauth-server-plain</artifactId>
 
     <dependencies>

--- a/oauth-server/pom.xml
+++ b/oauth-server/pom.xml
@@ -9,6 +9,7 @@
         <version>0.15.1-SNAPSHOT</version>
     </parent>
 
+    <name>Strimzi Kafka OAuth server</name>
     <artifactId>kafka-oauth-server</artifactId>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
         </license>
     </licenses>
 
-    <name>Strimzi - Apache Kafka on Kubernetes</name>
+    <name>Strimzi OAuth for Apache Kafka</name>
     <description>Strimzi uses the Kubernetes operator pattern to provide a way to run an Apache Kafka cluster on
         Kubernetes in various deployment configurations. The OAuth subproject implements the callbacks for
         Kafka authentication using OAuth (based on SASL OAUTHBEARER mechanism).</description>

--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
         <maven.checkstyle.version>3.2.1</maven.checkstyle.version>
         <maven.resources.version>3.3.0</maven.resources.version>
         <spotbugs.version>4.7.3</spotbugs.version>
-        <sonatype.nexus.staging>1.6.3</sonatype.nexus.staging>
+        <central-publishing-maven-plugin.version>0.7.0</central-publishing-maven-plugin.version>
         <kafka.version>3.9.1</kafka.version>
         <jackson.version>2.15.3</jackson.version>
         <jackson.databind.version>2.15.3</jackson.databind.version>
@@ -113,17 +113,6 @@
         <mockito.version>3.12.4</mockito.version>
         <nimbus.jose.version>9.37.2</nimbus.jose.version>
     </properties>
-
-    <distributionManagement>
-        <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
-        <repository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-        </repository>
-    </distributionManagement>
 
     <modules>
         <module>oauth-common</module>
@@ -400,7 +389,7 @@
             </properties>
         </profile>
         <profile>
-            <id>ossrh</id>
+            <id>central</id>
             <activation>
                 <activeByDefault>false</activeByDefault>
             </activation>
@@ -434,14 +423,12 @@
                         </executions>
                     </plugin>
                     <plugin>
-                        <groupId>org.sonatype.plugins</groupId>
-                        <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>${sonatype.nexus.staging}</version>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>${central-publishing-maven-plugin.version}</version>
                         <extensions>true</extensions>
                         <configuration>
-                            <serverId>ossrh</serverId>
-                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                            <autoReleaseAfterClose>false</autoReleaseAfterClose>
+                            <publishingServerId>central</publishingServerId>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
This PR moves to the changes the scripts, poms and our pipelines to push artifacts to the new Sonatype Central Portal, as we migrated from the legacy system to the new one.

It also adds release-pipeline in order to handle releases of RCs, as there is no staging area.