### PR TITLE
Bump Vertx to 5.1.2

### DIFF
--- a/testsuite/mock-oauth-server/pom.xml
+++ b/testsuite/mock-oauth-server/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <checkstyle.dir>../..</checkstyle.dir>
-        <vertx.version>4.5.24</vertx.version>
+        <vertx.version>5.1.2</vertx.version>
         <logback.version>1.3.15</logback.version>
 
         <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
@@ -29,7 +29,6 @@
 
         <exec-maven-plugin.version>3.0.0</exec-maven-plugin.version>
         <main.verticle>io.strimzi.testsuite.oauth.server.MockOAuthServerMainVerticle</main.verticle>
-        <launcher.class>io.vertx.core.Launcher</launcher.class>
 
         <jackson.version>2.21.2</jackson.version>
         <jackson.databind.version>2.21.2</jackson.databind.version>
@@ -108,8 +107,7 @@
                                 <transformer
                                         implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                     <manifestEntries>
-                                        <Main-Class>${launcher.class}</Main-Class>
-                                        <Main-Verticle>${main.verticle}</Main-Verticle>
+                                        <Main-Class>${main.verticle}</Main-Class>
                                     </manifestEntries>
                                 </transformer>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
@@ -125,11 +123,7 @@
                 <artifactId>exec-maven-plugin</artifactId>
                 <version>${exec-maven-plugin.version}</version>
                 <configuration>
-                    <mainClass>io.vertx.core.Launcher</mainClass>
-                    <arguments>
-                        <argument>run</argument>
-                        <argument>${main.verticle}</argument>
-                    </arguments>
+                    <mainClass>${main.verticle}</mainClass>
                 </configuration>
             </plugin>
             <plugin>

--- a/testsuite/mockoauth-jdk17-tests/src/test/java/io/strimzi/testsuite/oauth/MockOAuthJdk17Tests.java
+++ b/testsuite/mockoauth-jdk17-tests/src/test/java/io/strimzi/testsuite/oauth/MockOAuthJdk17Tests.java
@@ -34,7 +34,7 @@ public class MockOAuthJdk17Tests {
     private static TestContainersWatcher initWatcher() {
         TestContainersWatcher watcher = new TestContainersWatcher(new File("docker-compose.yml"));
         watcher.withServices("mockoauth", "kafka");
-        watcher.waitingFor("mockoauth", Wait.forLogMessage(".*Succeeded in deploying verticle.*", 1)
+        watcher.waitingFor("mockoauth", Wait.forLogMessage(".*AuthServer started successfully.*", 1)
                         .withStartupTimeout(Duration.ofSeconds(180)))
                 .waitingFor("kafka", Wait.forLogMessage(".*started \\(kafka.server.KafkaRaftServer\\).*", 1)
                         .withStartupTimeout(Duration.ofSeconds(300)));

--- a/testsuite/mockoauth-tests/src/test/java/io/strimzi/testsuite/oauth/MockOAuthTests.java
+++ b/testsuite/mockoauth-tests/src/test/java/io/strimzi/testsuite/oauth/MockOAuthTests.java
@@ -52,7 +52,7 @@ public class MockOAuthTests {
         } else {
             watcher.withServices("mockoauth", "kafka");
         }
-        watcher.waitingFor("mockoauth", Wait.forLogMessage(".*Succeeded in deploying verticle.*", 1)
+        watcher.waitingFor("mockoauth", Wait.forLogMessage(".*AuthServer started successfully.*", 1)
                         .withStartupTimeout(Duration.ofSeconds(180)))
                 .waitingFor("kafka", Wait.forLogMessage(".*started \\(kafka.server.KafkaRaftServer\\).*", 1)
                         .withStartupTimeout(Duration.ofSeconds(300)));


### PR DESCRIPTION
### Type of change

- Dependency update

### Description

Bump Vertx version used by mocko-auth-server and make some adjustment for the testsuite to work with the new version.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update documentation
- [ ] Update CHANGELOG.md (if present)
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Write tests
- [x] Make sure all tests pass
- [ ] Try your changes inside a Kubernetes cluster, not just from unit tests
- [ ] AI assistance was used to create this PR (see the [Strimzi AI policy](https://github.com/strimzi/governance/blob/main/AI_POLICY.md))
