### PR TITLE
Fix testsuite hydra-test

### DIFF
--- a/testsuite/docker/hydra-import/scripts/start.sh
+++ b/testsuite/docker/hydra-import/scripts/start.sh
@@ -23,7 +23,7 @@ cat < /hydra/certs/ca.crt >> /etc/ssl/certs/ca-certificates.crt
 
 URI=${HYDRA_URI}
 if [ "" == "${URI}" ]; then
-    URI="http://${HYDRA_HOST:-hydra}:{SERVE_ADMIN_PORT:-4445}/clients"
+    URI="https://${HYDRA_HOST:-hydra}:{SERVE_ADMIN_PORT:-4445}/admin/clients"
 fi
 
 wait_for_url $URI "Waiting for Hydra admin REST to start"

--- a/testsuite/docker/kafka/scripts/functions.sh
+++ b/testsuite/docker/kafka/scripts/functions.sh
@@ -9,9 +9,12 @@ wait_for_url() {
         CMD="curl -sL -o /dev/null -w %{http_code} $URL"
     fi
 
-    until [ "200" == "`$CMD`" ]
+    # Run 'curl' but suppress any error code from 'set -e' error hook
+    status=$($CMD || echo "000")
+    until [[ "$status" == "200" || "$status" == "405" ]]
     do
         echo "$MSG ($URL)"
+        status=$($CMD || echo "000")
         sleep 2
     done
 }

--- a/testsuite/docker/kafka/scripts/start_with_hydra.sh
+++ b/testsuite/docker/kafka/scripts/start_with_hydra.sh
@@ -3,13 +3,19 @@ set -e
 
 source functions.sh
 
-URI="https://hydra:4445/clients"
+URI="https://hydra:4445/admin/clients"
 wait_for_url $URI "Waiting for Hydra admin REST to start"
 wait_for_url $URI/kafka-broker "Waiting for kafka-broker client to be available"
 
-URI="https://hydra-jwt:4455/clients"
+URI="https://hydra-jwt:4455/admin/clients"
 wait_for_url $URI "Waiting for Hydra JWT admin REST to start"
 wait_for_url $URI/kafka-broker "Waiting for kafka-broker client to be available"
+
+URI="https://hydra:4444/oauth2/token"
+wait_for_url $URI "Waiting for hydra:4444 token endpoint to start"
+
+URI="https://hydra:4445/admin/oauth2/introspect"
+wait_for_url $URI "Waiting for hydra:4445 introspect endpoint to start"
 
 ./simple_kafka_config.sh | tee /tmp/strimzi.properties
 echo "Config created"

--- a/testsuite/hydra-test/docker-compose.yml
+++ b/testsuite/hydra-test/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
 
   hydra:
-    image: oryd/hydra:v1.8.5
+    image: oryd/hydra:v2.3.0
     ports:
       - "4444:4444"
       - "4445:4445"
@@ -14,10 +14,16 @@ services:
       - URLS_SELF_ISSUER=https://hydra:4444/
       - URLS_CONSENT=http://hydra:9020/consent
       - URLS_LOGIN=http://hydra:9020/login
-      - SERVE_TLS_KEY_PATH=/tmp/certs/hydra.key
-      - SERVE_TLS_CERT_PATH=/tmp/certs/hydra.crt
+      - SERVE_PUBLIC_TLS_ENABLED=true
+      - SERVE_ADMIN_TLS_ENABLED=true
+      - SERVE_PUBLIC_TLS_KEY_PATH=/tmp/certs/hydra.key
+      - SERVE_ADMIN_TLS_KEY_PATH=/tmp/certs/hydra.key
+      - SERVE_PUBLIC_TLS_CERT_PATH=/tmp/certs/hydra.crt
+      - SERVE_ADMIN_TLS_CERT_PATH=/tmp/certs/hydra.crt
       - SERVE_PUBLIC_PORT=4444
       - SERVE_ADMIN_PORT=4445
+      - SECRETS_SYSTEM=thisisaglobalsecret
+      - LOG_LEVEL=debug
 
   hydra-import:
     image: testsuite/hydra-import:latest
@@ -30,29 +36,34 @@ services:
       - -c
       - cd hydra && ./start.sh
     environment:
-      - HYDRA_ADMIN_URL=https://hydra:4445
-      - HYDRA_URI=https://hydra:4445/clients
+      - HYDRA_URI=https://hydra:4445/admin/clients
       - SERVE_ADMIN_PORT=4445
 
   hydra-jwt:
