### PR TITLE
[Feature]support configurable introspection token param

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,6 +416,7 @@ Specify the following `oauth.*` properties:
 - `oauth.valid.issuer.uri` (e.g.: "https://localhost:8443/realms/demo" - only access tokens issued by this issuer will be accepted)
 - `oauth.client.id` (e.g.: "kafka" - this is the OAuth2 client configuration id for the Kafka broker)
 - `oauth.client.secret` (e.g.: "kafka-secret")
+- `oauth.introspection.token.param.name` (e.g.: "access_token" - request parameter name for the token, defaults to "token")
  
 Introspection endpoint should be protected. The `oauth.client.id` and `oauth.client.secret` specify Kafka Broker credentials for authenticating to access the introspection endpoint. 
 

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/IOUtil.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/common/IOUtil.java
@@ -116,6 +116,21 @@ public class IOUtil {
     }
 
     /**
+     * Trim the specified value and return the default value when the result is empty.
+     *
+     * @param value The value to trim
+     * @param defaultValue The default value to return when value is null or empty
+     * @return trimmed value or defaultValue
+     */
+    public static String trimmedNonEmptyValueOrDefault(String value, String defaultValue) {
+        if (value == null) {
+            return defaultValue;
+        }
+        value = value.trim();
+        return value.isEmpty() ? defaultValue : value;
+    }
+
+    /**
      * Calculate a CRC32 for the specified String
      *
      * @param content The input string

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/services/ValidatorKey.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/services/ValidatorKey.java
@@ -357,6 +357,7 @@ public class ValidatorKey {
     public static class IntrospectionValidatorKey extends ValidatorKey {
 
         private final String introspectionEndpoint;
+        private final String introspectionTokenParamName;
         private final String userInfoEndpoint;
         private final String validTokenType;
         private final int retries;
@@ -383,6 +384,7 @@ public class ValidatorKey {
          * @param sslRandom sslRandom
          * @param hasHostnameVerifier hasHostnameVerifier
          * @param introspectionEndpoint introspectionEndpoint
+         * @param introspectionTokenParamName introspectionTokenParamName
          * @param userInfoEndpoint userInfoEndpoint
          * @param validTokenType validTokenType
          * @param connectTimeout connectTimeout
@@ -411,6 +413,7 @@ public class ValidatorKey {
                                   boolean hasHostnameVerifier,
 
                                   String introspectionEndpoint,
+                                  String introspectionTokenParamName,
                                   String userInfoEndpoint,
                                   String validTokenType,
                                   int connectTimeout,
@@ -441,6 +444,7 @@ public class ValidatorKey {
                     enableMetrics,
                     includeAcceptHeader);
             this.introspectionEndpoint = introspectionEndpoint;
+            this.introspectionTokenParamName = introspectionTokenParamName;
             this.userInfoEndpoint = userInfoEndpoint;
             this.validTokenType = validTokenType;
             this.retries = retries;
@@ -448,6 +452,7 @@ public class ValidatorKey {
 
             this.configIdHash = IOUtil.hashForObjects(super.getConfigIdHash(),
                     introspectionEndpoint,
+                    introspectionTokenParamName,
                     userInfoEndpoint,
                     validTokenType,
                     clientId,
@@ -463,6 +468,7 @@ public class ValidatorKey {
             if (!super.equals(o)) return false;
             IntrospectionValidatorKey that = (IntrospectionValidatorKey) o;
             return Objects.equals(introspectionEndpoint, that.introspectionEndpoint) &&
+                    Objects.equals(introspectionTokenParamName, that.introspectionTokenParamName) &&
                     Objects.equals(userInfoEndpoint, that.userInfoEndpoint) &&
                     Objects.equals(validTokenType, that.validTokenType) &&
                     Objects.equals(retries, that.retries) &&
@@ -473,6 +479,7 @@ public class ValidatorKey {
         public int hashCode() {
             return Objects.hash(super.hashCode(),
                     introspectionEndpoint,
+                    introspectionTokenParamName,
                     userInfoEndpoint,
                     validTokenType,
                     retries,
@@ -507,6 +514,7 @@ public class ValidatorKey {
                     + ", enableMetrics: " + super.enableMetrics
                     + ", includeAcceptHeader: " + super.includeAcceptHeader
                     + ", introspectionEndpoint: " + singleQuote(introspectionEndpoint)
+                    + ", introspectionTokenParamName: " + singleQuote(introspectionTokenParamName)
                     + ", userInfoEndpoint: " + singleQuote(userInfoEndpoint)
                     + ", validTokenType: " + singleQuote(validTokenType)
                     + ", retries: " + retries

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/validator/OAuthIntrospectionValidator.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/validator/OAuthIntrospectionValidator.java
@@ -52,9 +52,11 @@ import static io.strimzi.kafka.oauth.validator.TokenValidationException.Status;
 public class OAuthIntrospectionValidator implements TokenValidator {
 
     private static final Logger log = LoggerFactory.getLogger(OAuthIntrospectionValidator.class);
+    private static final String DEFAULT_INTROSPECTION_TOKEN_PARAM_NAME = "token";
 
     private final String validatorId;
     private final URI introspectionURI;
+    private final String introspectionTokenParamName;
     private final String validIssuerURI;
     private final URI userInfoURI;
     private final String validTokenType;
@@ -90,6 +92,7 @@ public class OAuthIntrospectionValidator implements TokenValidator {
      * @param clientSecret The secret of the OAuth2 client representing this Kafka broker - used to authenticate to the introspection endpoint using Basic authentication
      * @param bearerTokenProvider The provider of the bearer token as an alternative to clientId and secret of the OAuth2 client representing this Kafka broker - used to authenticate to the introspection endpoint using Bearer authentication
      * @param introspectionEndpointUri The introspection endpoint url at the authorization server
+     * @param introspectionTokenParamName The request parameter name used to send token to introspection endpoint
      * @param socketFactory The optional SSL socket factory to use when establishing the connection to authorization server
      * @param verifier The optional hostname verifier used to validate the TLS certificate by the authorization server
      * @param principalExtractor The object used to extract the username from the attributes in the server's response
@@ -113,6 +116,7 @@ public class OAuthIntrospectionValidator implements TokenValidator {
                                        String clientSecret,
                                        TokenProvider bearerTokenProvider,
                                        String introspectionEndpointUri,
+                                       String introspectionTokenParamName,
                                        SSLSocketFactory socketFactory,
                                        HostnameVerifier verifier,
                                        PrincipalExtractor principalExtractor,
@@ -133,6 +137,7 @@ public class OAuthIntrospectionValidator implements TokenValidator {
         this.validatorId = checkValidatorId(id);
 
         this.introspectionURI = checkIntrospectionUri(introspectionEndpointUri);
+        this.introspectionTokenParamName = parseIntrospectionTokenParamName(introspectionTokenParamName);
 
         this.socketFactory = checkSocketFactory(socketFactory);
 
@@ -176,6 +181,7 @@ public class OAuthIntrospectionValidator implements TokenValidator {
             log.debug("Configured OAuthIntrospectionValidator:"
                     + "\n\t  id: " + id
                     + "\n\t  introspectionEndpointUri: " + introspectionURI
+                    + "\n\t  introspectionTokenParamName: " + this.introspectionTokenParamName
                     + "\n\t  sslSocketFactory: " + socketFactory
                     + "\n\t  hostnameVerifier: " + hostnameVerifier
                     + "\n\t  principalExtractor: " + principalExtractor
@@ -260,6 +266,17 @@ public class OAuthIntrospectionValidator implements TokenValidator {
         return validatorId;
     }
 
+    private String parseIntrospectionTokenParamName(String tokenParamName) {
+        if (tokenParamName == null) {
+            return DEFAULT_INTROSPECTION_TOKEN_PARAM_NAME;
+        }
+        String result = tokenParamName.trim();
+        if (result.isEmpty()) {
+            return DEFAULT_INTROSPECTION_TOKEN_PARAM_NAME;
+        }
+        return result;
+    }
+
     private JsonPathFilterQuery parseCustomClaimCheck(String customClaimCheck) {
         if (customClaimCheck != null) {
             String query = customClaimCheck.trim();
@@ -296,7 +313,7 @@ public class OAuthIntrospectionValidator implements TokenValidator {
 
         String authorization = generateAuthorizationHeader();
 
-        StringBuilder body = new StringBuilder("token=").append(token);
+        StringBuilder body = new StringBuilder(introspectionTokenParamName).append("=").append(token);
 
         JsonNode response;
         try {

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/validator/OAuthIntrospectionValidator.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/validator/OAuthIntrospectionValidator.java
@@ -7,6 +7,7 @@ package io.strimzi.kafka.oauth.validator;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.BooleanNode;
 import io.strimzi.kafka.oauth.common.HttpUtil;
+import io.strimzi.kafka.oauth.common.IOUtil;
 import io.strimzi.kafka.oauth.common.JSONUtil;
 import io.strimzi.kafka.oauth.common.MetricsHandler;
 import io.strimzi.kafka.oauth.common.PrincipalExtractor;
@@ -39,6 +40,7 @@ import static io.strimzi.kafka.oauth.common.HttpUtil.post;
 import static io.strimzi.kafka.oauth.common.HttpUtil.get;
 import static io.strimzi.kafka.oauth.common.LogUtil.mask;
 import static io.strimzi.kafka.oauth.common.OAuthAuthenticator.base64encode;
+import static io.strimzi.kafka.oauth.common.OAuthAuthenticator.urlencode;
 import static io.strimzi.kafka.oauth.validator.TokenValidationException.Status;
 
 /**
@@ -137,7 +139,8 @@ public class OAuthIntrospectionValidator implements TokenValidator {
         this.validatorId = checkValidatorId(id);
 
         this.introspectionURI = checkIntrospectionUri(introspectionEndpointUri);
-        this.introspectionTokenParamName = parseIntrospectionTokenParamName(introspectionTokenParamName);
+        this.introspectionTokenParamName = IOUtil.trimmedNonEmptyValueOrDefault(
+                introspectionTokenParamName, DEFAULT_INTROSPECTION_TOKEN_PARAM_NAME);
 
         this.socketFactory = checkSocketFactory(socketFactory);
 
@@ -266,17 +269,6 @@ public class OAuthIntrospectionValidator implements TokenValidator {
         return validatorId;
     }
 
-    private String parseIntrospectionTokenParamName(String tokenParamName) {
-        if (tokenParamName == null) {
-            return DEFAULT_INTROSPECTION_TOKEN_PARAM_NAME;
-        }
-        String result = tokenParamName.trim();
-        if (result.isEmpty()) {
-            return DEFAULT_INTROSPECTION_TOKEN_PARAM_NAME;
-        }
-        return result;
-    }
-
     private JsonPathFilterQuery parseCustomClaimCheck(String customClaimCheck) {
         if (customClaimCheck != null) {
             String query = customClaimCheck.trim();
@@ -313,7 +305,7 @@ public class OAuthIntrospectionValidator implements TokenValidator {
 
         String authorization = generateAuthorizationHeader();
 
-        StringBuilder body = new StringBuilder(introspectionTokenParamName).append("=").append(token);
+        String body = buildIntrospectionRequestBody(introspectionTokenParamName, token);
 
         JsonNode response;
         try {
@@ -323,7 +315,7 @@ public class OAuthIntrospectionValidator implements TokenValidator {
                             hostnameVerifier,
                             authorization,
                             "application/x-www-form-urlencoded",
-                            body.toString(),
+                            body,
                             JsonNode.class,
                             connectTimeoutSeconds,
                             readTimeoutSeconds,
@@ -392,6 +384,10 @@ public class OAuthIntrospectionValidator implements TokenValidator {
         String scopes = value != null ? String.join(" ", JSONUtil.asListOfString(value)) : null;
 
         return new TokenInfo(token, scopes, principal, groups, iat, expiresMillis);
+    }
+
+    static String buildIntrospectionRequestBody(String introspectionTokenParamName, String token) {
+        return urlencode(introspectionTokenParamName) + "=" + urlencode(token);
     }
 
     private String generateAuthorizationHeader() {

--- a/oauth-common/src/test/java/io/strimzi/kafka/oauth/common/HttpUtilTimeoutTest.java
+++ b/oauth-common/src/test/java/io/strimzi/kafka/oauth/common/HttpUtilTimeoutTest.java
@@ -116,7 +116,7 @@ public class HttpUtilTimeoutTest {
             // Test validator
             try {
                 OAuthIntrospectionValidator validator = new OAuthIntrospectionValidator("test", "kafka", "kafka-secret",  null, "http://192.168.255.255:26309",
-                        null, null, new PrincipalExtractor(), null, null, "http://172.0.0.13/", null, "Bearer",
+                        null, null, null, new PrincipalExtractor(), null, null, "http://172.0.0.13/", null, "Bearer",
                         null, null, timeout, timeout, false, 0, 0, true);
 
                 start = System.currentTimeMillis();

--- a/oauth-common/src/test/java/io/strimzi/kafka/oauth/common/IOUtilTest.java
+++ b/oauth-common/src/test/java/io/strimzi/kafka/oauth/common/IOUtilTest.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2017-2026, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.kafka.oauth.common;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class IOUtilTest {
+
+    @Test
+    public void testTrimmedNonEmptyValueOrDefault() {
+        Assert.assertEquals("token", IOUtil.trimmedNonEmptyValueOrDefault(null, "token"));
+        Assert.assertEquals("token", IOUtil.trimmedNonEmptyValueOrDefault("", "token"));
+        Assert.assertEquals("token", IOUtil.trimmedNonEmptyValueOrDefault("   ", "token"));
+        Assert.assertEquals("access_token", IOUtil.trimmedNonEmptyValueOrDefault("  access_token  ", "token"));
+        Assert.assertEquals("access_token", IOUtil.trimmedNonEmptyValueOrDefault("access_token", "token"));
+    }
+}

--- a/oauth-common/src/test/java/io/strimzi/kafka/oauth/validator/ConfigIdHashTest.java
+++ b/oauth-common/src/test/java/io/strimzi/kafka/oauth/validator/ConfigIdHashTest.java
@@ -16,14 +16,14 @@ public class ConfigIdHashTest {
         ValidatorKey vkey = getKey(null, null);
         ValidatorKey vkey2 = getKey(null, null);
 
-        Assert.assertEquals("Config id hash mismatch", "f433dbf8", vkey.getConfigIdHash());
+        Assert.assertEquals("Config id hash mismatch", "29f15220", vkey.getConfigIdHash());
         Assert.assertEquals("Config id hash should be the same", vkey.getConfigIdHash(), vkey2.getConfigIdHash());
 
         ValidatorKey key3 = getKey("group", null);
         ValidatorKey key4 = getKey(null, "group");
 
-        Assert.assertEquals("Config id hash mismatch", "024dcc79", key3.getConfigIdHash());
-        Assert.assertEquals("Config id hash mismatch", "dfec1585", key4.getConfigIdHash());
+        Assert.assertEquals("Config id hash mismatch", "801f35da", key3.getConfigIdHash());
+        Assert.assertEquals("Config id hash mismatch", "8189b1bb", key4.getConfigIdHash());
     }
 
     ValidatorKey getKey(String groupQuery, String groupDelimiter) {
@@ -45,6 +45,7 @@ public class ConfigIdHashTest {
                 null,
                 false,
                 "http://mockoauth:8080/introspect",
+                null,
                 null,
                 null,
                 60,

--- a/oauth-common/src/test/java/io/strimzi/kafka/oauth/validator/OAuthIntrospectionValidatorTest.java
+++ b/oauth-common/src/test/java/io/strimzi/kafka/oauth/validator/OAuthIntrospectionValidatorTest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017-2026, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.kafka.oauth.validator;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class OAuthIntrospectionValidatorTest {
+
+    @Test
+    public void testBuildIntrospectionRequestBodyWithDefaultParamName() {
+        Assert.assertEquals("token=abc", OAuthIntrospectionValidator.buildIntrospectionRequestBody("token", "abc"));
+    }
+
+    @Test
+    public void testBuildIntrospectionRequestBodyWithCustomParamName() {
+        Assert.assertEquals("access_token=abc", OAuthIntrospectionValidator.buildIntrospectionRequestBody("access_token", "abc"));
+    }
+
+    @Test
+    public void testBuildIntrospectionRequestBodyUrlEncodesParamNameAndToken() {
+        Assert.assertEquals("access+token%2B%26%3D=abc+123%2B%26%3D",
+                OAuthIntrospectionValidator.buildIntrospectionRequestBody("access token+&=", "abc 123+&="));
+    }
+}

--- a/oauth-server/src/main/java/io/strimzi/kafka/oauth/server/JaasServerOauthValidatorCallbackHandler.java
+++ b/oauth-server/src/main/java/io/strimzi/kafka/oauth/server/JaasServerOauthValidatorCallbackHandler.java
@@ -377,8 +377,8 @@ public class JaasServerOauthValidatorCallbackHandler implements AuthenticateCall
             boolean includeAcceptHeader) {
 
         String introspectionEndpoint = config.getValue(ServerConfig.OAUTH_INTROSPECTION_ENDPOINT_URI);
-        String introspectionTokenParamName = normalizeIntrospectionTokenParamName(
-                config.getValue(ServerConfig.OAUTH_INTROSPECTION_TOKEN_PARAM_NAME));
+        String introspectionTokenParamName = IOUtil.trimmedNonEmptyValueOrDefault(
+                config.getValue(ServerConfig.OAUTH_INTROSPECTION_TOKEN_PARAM_NAME), DEFAULT_INTROSPECTION_TOKEN_PARAM_NAME);
         String userInfoEndpoint = config.getValue(ServerConfig.OAUTH_USERINFO_ENDPOINT_URI);
         String validTokenType = config.getValue(ServerConfig.OAUTH_VALID_TOKEN_TYPE);
 
@@ -440,14 +440,6 @@ public class JaasServerOauthValidatorCallbackHandler implements AuthenticateCall
         validator = Services.getInstance().getValidators().get(confKey, factory);
 
         return effectiveConfigId;
-    }
-
-    private String normalizeIntrospectionTokenParamName(String introspectionTokenParamName) {
-        if (introspectionTokenParamName == null) {
-            return DEFAULT_INTROSPECTION_TOKEN_PARAM_NAME;
-        }
-        String result = introspectionTokenParamName.trim();
-        return result.isEmpty() ? DEFAULT_INTROSPECTION_TOKEN_PARAM_NAME : result;
     }
 
     @SuppressWarnings("checkstyle:ParameterNumber")

--- a/oauth-server/src/main/java/io/strimzi/kafka/oauth/server/JaasServerOauthValidatorCallbackHandler.java
+++ b/oauth-server/src/main/java/io/strimzi/kafka/oauth/server/JaasServerOauthValidatorCallbackHandler.java
@@ -133,6 +133,7 @@ import static io.strimzi.kafka.oauth.common.TokenIntrospection.debugLogJWT;
  * <ul>
  * <li><em>oauth.client.id</em> OAuth client id which the Kafka broker uses to authenticate against the authorization server to use the introspection endpoint.</li>
  * <li><em>oauth.client.secret</em> The OAuth client secret which the Kafka broker uses to authenticate to the authorization server and use the introspection endpoint.</li>
+ * <li><em>oauth.introspection.token.param.name</em> The request parameter name used to send the token to introspection endpoint. Default value is <em>token</em>.</li>
  * <li><em>oauth.server.bearer.token</em> The bearer token which the Kafka broker uses to authenticate to the authorization server and use the introspection endpoint as an alternative to using client id and secret.</li>
  * <li><em>oauth.server.bearer.token.location</em> The path to the file containing the bearer token (as opposed to raw value if <em>oauth.server.bearer.token</em> is configured) which the Kafka broker uses to authenticate to the authorization server and use the introspection endpoint as an alternative to using client id and secret.</li>
  * <li><em>oauth.userinfo.endpoint.uri</em> A URL of the token introspection endpoint which can be used to validate opaque non-JWT tokens.<br>
@@ -202,6 +203,7 @@ import static io.strimzi.kafka.oauth.common.TokenIntrospection.debugLogJWT;
 public class JaasServerOauthValidatorCallbackHandler implements AuthenticateCallbackHandler {
 
     private static final Logger log = LoggerFactory.getLogger(JaasServerOauthValidatorCallbackHandler.class);
+    private static final String DEFAULT_INTROSPECTION_TOKEN_PARAM_NAME = "token";
 
     private TokenValidator validator;
 
@@ -375,6 +377,8 @@ public class JaasServerOauthValidatorCallbackHandler implements AuthenticateCall
             boolean includeAcceptHeader) {
 
         String introspectionEndpoint = config.getValue(ServerConfig.OAUTH_INTROSPECTION_ENDPOINT_URI);
+        String introspectionTokenParamName = normalizeIntrospectionTokenParamName(
+                config.getValue(ServerConfig.OAUTH_INTROSPECTION_TOKEN_PARAM_NAME));
         String userInfoEndpoint = config.getValue(ServerConfig.OAUTH_USERINFO_ENDPOINT_URI);
         String validTokenType = config.getValue(ServerConfig.OAUTH_VALID_TOKEN_TYPE);
 
@@ -396,6 +400,7 @@ public class JaasServerOauthValidatorCallbackHandler implements AuthenticateCall
                 sslRnd,
                 verifier != null,
                 introspectionEndpoint,
+                introspectionTokenParamName,
                 userInfoEndpoint,
                 validTokenType,
                 connectTimeout,
@@ -413,6 +418,7 @@ public class JaasServerOauthValidatorCallbackHandler implements AuthenticateCall
                 clientSecret,
                 bearerTokenProvider,
                 introspectionEndpoint,
+                introspectionTokenParamName,
                 socketFactory,
                 verifier,
                 principalExtractor,
@@ -434,6 +440,14 @@ public class JaasServerOauthValidatorCallbackHandler implements AuthenticateCall
         validator = Services.getInstance().getValidators().get(confKey, factory);
 
         return effectiveConfigId;
+    }
+
+    private String normalizeIntrospectionTokenParamName(String introspectionTokenParamName) {
+        if (introspectionTokenParamName == null) {
+            return DEFAULT_INTROSPECTION_TOKEN_PARAM_NAME;
+        }
+        String result = introspectionTokenParamName.trim();
+        return result.isEmpty() ? DEFAULT_INTROSPECTION_TOKEN_PARAM_NAME : result;
     }
 
     @SuppressWarnings("checkstyle:ParameterNumber")

--- a/oauth-server/src/main/java/io/strimzi/kafka/oauth/server/ServerConfig.java
+++ b/oauth-server/src/main/java/io/strimzi/kafka/oauth/server/ServerConfig.java
@@ -49,6 +49,11 @@ public class ServerConfig extends Config {
     public static final String OAUTH_INTROSPECTION_ENDPOINT_URI = "oauth.introspection.endpoint.uri";
 
     /**
+     * "oauth.introspection.token.param.name"
+     */
+    public static final String OAUTH_INTROSPECTION_TOKEN_PARAM_NAME = "oauth.introspection.token.param.name";
+
+    /**
      * "oauth.userinfo.endpoint.uri"
      */
     public static final String OAUTH_USERINFO_ENDPOINT_URI = "oauth.userinfo.endpoint.uri";

