### PR TITLE
Add support for OKP key type validation

### DIFF
--- a/oauth-common/pom.xml
+++ b/oauth-common/pom.xml
@@ -58,6 +58,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>com.google.crypto.tink</groupId>
+            <artifactId>tink</artifactId>
+            <version>${tink.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
             <scope>test</scope>

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/validator/JCASigningKey.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/validator/JCASigningKey.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017-2025, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.kafka.oauth.validator;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.JWSVerifier;
+import com.nimbusds.jose.crypto.factories.DefaultJWSVerifierFactory;
+
+import java.security.PublicKey;
+
+class JCASigningKey implements SigningKey {
+
+    private static final DefaultJWSVerifierFactory VERIFIER_FACTORY = new DefaultJWSVerifierFactory();
+
+    private final PublicKey publicKey;
+
+    JCASigningKey(PublicKey publicKey) {
+        this.publicKey = publicKey;
+    }
+
+    @Override
+    public JWSVerifier createVerifier(JWSHeader header) throws JOSEException {
+        return VERIFIER_FACTORY.createJWSVerifier(header, publicKey);
+    }
+}

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/validator/JWTSignatureValidator.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/validator/JWTSignatureValidator.java
@@ -5,11 +5,12 @@
 package io.strimzi.kafka.oauth.validator;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.nimbusds.jose.crypto.factories.DefaultJWSVerifierFactory;
+import com.nimbusds.jose.jwk.Curve;
 import com.nimbusds.jose.jwk.ECKey;
 import com.nimbusds.jose.jwk.JWK;
 import com.nimbusds.jose.jwk.JWKSet;
 import com.nimbusds.jose.jwk.KeyUse;
+import com.nimbusds.jose.jwk.OctetKeyPair;
 import com.nimbusds.jose.jwk.RSAKey;
 import com.nimbusds.jwt.SignedJWT;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -33,7 +34,6 @@ import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLSocketFactory;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.security.PublicKey;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -66,8 +66,6 @@ public class JWTSignatureValidator implements TokenValidator {
 
     private static final Logger log = LoggerFactory.getLogger(JWTSignatureValidator.class);
 
-    private static final DefaultJWSVerifierFactory VERIFIER_FACTORY = new DefaultJWSVerifierFactory();
-
     private final String validatorId;
     private final String clientId;
     private final String clientSecret;
@@ -91,8 +89,8 @@ public class JWTSignatureValidator implements TokenValidator {
 
     private long lastFetchTime;
 
-    private Map<String, PublicKey> cache = Collections.emptyMap();
-    private Map<String, PublicKey> oldCache = Collections.emptyMap();
+    private Map<String, SigningKey> cache = Collections.emptyMap();
+    private Map<String, SigningKey> oldCache = Collections.emptyMap();
 
     private BackOffTaskScheduler fastScheduler;
 
@@ -361,13 +359,13 @@ public class JWTSignatureValidator implements TokenValidator {
         }, refreshSeconds, refreshSeconds, TimeUnit.SECONDS);
     }
 
-    private PublicKey getPublicKey(String id) {
+    private SigningKey getSigningKey(String id) {
         return getKeyUnlessStale(id);
     }
 
-    private PublicKey getKeyUnlessStale(String id) {
+    private SigningKey getKeyUnlessStale(String id) {
         if (lastFetchTime + maxStaleSeconds * 1000L > System.currentTimeMillis()) {
-            PublicKey result = cache.get(id);
+            SigningKey result = cache.get(id);
             if (result == null) {
                 log.warn("No public key for id: {}", id);
             }
@@ -385,23 +383,29 @@ public class JWTSignatureValidator implements TokenValidator {
             String response = HttpUtil.get(keysUri, socketFactory, hostnameVerifier, authorization, String.class, connectTimeout, readTimeout, includeAcceptHeader);
             addJwksHttpMetricSuccessTime(requestStartTime);
 
-            Map<String, PublicKey> newCache = new HashMap<>();
+            Map<String, SigningKey> newCache = new HashMap<>();
             JWKSet jwks = JWKSet.parse(response);
 
             for (JWK jwk : jwks.getKeys()) {
                 if (ignoreKeyUse || KeyUse.SIGNATURE.equals(jwk.getKeyUse())) {
-
-                    PublicKey publicKey;
+                    SigningKey signingKey;
 
                     if (jwk instanceof ECKey) {
-                        publicKey = ((ECKey) jwk).toPublicKey();
+                        signingKey = new JCASigningKey(((ECKey) jwk).toPublicKey());
                     } else if (jwk instanceof RSAKey) {
-                        publicKey = ((RSAKey) jwk).toPublicKey();
+                        signingKey = new JCASigningKey(((RSAKey) jwk).toPublicKey());
+                    } else if (jwk instanceof OctetKeyPair) {
+                        OctetKeyPair okp = (OctetKeyPair) jwk;
+                        if (!Curve.Ed25519.equals(okp.getCurve())) {
+                            log.warn("Unsupported OKP curve: {}", okp .getCurve());
+                            continue;
+                        }
+                        signingKey = new OKPSigningKey(okp.toPublicJWK());
                     } else {
                         log.warn("Unsupported JWK key type: {}", jwk.getKeyType());
                         continue;
                     }
-                    newCache.put(jwk.getKeyID(), publicKey);
+                    newCache.put(jwk.getKeyID(), signingKey);
                 }
             }
 
@@ -445,8 +449,8 @@ public class JWTSignatureValidator implements TokenValidator {
 
         JsonNode t;
         try {
-            PublicKey pub = getPublicKey(kid);
-            if (pub == null) {
+            SigningKey signingKey = getSigningKey(kid);
+            if (signingKey == null) {
                 if (oldCache.get(kid) != null) {
                     throw new TokenValidationException("Token validation failed: The signing key is no longer valid (kid:" + kid + ")");
                 } else {
@@ -460,7 +464,7 @@ public class JWTSignatureValidator implements TokenValidator {
                 }
             }
 
-            if (!jwt.verify(VERIFIER_FACTORY.createJWSVerifier(jwt.getHeader(), pub))) {
+            if (!jwt.verify(signingKey.createVerifier(jwt.getHeader()))) {
                 throw new TokenSignatureException("Signature check failed: Invalid token signature");
             }
             t = JSONUtil.asJson(jwt.getPayload().toJSONObject());

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/validator/OKPSigningKey.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/validator/OKPSigningKey.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2017-2025, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.kafka.oauth.validator;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.JWSVerifier;
+import com.nimbusds.jose.crypto.Ed25519Verifier;
+import com.nimbusds.jose.jwk.OctetKeyPair;
+
+class OKPSigningKey implements SigningKey {
+
+    private final OctetKeyPair octetKeyPair;
+
+    OKPSigningKey(OctetKeyPair octetKeyPair) {
+        this.octetKeyPair = octetKeyPair;
+    }
+
+    @Override
+    public JWSVerifier createVerifier(JWSHeader header) throws JOSEException {
+        return new Ed25519Verifier(octetKeyPair);
+    }
+}

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/validator/SigningKey.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/validator/SigningKey.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright 2017-2025, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.kafka.oauth.validator;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.JWSVerifier;
+
+interface SigningKey {
+    JWSVerifier createVerifier(JWSHeader header) throws JOSEException;
+}

--- a/oauth-common/src/test/java/io/strimzi/kafka/oauth/validator/JWKSTest.java
+++ b/oauth-common/src/test/java/io/strimzi/kafka/oauth/validator/JWKSTest.java
@@ -4,10 +4,12 @@
  */
 package io.strimzi.kafka.oauth.validator;
 
+import com.nimbusds.jose.jwk.Curve;
 import com.nimbusds.jose.jwk.ECKey;
 import com.nimbusds.jose.jwk.JWK;
 import com.nimbusds.jose.jwk.JWKSet;
 import com.nimbusds.jose.jwk.KeyUse;
+import com.nimbusds.jose.jwk.OctetKeyPair;
 import com.nimbusds.jose.jwk.RSAKey;
 import io.strimzi.kafka.oauth.common.JSONUtil;
 import org.junit.Assert;
@@ -48,4 +50,26 @@ public class JWKSTest {
         Assert.assertEquals("PdbyxXXc7pwIX8xoIS7Kb-g1ZEDNFISpbyZs2MNkRJY", parsedKeyID);
         Assert.assertNotNull(publicKey);
     }
+
+    @Test
+    public void testParseOKPKey() throws Exception {
+        String keyId = "ed25519-test-key";
+        String bodyString = "{\"keys\":[{\"kid\":\"" + keyId +
+                "\",\"kty\":\"OKP\",\"alg\":\"EdDSA\",\"use\":\"sig\"," +
+                "\"crv\":\"Ed25519\",\"x\":\"11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo\"}]}";
+
+        JWKSet jwks = JWKSet.parse(bodyString);
+        Assert.assertEquals(1, jwks.getKeys().size());
+
+        JWK jwk = jwks.getKeys().iterator().next();
+        Assert.assertEquals(KeyUse.SIGNATURE, jwk.getKeyUse());
+        Assert.assertTrue(jwk instanceof OctetKeyPair);
+
+        Assert.assertEquals(keyId, jwk.getKeyID());
+        OctetKeyPair signingKey = (OctetKeyPair) jwk.toPublicJWK();
+        Assert.assertNotNull(signingKey);
+        Assert.assertEquals(Curve.Ed25519, signingKey.getCurve());
+        Assert.assertFalse(signingKey.isPrivate());
+    }
+
 }

--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,7 @@
         <jsonpath.version>2.9.0</jsonpath.version>
         <jsonsmart.version>2.5.2</jsonsmart.version>
         <junit.version>4.13.2</junit.version>
+        <tink.version>1.16.0</tink.version>
         <slf4j.version>1.7.36</slf4j.version>
         <mockito.version>3.12.4</mockito.version>
         <nimbus.jose.version>10.0.2</nimbus.jose.version>
@@ -281,6 +282,8 @@
                                 <ignoredUnusedDeclaredDependency>org.slf4j:slf4j-simple:jar</ignoredUnusedDeclaredDependency>
                                 <!-- Added due to transitive override to address CVE-2024-57699. Remove in the future. -->
                                 <ignoredUnusedDeclaredDependency>net.minidev:json-smart:jar</ignoredUnusedDeclaredDependency>
+                                <!-- Added for ability to construct com.nimbusds.jose.crypto.Ed25519Verifier -->
+                                <ignoredUnusedDeclaredDependency>com.google.crypto.tink:tink</ignoredUnusedDeclaredDependency>
                             </ignoredUnusedDeclaredDependencies>
                         </configuration>
                     </execution>

--- a/testsuite/mock-oauth-server/src/main/java/io/strimzi/testsuite/oauth/server/AuthServerRequestHandler.java
+++ b/testsuite/mock-oauth-server/src/main/java/io/strimzi/testsuite/oauth/server/AuthServerRequestHandler.java
@@ -11,6 +11,7 @@ import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.JWSHeader;
 import com.nimbusds.jose.JWSSigner;
+import com.nimbusds.jose.crypto.Ed25519Signer;
 import com.nimbusds.jose.crypto.RSASSASigner;
 import com.nimbusds.jose.jwk.JWKSet;
 import com.nimbusds.jose.jwk.RSAKey;
@@ -67,6 +68,7 @@ import static io.strimzi.testsuite.oauth.server.Mode.MODE_200_DELAYED;
 import static io.strimzi.testsuite.oauth.server.Mode.MODE_200_PROTECTED;
 import static io.strimzi.testsuite.oauth.server.Mode.MODE_200_UNPROTECTED;
 import static io.strimzi.testsuite.oauth.server.Mode.MODE_FAILING_500;
+import static io.strimzi.testsuite.oauth.server.Mode.MODE_JWKS_OKP_WITH_SIG_USE;
 import static io.strimzi.testsuite.oauth.server.Mode.MODE_JWKS_RSA_WITHOUT_SIG_USE;
 import static io.strimzi.testsuite.oauth.server.Mode.MODE_JWKS_RSA_WITH_SIG_USE;
 import static io.vertx.core.http.HttpMethod.GET;
@@ -119,7 +121,7 @@ public class AuthServerRequestHandler implements Handler<HttpServerRequest> {
 
     private boolean processRequest(Endpoint endpoint, Mode mode, HttpServerRequest req) throws NoSuchAlgorithmException, JOSEException, InterruptedException {
         if (endpoint == Endpoint.JWKS &&
-                isOneOf(mode, MODE_200, MODE_200_PROTECTED, MODE_JWKS_RSA_WITH_SIG_USE, MODE_JWKS_RSA_WITHOUT_SIG_USE)) {
+                isOneOf(mode, MODE_200, MODE_200_PROTECTED, MODE_JWKS_RSA_WITH_SIG_USE, MODE_JWKS_RSA_WITHOUT_SIG_USE, MODE_JWKS_OKP_WITH_SIG_USE)) {
             processJwksRequest(req, mode);
         } else if (endpoint == TOKEN && mode == MODE_200) {
             processTokenRequest(req, mode);
@@ -564,9 +566,17 @@ public class AuthServerRequestHandler implements Handler<HttpServerRequest> {
     }
 
     private String createSignedAccessToken(String clientId, String username, long expiresIn, Map<String, String> claims) throws JOSEException, NoSuchAlgorithmException {
+        JWSSigner signer;
+        JWSHeader header;
 
-        // Create RSA-signer with the private key
-        JWSSigner signer = new RSASSASigner(verticle.getSigKey());
+        Mode jwksMode = verticle.getMode(Endpoint.JWKS);
+        if (jwksMode == MODE_JWKS_OKP_WITH_SIG_USE) {
+            signer = new Ed25519Signer(verticle.getOkpSigKey());
+            header = new JWSHeader.Builder(JWSAlgorithm.EdDSA).keyID(verticle.getOkpSigKey().getKeyID()).build();
+        } else {
+            signer = new RSASSASigner(verticle.getRsaSigKey());
+            header = new JWSHeader.Builder(JWSAlgorithm.RS256).keyID(verticle.getRsaSigKey().getKeyID()).build();
+        }
 
         // Prepare JWT with claims set
         JWTClaimsSet.Builder builder = new JWTClaimsSet.Builder()
@@ -590,9 +600,7 @@ public class AuthServerRequestHandler implements Handler<HttpServerRequest> {
             builder.claim("username", username);
         }
         JWTClaimsSet claimsSet = builder.build();
-        SignedJWT signedJWT = new SignedJWT(
-                new JWSHeader.Builder(JWSAlgorithm.RS256).keyID(verticle.getSigKey().getKeyID()).build(),
-                claimsSet);
+        SignedJWT signedJWT = new SignedJWT(header, claimsSet);
 
         // Compute the RSA signature
         signedJWT.sign(signer);
@@ -698,10 +706,13 @@ public class AuthServerRequestHandler implements Handler<HttpServerRequest> {
                 // pass through to next case block
             case MODE_200:
             case MODE_JWKS_RSA_WITH_SIG_USE:
-                sendResponse(req, OK, jwksWithSig());
+                sendResponse(req, OK, jwksWithRsaSig());
                 break;
             case MODE_JWKS_RSA_WITHOUT_SIG_USE:
                 sendResponse(req, OK, jwksWithoutSig());
+                break;
+            case MODE_JWKS_OKP_WITH_SIG_USE:
+                sendResponse(req, OK, jwksWithOkpSig());
                 break;
             default:
                 throw new IllegalStateException("Internal error");
@@ -709,16 +720,20 @@ public class AuthServerRequestHandler implements Handler<HttpServerRequest> {
     }
 
 
-    private String jwksWithSig() throws NoSuchAlgorithmException {
-        return JSONUtil.asJson(new JWKSet(verticle.getSigKey()).toJSONObject()).toPrettyString();
+    private String jwksWithRsaSig() throws NoSuchAlgorithmException {
+        return JSONUtil.asJson(new JWKSet(verticle.getRsaSigKey()).toJSONObject()).toPrettyString();
     }
 
     private String jwksWithoutSig() throws NoSuchAlgorithmException, JOSEException {
-        RSAKey jwk = verticle.getSigKey();
+        RSAKey jwk = verticle.getRsaSigKey();
         jwk = new RSAKey.Builder(jwk.toRSAPublicKey())
                 .privateKey(jwk.toRSAPrivateKey())
                 .keyID(jwk.getKeyID())
                 .build();
         return JSONUtil.asJson(new JWKSet(jwk).toJSONObject()).toPrettyString();
+    }
+
+    private String jwksWithOkpSig() throws JOSEException {
+        return JSONUtil.asJson(new JWKSet(verticle.getOkpSigKey()).toJSONObject()).toPrettyString();
     }
 }

--- a/testsuite/mock-oauth-server/src/main/java/io/strimzi/testsuite/oauth/server/MockOAuthServerMainVerticle.java
+++ b/testsuite/mock-oauth-server/src/main/java/io/strimzi/testsuite/oauth/server/MockOAuthServerMainVerticle.java
@@ -4,8 +4,12 @@
  */
 package io.strimzi.testsuite.oauth.server;
 
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.jwk.Curve;
 import com.nimbusds.jose.jwk.KeyUse;
+import com.nimbusds.jose.jwk.OctetKeyPair;
 import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jose.jwk.gen.OctetKeyPairGenerator;
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
@@ -78,10 +82,11 @@ import static io.strimzi.testsuite.oauth.server.Mode.MODE_404;
  *
  * Some other modes are endpoint specific.
  * <p>
- * For 'jwks' there are two specific modes:
+ * For 'jwks' there are three specific modes:
  * <ul>
  *     <li>MODE_JWKS_RSA_WITH_SIG_USE</li>
  *     <li>MODE_JWKS_RSA_WITHOUT_SIG_USE</li>
+ *     <li>MODE_JWKS_OKP_WITH_SIG_USE</li>
  * </ul>
  *
  * For example, <tt>POST /admin/jwks?mode=MODE_404</tt> will configure the authorization server to always return status 404
@@ -147,6 +152,7 @@ public class MockOAuthServerMainVerticle extends AbstractVerticle {
     private final Map<String, JsonArray> grants = new HashMap<>();
 
     private RSAKey sigKey;
+    private OctetKeyPair okpSigKey;
 
     private final Map<Endpoint, AtomicCoin> coins = new ConcurrentHashMap<>();
 
@@ -268,7 +274,7 @@ public class MockOAuthServerMainVerticle extends AbstractVerticle {
         return modes.get(e);
     }
 
-    synchronized RSAKey getSigKey() throws NoSuchAlgorithmException {
+    synchronized RSAKey getRsaSigKey() throws NoSuchAlgorithmException {
         if (sigKey != null) {
             return sigKey;
         }
@@ -285,6 +291,18 @@ public class MockOAuthServerMainVerticle extends AbstractVerticle {
                 .keyUse(KeyUse.SIGNATURE)
                 .build();
         return sigKey;
+    }
+
+    synchronized OctetKeyPair getOkpSigKey() throws JOSEException {
+        if (okpSigKey != null) {
+            return okpSigKey;
+        }
+
+        okpSigKey = new OctetKeyPairGenerator(Curve.Ed25519)
+                .keyID(UUID.randomUUID().toString())
+                .keyUse(KeyUse.SIGNATURE)
+                .generate();
+        return okpSigKey;
     }
 
     void createOrUpdateClient(String clientId, String secret) {

--- a/testsuite/mock-oauth-server/src/main/java/io/strimzi/testsuite/oauth/server/Mode.java
+++ b/testsuite/mock-oauth-server/src/main/java/io/strimzi/testsuite/oauth/server/Mode.java
@@ -26,7 +26,8 @@ enum Mode {
     MODE_CERT_TWO_ON,
     MODE_EXPIRED_CERT_ON,
     MODE_JWKS_RSA_WITH_SIG_USE,
-    MODE_JWKS_RSA_WITHOUT_SIG_USE;
+    MODE_JWKS_RSA_WITHOUT_SIG_USE,
+    MODE_JWKS_OKP_WITH_SIG_USE;
 
 
     public static Mode fromString(String value) {

--- a/testsuite/mockoauth-tests/src/test/java/io/strimzi/testsuite/oauth/mockoauth/JWKSKeyUseTest.java
+++ b/testsuite/mockoauth-tests/src/test/java/io/strimzi/testsuite/oauth/mockoauth/JWKSKeyUseTest.java
@@ -28,6 +28,11 @@ public class JWKSKeyUseTest {
     private static final Logger log = LoggerFactory.getLogger(JWKSKeyUseTest.class);
 
     public void doTest() throws Exception {
+        testKeyUseEnforcement();
+        testOKPSignatureValidation();
+    }
+
+    public void testKeyUseEnforcement() throws Exception {
         Services.configure(Collections.emptyMap());
 
         changeAuthServerMode("jwks", "MODE_JWKS_RSA_WITHOUT_SIG_USE");
@@ -72,6 +77,42 @@ public class JWKSKeyUseTest {
         // Try to validate the token
         // It should pass
         validatorIgnoreKeyUse.validate(tokenInfo.token());
+    }
+
+    /**
+     * Test that JWTSignatureValidator correctly validates a token signed with an OKP (Ed25519) key
+     * by the mock OAuth server, using the mock server's JWKS endpoint.
+     */
+    public void testOKPSignatureValidation() throws Exception {
+        Services.configure(Collections.emptyMap());
+
+        changeAuthServerMode("jwks", "MODE_JWKS_OKP_WITH_SIG_USE");
+        changeAuthServerMode("token", "MODE_200");
+
+        String testClient = "testclient";
+        String testSecret = "testsecret";
+        createOAuthClient(testClient, testSecret);
+
+        String projectRoot = getProjectRoot();
+        SSLSocketFactory sslFactory = SSLUtil.createSSLFactory(
+                projectRoot + "/../docker/certificates/ca-truststore.p12", null, "changeit", null, null);
+
+        JWTSignatureValidator validator = createTokenValidator("okpValidator", sslFactory, false);
+
+        TokenInfo tokenInfo = OAuthAuthenticator.loginWithClientSecret(
+                URI.create("https://mockoauth:8090/token"),
+                sslFactory,
+                null,
+                testClient,
+                testSecret,
+                true,
+                null,
+                null,
+                true);
+
+        TokenIntrospection.debugLogJWT(log, tokenInfo.token());
+
+        validator.validate(tokenInfo.token());
     }
 
     private static JWTSignatureValidator createTokenValidator(String validatorId, SSLSocketFactory sslFactory, boolean ignoreKeyUse) {


### PR DESCRIPTION
Enhancement:
1. Added support for validating JWTs signed by OKP key type (today only RSA / EC supported).
2. Added `com.google.crypto.tink:tink` dependency (transitive version from com.nimbusds:nimbus-jose-jwt:10.0.2).
This is required by `com.nimbusds.jose.crypto.Ed25519Verifier`.
Only supported curve is ED25519 - `JWTSignatureValidator` reflects this as well.
3. Added simple unit test for parsing OKP key.
4. Added mock auth server test (defined a new JWKS mode, etc.)

Tested with Docker Desktop version 4.53.0 (211793)

Fixes #297 