-    image: oryd/hydra:v1.8.5
+    image: oryd/hydra:v2.3.0
     ports:
       - "4454:4454"
       - "4455:4455"
     volumes:
       - ${PWD}/../docker/target/hydra/certs:/tmp/certs
-    command: serve all
 
     environment:
       - DSN=memory
       - URLS_SELF_ISSUER=https://hydra-jwt:4454/
       - URLS_CONSENT=http://hydra-jwt:9120/consent
       - URLS_LOGIN=http://hydra-jwt:9120/login
-      - SERVE_TLS_KEY_PATH=/tmp/certs/hydra-jwt.key
-      - SERVE_TLS_CERT_PATH=/tmp/certs/hydra-jwt.crt
+      - SERVE_PUBLIC_TLS_ENABLED=true
+      - SERVE_ADMIN_TLS_ENABLED=true
+      - SERVE_PUBLIC_TLS_KEY_PATH=/tmp/certs/hydra-jwt.key
+      - SERVE_ADMIN_TLS_KEY_PATH=/tmp/certs/hydra-jwt.key
+      - SERVE_PUBLIC_TLS_CERT_PATH=/tmp/certs/hydra-jwt.crt
+      - SERVE_ADMIN_TLS_CERT_PATH=/tmp/certs/hydra-jwt.crt
+
       - SERVE_PUBLIC_PORT=4454
       - SERVE_ADMIN_PORT=4455
       - STRATEGIES_ACCESS_TOKEN=jwt
+      - SECRETS_SYSTEM=thisisaglobalsecret
+      - LOG_LEVEL=debug
 
   hydra-jwt-import:
     image: testsuite/hydra-import:latest
@@ -65,8 +76,7 @@ services:
       - -c
       - cd hydra && ./start.sh
     environment:
-      - HYDRA_ADMIN_URL=https://hydra-jwt:4455
-      - HYDRA_URI=https://hydra-jwt:4455/clients
+      - HYDRA_URI=https://hydra-jwt:4455/admin/clients
       - SERVE_ADMIN_PORT=4455
 
   kafka:
@@ -107,7 +117,7 @@ services:
       - KAFKA_LISTENER_NAME_CONTROLLER_SASL_ENABLED_MECHANISMS=SCRAM-SHA-512
       - KAFKA_LISTENER_NAME_CONTROLLER_SCRAM__2DSHA__2D512_SASL_JAAS_CONFIG=org.apache.kafka.common.security.scram.ScramLoginModule required    username=\"admin\"    password=\"admin-secret\" ;
 
-      - KAFKA_LISTENER_NAME_INTROSPECT_OAUTHBEARER_SASL_JAAS_CONFIG=org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required    oauth.introspection.endpoint.uri=\"https://hydra:4445/oauth2/introspect\"    oauth.client.id=\"kafka-broker\"    oauth.client.secret=\"kafka-broker-secret\"    oauth.valid.issuer.uri=\"https://hydra:4444/\"    oauth.token.endpoint.uri=\"https://hydra:4444/oauth2/token\"    oauth.check.access.token.type=\"false\"    oauth.access.token.is.jwt=\"false\" ;
+      - KAFKA_LISTENER_NAME_INTROSPECT_OAUTHBEARER_SASL_JAAS_CONFIG=org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required    oauth.introspection.endpoint.uri=\"https://hydra:4445/admin/oauth2/introspect\"    oauth.client.id=\"kafka-broker\"    oauth.client.secret=\"kafka-broker-secret\"    oauth.valid.issuer.uri=\"https://hydra:4444/\"    oauth.token.endpoint.uri=\"https://hydra:4444/oauth2/token\"    oauth.check.access.token.type=\"false\"    oauth.access.token.is.jwt=\"false\" ;
       - KAFKA_LISTENER_NAME_INTROSPECT_OAUTHBEARER_SASL_LOGIN_CALLBACK_HANDLER_CLASS=io.strimzi.kafka.oauth.client.JaasClientOauthLoginCallbackHandler
       - KAFKA_LISTENER_NAME_INTROSPECT_OAUTHBEARER_SASL_SERVER_CALLBACK_HANDLER_CLASS=io.strimzi.kafka.oauth.server.JaasServerOauthValidatorCallbackHandler
 


### PR DESCRIPTION
Bump testsuite Hydra version and fix the functions.sh script to never fail with error code in order to avoid early exit due to `set -e` fail fast mode enabled in the calling scripts.