--- a/testsuite/mockoauth-tests/src/test/java/io/strimzi/testsuite/oauth/mockoauth/JaasServerConfigTest.java
+++ b/testsuite/mockoauth-tests/src/test/java/io/strimzi/testsuite/oauth/mockoauth/JaasServerConfigTest.java
@@ -227,6 +227,7 @@ public class JaasServerConfigTest {
         Common.checkLog(logReader, "OAuthIntrospectionValidator", "",
                 "id", "config-id-1_1",
                 "introspectionEndpointUri", "https://sso/introspect",
+                "introspectionTokenParamName", "token",
                 "groupsClaimQuery", "\\$\\.groups",
                 "groupsClaimDelimiter", ",",
                 "validIssuerUri", "https://sso",


### PR DESCRIPTION
This PR addresses an interoperability gap in introspection-based validation.

Problem solved:
The broker always sent introspection requests as token=<access_token>.
Some OAuth/tokeninfo providers require a different parameter name (for example access_token).
Result: introspection call failed (HTTP 400 / missing access token), so authentication could not proceed.
this close https://github.com/strimzi/strimzi-kafka-oauth/issues/299

What was changed:
Added a new server config: `oauth.introspection.token.param.name`.
Kept backward compatibility by defaulting to token when the option is not set.
Wired the new option through server config parsing and validator initialization.
Updated OAuthIntrospectionValidator to build the POST body using the configured parameter name instead of a hardcoded token.
Included the new parameter in IntrospectionValidatorKey (equals/hash/config id hash) to prevent incorrect validator/cache reuse across different configs.
Updated tests and README to cover/document the new behavior.

Impact:
Enables Strimzi OAuth to work with providers that expect non-default introspection parameter names (e.g., access_token) without changing client behavior.
Existing deployments remain unaffected unless they opt in to the new setting.