### PR TITLE
Try to address a testsuite race condition

### DIFF
--- a/testsuite/keycloak-authz-kraft-tests/src/test/java/io/strimzi/testsuite/oauth/authz/Common.java
+++ b/testsuite/keycloak-authz-kraft-tests/src/test/java/io/strimzi/testsuite/oauth/authz/Common.java
@@ -39,9 +39,12 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
 
 import static io.strimzi.kafka.oauth.common.OAuthAuthenticator.loginWithClientSecret;
 import static io.strimzi.kafka.oauth.common.OAuthAuthenticator.urlencode;
@@ -411,10 +414,19 @@ public class Common {
         return Admin.create(adminProps);
     }
 
-    void cleanup() {
+    void cleanup() throws InterruptedException, TimeoutException {
         Properties bobAdminProps = buildAdminConfigForAccount(BOB);
         try (Admin admin = Admin.create(bobAdminProps)) {
-            admin.deleteTopics(Arrays.asList(TOPIC_A, TOPIC_B, TOPIC_X, "non-existing-topic"));
+            final List<String> topics = Arrays.asList(TOPIC_A, TOPIC_B, TOPIC_X, "non-existing-topic");
+            admin.deleteTopics(topics);
+            TestUtil.waitForCondition(() -> {
+                try {
+                    Set<String> remaining = admin.listTopics().names().get();
+                    return Collections.disjoint(remaining, topics);
+                } catch (Throwable e) {
+                    throw new RuntimeException("Failed to list topics during cleanup: ", e);
+                }
+            }, 500, 30);
             admin.deleteConsumerGroups(Arrays.asList(groupFor(TOPIC_A), groupFor(TOPIC_B), groupFor(TOPIC_X), groupFor("non-existing-topic")));
         }
     }


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

There is a race condition in the testsuite that sometimes results in test failure.
Here we try to address a possible cause by ensuring that the topics are cleaned up before the next subtest starts.

### Checklist

- [ ] Update documentation
- [ ] Update CHANGELOG.md (if present)
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Try your changes inside a Kubernetes cluster, not just from unit tests
- [x] AI assistance was used to create this PR (see the [Strimzi AI policy](https://github.com/strimzi/governance/blob/main/AI_POLICY.md))
