### PR TITLE
Use shared-actions in codeql workflow

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -43,7 +43,7 @@ jobs:
       uses: actions/checkout@v6
     
     - name: Setup Java
-      uses: strimzi/strimzi-kafka-operator/.github/actions/dependencies/setup-java@main
+      uses: strimzi/github-actions/.github/actions/dependencies/setup-java@v1
       with:
         javaVersion: "17"
 


### PR DESCRIPTION
This PR fix usage of our setup-java action in codeql workflow after https://github.com/strimzi/strimzi-kafka-operator/pull/12464